### PR TITLE
Add contour option to dfsu.plot

### DIFF
--- a/tests/test_dfsu.py
+++ b/tests/test_dfsu.py
@@ -677,6 +677,8 @@ def test_plot_bathymetry():
     dfs = Dfsu(filename)
 
     dfs.plot()
+    
+    assert True
 
 
 def test_to_mesh_3d(tmpdir):
@@ -744,3 +746,15 @@ def test_to_shapely():
     shp = dfs.to_shapely()
     assert True
 
+def test_plot_dfsu_contour():
+    filename = os.path.join("tests", "testdata", "HD2D.dfsu")
+    dfs = Dfsu(filename)
+    dfs.plot(do_contour=True)
+    assert True
+
+def test_plot_dfsu():
+    filename = os.path.join("tests", "testdata", "HD2D.dfsu")
+    dfs = Dfsu(filename)
+    data = dfs.read()
+    dfs.plot(z=data[1][0,:])
+    assert True


### PR DESCRIPTION
I added do_contour as an option to dfsu.plot() method. 

It works for both triangular and quadrilateral and flexible mesh. It needs data at the nodes so I wrote a function that produce node based data from the cell centered data using the Pseudo Laplacian interpolation, similar to MeshNodeInterpolation (https://github.com/DHI/DHI.Mesh). Whenever  Pseudo Laplacian fails I used inverse distance for interpolation. 

![image](https://user-images.githubusercontent.com/65772896/92136624-3b31e300-edda-11ea-967f-db4ef84c0e5b.png)

Please feel free to optimize the code if it is required. 