### PR TITLE
Dfs1 and Dfs2 NonEquidistant Time Axis

### DIFF
--- a/mikeio/dfs.py
+++ b/mikeio/dfs.py
@@ -149,6 +149,7 @@ class _Dfs123:
                 raise DataDimensionMismatch()
         if dateTimes:
             self._is_equidistant = False
+            start_time = dateTimes[0]
 
         dfs = self._setup_header(filename)
 

--- a/mikeio/dfs.py
+++ b/mikeio/dfs.py
@@ -122,7 +122,7 @@ class _Dfs123:
 
         dfs.Close()
 
-    def _write(self, filename, data, start_time, dt, items, coordinate, title):
+    def _write(self, filename, data, start_time, dateTimes, dt, items, coordinate, title):
         self._write_handle_common_arguments(
             title, data, items, coordinate, start_time, dt
         )
@@ -147,6 +147,8 @@ class _Dfs123:
 
             if not all(np.shape(d)[2] == self._nx for d in data):
                 raise DataDimensionMismatch()
+        if dateTimes:
+            self._is_equidistant = False
 
         dfs = self._setup_header(filename)
 
@@ -166,8 +168,13 @@ class _Dfs123:
                     d = d.reshape(self.shape[1:])
                     d = np.flipud(d)
                     darray = to_dotnet_float_array(d.reshape(d.size, 1)[:, 0])
+                if self._is_equidistant:
+                    dfs.WriteItemTimeStepNext(0, darray)
+                else:
+                    t = dateTimes[i]
+                    relt = (t - start_time).total_seconds()
+                    dfs.WriteItemTimeStepNext(relt, darray)
 
-                dfs.WriteItemTimeStepNext(0, darray)
 
         dfs.Close()
 

--- a/mikeio/dfs.py
+++ b/mikeio/dfs.py
@@ -26,6 +26,7 @@ class _Dfs123:
     _filename = None
     _projstr = None
     _start_time = None
+    _end_time = None
     _is_equidistant = True
     _items = None
     _builder = None
@@ -124,6 +125,10 @@ class _Dfs123:
         dfs.Close()
 
     def _write(self, filename, data, start_time, dt, datetimes, items, coordinate, title):
+
+        if isinstance(data, Dataset) and not data.is_equidistant:
+            datetimes = data.time
+
         self._write_handle_common_arguments(
             title, data, items, coordinate, start_time, dt
         )
@@ -148,7 +153,7 @@ class _Dfs123:
 
             if not all(np.shape(d)[2] == self._nx for d in data):
                 raise DataDimensionMismatch()
-        if datetimes:
+        if datetimes is not None:
             self._is_equidistant = False
             start_time = datetimes[0]
             self._start_time = start_time
@@ -411,6 +416,15 @@ class _Dfs123:
     def start_time(self):
         """File start time"""
         return self._start_time
+
+    @property
+    def end_time(self):
+        """File end time
+        """
+        if self._end_time is None:
+            self._end_time = self.read([0]).time[-1].to_pydatetime()
+        
+        return self._end_time
 
     @property
     def n_timesteps(self):

--- a/mikeio/dfs.py
+++ b/mikeio/dfs.py
@@ -113,6 +113,7 @@ class _Dfs123:
             self._timestep_in_seconds = (
                 dfs.FileInfo.TimeAxis.TimeStep
             )  # TODO handle other timeunits
+               # TODO to get the EndTime
         self._n_timesteps = dfs.FileInfo.TimeAxis.NumberOfTimeSteps
         self._projstr = dfs.FileInfo.Projection.WKTString
         self._longitude = dfs.FileInfo.Projection.Longitude
@@ -122,7 +123,7 @@ class _Dfs123:
 
         dfs.Close()
 
-    def _write(self, filename, data, start_time, dateTimes, dt, items, coordinate, title):
+    def _write(self, filename, data, start_time, dt, datetimes, items, coordinate, title):
         self._write_handle_common_arguments(
             title, data, items, coordinate, start_time, dt
         )
@@ -147,9 +148,9 @@ class _Dfs123:
 
             if not all(np.shape(d)[2] == self._nx for d in data):
                 raise DataDimensionMismatch()
-        if dateTimes:
+        if datetimes:
             self._is_equidistant = False
-            start_time = dateTimes[0]
+            start_time = datetimes[0]
             self._start_time = start_time
 
         dfs = self._setup_header(filename)
@@ -173,7 +174,7 @@ class _Dfs123:
                 if self._is_equidistant:
                     dfs.WriteItemTimeStepNext(0, darray)
                 else:
-                    t = dateTimes[i]
+                    t = datetimes[i]
                     relt = (t - start_time).total_seconds()
                     dfs.WriteItemTimeStepNext(relt, darray)
 

--- a/mikeio/dfs.py
+++ b/mikeio/dfs.py
@@ -150,6 +150,7 @@ class _Dfs123:
         if dateTimes:
             self._is_equidistant = False
             start_time = dateTimes[0]
+            self._start_time = start_time
 
         dfs = self._setup_header(filename)
 

--- a/mikeio/dfs1.py
+++ b/mikeio/dfs1.py
@@ -60,6 +60,7 @@ class Dfs1(_Dfs123):
         filename,
         data,
         start_time=None,
+        dateTimes = None,
         dt=None,
         items=None,
         dx=1,
@@ -96,7 +97,7 @@ class Dfs1(_Dfs123):
 
         self._builder = Dfs1Builder.Create(title, "mikeio", 0)
         self._dx = dx
-        self._write(filename, data, start_time, dt, items, coordinate, title)
+        self._write(filename, data, start_time, dateTimes, dt, items, coordinate, title)
 
     def _set_spatial_axis(self):
         self._builder.SetSpatialAxis(

--- a/mikeio/dfs1.py
+++ b/mikeio/dfs1.py
@@ -60,8 +60,8 @@ class Dfs1(_Dfs123):
         filename,
         data,
         start_time=None,
-        dateTimes = None,
         dt=None,
+        datetimes=None,
         items=None,
         dx=1,
         x0=0,
@@ -81,6 +81,8 @@ class Dfs1(_Dfs123):
             start datetime
         dt: float
             The time step in seconds.
+        dt: datetime
+            The list of datetimes for the case of nonEquadistant Timeaxis.
         items: list[ItemInfo], optional
             List of ItemInfo (e.g. Water Level).
         coordinate:
@@ -97,7 +99,7 @@ class Dfs1(_Dfs123):
 
         self._builder = Dfs1Builder.Create(title, "mikeio", 0)
         self._dx = dx
-        self._write(filename, data, start_time, dateTimes, dt, items, coordinate, title)
+        self._write(filename, data, start_time, dt, datetimes, items, coordinate, title)
 
     def _set_spatial_axis(self):
         self._builder.SetSpatialAxis(

--- a/mikeio/dfs2.py
+++ b/mikeio/dfs2.py
@@ -174,7 +174,7 @@ class Dfs2(_Dfs123):
     def end_time(self):
         """File end time
         """
-        return self.read(0).time[-1].to_pydatetime()
+        return self.read([0]).time[-1].to_pydatetime()
 
     @property
     def dx(self):

--- a/mikeio/dfs2.py
+++ b/mikeio/dfs2.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from DHI.Generic.MikeZero import eumUnit
 from DHI.Generic.MikeZero.DFS import DfsFileFactory
 from DHI.Generic.MikeZero.DFS.dfs123 import Dfs2Builder, Dfs2Reprojector
@@ -63,7 +64,11 @@ class Dfs2(_Dfs123):
 
         self._read_header()
 
-    def find_nearest_element(
+    def find_nearest_element(self, lon, lat):
+        warnings.warn("OBSOLETE! method name changed to find_nearest_elements")
+        return self.find_nearest_elements(lon, lat)
+
+    def find_nearest_elements(
         self, lon, lat,
     ):
         """Find index of closest element

--- a/mikeio/dfs2.py
+++ b/mikeio/dfs2.py
@@ -177,11 +177,7 @@ class Dfs2(_Dfs123):
                 self._dy,
             )
         )
-    @property
-    def end_time(self):
-        """File end time
-        """
-        return self.read([0]).time[-1].to_pydatetime()
+    
 
     @property
     def dx(self):

--- a/mikeio/dfs2.py
+++ b/mikeio/dfs2.py
@@ -58,6 +58,8 @@ class Dfs2(_Dfs123):
         self._dy = self._dfs.SpatialAxis.Dy
         self._nx = self._dfs.SpatialAxis.XCount
         self._ny = self._dfs.SpatialAxis.YCount
+        if self._dfs.FileInfo.TimeAxis.TimeAxisType == 4:
+            self._is_equidistant = False
 
         self._read_header()
 
@@ -108,6 +110,7 @@ class Dfs2(_Dfs123):
         filename,
         data,
         start_time=None,
+        dateTimes=None,
         dt=None,
         items=None,
         dx=None,
@@ -153,7 +156,7 @@ class Dfs2(_Dfs123):
         if dy:
             self._dy = dy
 
-        self._write(filename, data, start_time, dt, items, coordinate, title)
+        self._write(filename, data, start_time, dateTimes, dt, items, coordinate, title)
 
     def _set_spatial_axis(self):
         self._builder.SetSpatialAxis(

--- a/mikeio/dfs2.py
+++ b/mikeio/dfs2.py
@@ -170,6 +170,11 @@ class Dfs2(_Dfs123):
                 self._dy,
             )
         )
+    @property
+    def end_time(self):
+        """File end time
+        """
+        return self.read(0).time[-1].to_pydatetime()
 
     @property
     def dx(self):

--- a/mikeio/dfs2.py
+++ b/mikeio/dfs2.py
@@ -115,8 +115,8 @@ class Dfs2(_Dfs123):
         filename,
         data,
         start_time=None,
-        dateTimes=None,
         dt=None,
+        datetimes=None,
         items=None,
         dx=None,
         dy=None,
@@ -137,6 +137,8 @@ class Dfs2(_Dfs123):
             start date of type datetime.
         dt: float, optional
             The time step in seconds.
+        dt: datetime
+            The list of datetimes for the case of nonEquadistant Timeaxis.
         items: list[ItemInfo], optional
             List of ItemInfo corresponding to a variable types (ie. Water Level).
         dx: float, optional
@@ -161,7 +163,7 @@ class Dfs2(_Dfs123):
         if dy:
             self._dy = dy
 
-        self._write(filename, data, start_time, dateTimes, dt, items, coordinate, title)
+        self._write(filename, data, start_time, dt, datetimes, items, coordinate, title)
 
     def _set_spatial_axis(self):
         self._builder.SetSpatialAxis(

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -420,3 +420,42 @@ def test_write_default_datatype(tmpdir):
 
     newdfs = Dfs2(filename)
     assert newdfs.items[0].data_value_type == 0
+
+
+def test_write_NonEqCalendarAxis(tmpdir):
+
+    filename = os.path.join(tmpdir.dirname, "simple.dfs2")
+    data = []
+    d = np.random.random([6, 5, 10])
+    d[1, :, :] = np.nan
+    d[2, :, :] = 0
+    d[3, 3:, :] = 2
+    d[4, :, 4:] = 5
+    data.append(d)
+    east = 308124
+    north = 6098907
+    orientation = 0
+    dateTime = [datetime.datetime(2012, 1, 1), datetime.datetime(2012, 1, 4),
+                datetime.datetime(2012, 1, 5), datetime.datetime(2012, 1, 10),
+                datetime.datetime(2012, 1, 15), datetime.datetime(2012, 1, 28)]
+    dfs = Dfs2()
+    dfs.write(
+        filename=filename,
+        data=data,
+        start_time=datetime.datetime(2012, 1, 1),
+        dt=12,
+        dateTimes=dateTime,
+        items=[ItemInfo("testing water level", EUMType.Water_Level, EUMUnit.meter)],
+        coordinate=["UTM-33", east, north, orientation],
+        dx=100,
+        dy=200,
+        title="test dfs2",
+    )
+
+    newdfs = Dfs2(filename)
+    assert newdfs.projection_string == "UTM-33"
+    assert pytest.approx(newdfs.longitude) == 12.0
+    assert pytest.approx(newdfs.latitude) == 55.0
+    assert newdfs.dx == 100.0
+    assert newdfs.dy == 200.0
+    assert newdfs._is_equidistant == False

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -167,6 +167,7 @@ def test_write_selected_item_to_new_file(tmpdir):
     assert len(ds2) == 1
     assert ds.items[0].name == "Untitled"
     assert dfs.start_time == dfs2.start_time
+    assert dfs.end_time == dfs2.end_time
     assert dfs.projection_string == dfs2.projection_string
     assert dfs.longitude == dfs2.longitude
     assert dfs.latitude == dfs2.latitude
@@ -223,6 +224,8 @@ def test_write_modified_data_to_new_file(tmpdir):
     dfsmod = Dfs2(outfilename)
 
     assert dfs._longitude == dfsmod._longitude
+
+
 
 
 def test_read_some_time_step():
@@ -459,3 +462,23 @@ def test_write_NonEqCalendarAxis(tmpdir):
     assert newdfs.dx == 100.0
     assert newdfs.dy == 200.0
     assert newdfs._is_equidistant == False
+
+
+def test_write_non_equidistant_data(tmpdir):
+
+    filename = r"tests/testdata/eq.dfs2"
+    dfs = Dfs2(filename)
+
+    ds = dfs.read(time_steps=[0, 2, 3, 6])  # non-equidistant dataset
+
+    assert not ds.is_equidistant
+
+    outfilename = os.path.join(tmpdir.dirname, "neq_from_dataset.dfs2")
+
+    dfs.write(outfilename, ds)
+
+    dfs2 = Dfs2(outfilename)
+    ds3 = dfs2.read()
+
+    assert not ds3.is_equidistant
+

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -442,8 +442,8 @@ def test_write_NonEqCalendarAxis(tmpdir):
     dfs.write(
         filename=filename,
         data=data,
-        start_time=datetime.datetime(2012, 1, 1),
-        dt=12,
+        # start_time=datetime.datetime(2012, 1, 1),
+        # dt=12,
         dateTimes=dateTime,
         items=[ItemInfo("testing water level", EUMType.Water_Level, EUMUnit.meter)],
         coordinate=["UTM-33", east, north, orientation],

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -444,7 +444,7 @@ def test_write_NonEqCalendarAxis(tmpdir):
         data=data,
         # start_time=datetime.datetime(2012, 1, 1),
         # dt=12,
-        dateTimes=dateTime,
+        datetimes=dateTime,
         items=[ItemInfo("testing water level", EUMType.Water_Level, EUMUnit.meter)],
         coordinate=["UTM-33", east, north, orientation],
         dx=100,


### PR DESCRIPTION
I noticed that you already change the method find_nearest_element in the dfsu to find_nearest_elements so I applied that change to the dfs2 as well. 

Additionally, as per our discussion I modified the code to handle the NonEquidistant  Time axis as well. When I tried to do that I noticed that some of the checking for Equidistant and nonEquidistant  was some of the codes were there before. in The current code both Equidistant and nonEquidistant Time Axis can be created depend on the parameter that is used by user. 

Thanks, 