### PR TITLE
add some features to mesh.py

### DIFF
--- a/mikeio/mesh.py
+++ b/mikeio/mesh.py
@@ -112,7 +112,7 @@ class Mesh:
 
         return mp
 
-    def plot(self, cmap=None, z=None, label=None):
+    def plot(self, cmap=None, z=None, label=None, vmin=None, vmax=None):
         """
         Plot mesh elements
 
@@ -137,6 +137,12 @@ class Mesh:
             if label is None:
                 label = "Bathymetry (m)"
 
+        if vmin is None:
+            vmin = z.min()
+
+        if vmax is None:
+            vmax = z.max()
+
         patches = []
 
         for j in range(ne):
@@ -153,7 +159,77 @@ class Mesh:
         p = PatchCollection(patches, cmap=cmap, edgecolor="black")
 
         p.set_array(z)
+        p.set_clim(vmin,vmax)
         ax.add_collection(p)
         fig.colorbar(p, ax=ax, label=label)
         ax.set_xlim(nc[:, 0].min(), nc[:, 0].max())
         ax.set_ylim(nc[:, 1].min(), nc[:, 1].max())
+
+    def get_node_centered_data(self, data):
+        nc = self.get_node_coords()
+        ec = self.get_element_coords()
+        elements = [list(self._mesh.ElementTable[i]) for i in range(len(list(self._mesh.ElementTable)))]
+        elements = np.asarray(elements) - 1
+        node_cellID = [list(np.argwhere(elements == i)[:, 0]) for i in np.unique(elements.reshape(-1, ))]
+        node_centered_data = np.zeros(shape=nc.shape[0])
+        for n, item in enumerate(node_cellID):
+            InvDis = [1 / np.hypot(case[0], case[1]) for case in ec[item][:, :2] - nc[n][:2]]
+            node_centered_data[n] = np.sum(InvDis * data[item]) / np.sum(InvDis)
+
+        return node_centered_data
+
+    def plot2(self, cmap=None, z=None, label=None, vmin=None, vmax=None, n_contour=10):
+        """
+        Plot mesh elements and contour
+
+        Parameters
+        ----------
+        cmap: matplotlib.cm.cmap, optional
+            default viridis
+        z: np.array
+            value for each element to plot, default bathymetry
+        label: str, optional
+            colorbar label
+        vmin: float, optional
+            minimum value to show on colorbar
+        vmax: float, optional
+            maximum value to show on colorbar
+        n_contour, int, optional
+            number of contour levels to plot
+        """
+        import matplotlib.tri as tri
+        if cmap is None:
+            cmap = cm.viridis
+
+        nc = self.get_node_coords()
+        ec = self.get_element_coords()
+
+        elements = [list(self._mesh.ElementTable[i]) for i in range(len(list(self._mesh.ElementTable)))]
+        elements = np.asarray(elements) - 1
+
+        if z is None:
+            zz = nc[:, 2]
+            if label is None:
+                label = "Bathymetry (m)"
+        else:
+            zz = self.get_node_centered_data(z)
+
+        if vmin is None:
+            vmin = zz.min()
+
+        if vmax is None:
+            vmax = zz.max()
+
+        triang = tri.Triangulation(nc[:, 0], nc[:, 1], elements)
+        refiner = tri.UniformTriRefiner(triang)
+        tri_refi, z_test_refi = refiner.refine_field(zz, subdiv=3)
+
+        fig, ax = plt.subplots()
+        ax.triplot(triang, lw=0.5, color='blue')
+        tr_fig = ax.tripcolor(tri_refi, z_test_refi, edgecolors='face', vmin=vmin, vmax=vmax)
+        levels = np.linspace(vmin, vmax, n_contour)
+        ax.tricontourf(tri_refi, z_test_refi, levels=levels, cmap=cmap)
+        ax.tricontour(tri_refi, z_test_refi, levels=levels,
+                      colors=['0.5'],
+                      linewidths=[0.5])
+        plt.colorbar(tr_fig, label=label)


### PR DESCRIPTION
It is nice to be able to have contour plot in mikeio. I used matplotlib.tri to do so. It is just working on fully triangular mesh. It needs to have data on the nodes so I wrote a function to convert cell-centered data to note-centered data. 
using plot()
![Plot](https://user-images.githubusercontent.com/65772896/89750456-1461e480-da9a-11ea-937e-9a7e0b82adc4.png)

using plot2()  we can rename it to more meaningful name!
![Plot2](https://user-images.githubusercontent.com/65772896/89750459-19bf2f00-da9a-11ea-90c8-dfa7d617470d.png)
