### PR TITLE
Handle dfsu contour_lines

### DIFF
--- a/mikeio/dfsu.py
+++ b/mikeio/dfsu.py
@@ -1082,11 +1082,12 @@ class _UnstructuredGeometry:
             else:
                 # must be contourf plot then
                 levels = np.linspace(vmin, vmax, n_levels)
+                ax.tripcolor(triang, zn, edgecolors='face', vmin=vmin, vmax=vmax, cmap=cmap)
                 tr_fig = ax.tricontourf(triang, zn, levels=levels, cmap=cmap)
-                # if plot_type == 'contour_lines':
-                #     ax.tricontour(triang, zn, levels=levels,
-                #             colors=['0.5'],
-                #             linewidths=[0.5])
+                if plot_type == 'contour_lines':
+                    ax.tricontour(triang, zn, levels=levels,
+                            colors=['0.5'],
+                            linewidths=[0.5])
             
             plt.colorbar(tr_fig, label=label)
 


### PR DESCRIPTION
this line of code is needed 
ax.tripcolor(triang, zn, edgecolors='face', vmin=vmin, vmax=vmax, cmap=cmap)
otherwise if the vmin and vmax do not cover the entire zn range it plots white area. 

with: 
![image](https://user-images.githubusercontent.com/65772896/92414727-8b36df80-f123-11ea-8002-350e60dca697.png)


without would be like this! 
![image](https://user-images.githubusercontent.com/65772896/92414747-a6a1ea80-f123-11ea-9853-4a5516b06986.png)


