### PR TITLE
Exporting Dfsu to Dfs2

### DIFF
--- a/mikeio/dfsu.py
+++ b/mikeio/dfsu.py
@@ -2,12 +2,15 @@ from logging import warn
 import os
 from collections import namedtuple
 import pandas as pd
+import pathlib
 from enum import IntEnum
 import warnings
 import numpy as np
 from datetime import datetime, timedelta
 from scipy.spatial import cKDTree
+import tempfile
 from tqdm import trange
+import typing
 
 from DHI.Generic.MikeZero import eumUnit, eumQuantity
 from DHI.Generic.MikeZero.DFS import DfsFileFactory, DfsFactory
@@ -2375,6 +2378,94 @@ class Dfsu(_UnstructuredFile):
             geometry = self.geometry2d
 
         Mesh._geometry_to_mesh(outfilename, geometry)
+
+    def to_dfs2(
+        x0: = None,
+        y0: = None,
+        dx: float,
+        dy: float,
+        nx: int = 20,
+        ny: int = 20,
+        rotation: float = 0,
+        epsg: typing.Optional[int] = None,
+        interpolation_method: str = "nearest",
+        filename: typing.Optional[typing.Union[str, pathlib.Path]] = None,
+    ):
+        """Export Dfsu to Dfs2 file.
+
+        Export Dfsu file to a Dfs2 file with a regular 2D grid.
+
+        Parameters
+        ----------
+        x0 : float
+            X-coordinate of the bottom left corner of the 2D grid,
+            must be in the same coordinate system as the parent Dfsu file.
+        y0 : float
+            Y-coordinate of the bottom left corner of the 2D grid,
+            must be in the same coordinate system as the parent Dfsu file.
+        dx : float
+            Grid resolution in the X direction in the units of CRS defined by `epsg`.
+        dy : float
+            Grid resolution in the Y direction in the units of CRS defined by `epsg`.
+        nx : int, optional
+            Grid size in the X direction. By default it is 20.
+        ny : int, optional
+            Grid size in the Y direction. By default it is 20.
+        rotation : float, optional
+            Grid clockwise rotation in degrees. Be default it is 0.
+        epsg : int, optional
+            EPSG identificator of coordinate system
+            in which the Dfs2 file will be created.
+            If None (default), uses coordinate system of the parent Dfsu file.
+        interpolation_method : str, optional
+            Interpolation method, by default it is 'nearest'.
+            See https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.griddata.html
+        filename : str or pathlib.Path, optional
+            Path to *.dfs2 file to be created.
+            If None (default), creates a temporary dfs2 file
+            in the system temporary directory.
+
+        Returns
+        -------
+        Dfs2
+            mikeio Dfs2 object pointing to the file located at `filename`.
+
+        """
+        # Process 'filename' argument
+        if filename is None:
+            filename = tempfile.NamedTemporaryFile().name + ".dfs2"
+        else:
+            if isinstance(filename, str):
+                filename = pathlib.Path(filename)
+
+            if isinstance(filename, pathlib.Path):
+                filename = filename.resolve()
+                if not filename.suffix == ".dfs2":
+                    raise ValueError(
+                        f"'filename' must point to a dfs2 file, "
+                        f"not to '{filename.suffix}'"
+                    )
+            else:
+                raise TypeError(
+                    f"invalid type in '{type(filename)}' for the 'filename' argument, "
+                    f"must be string or pathlib.Path"
+                )
+
+        # Define 2D grid in 'epsg' projection
+        # TODO
+
+        # Determine Dfsu projection
+        # Convert X/Y points from Dfsu to 'epsg' projection
+        # TODO
+
+        # Interpolate Dfsu items to 2D grid using scipy.interpolate.griddata
+        # TODO
+
+        # Write interpolated data to 'filename'
+        # TODO - use Dfs2.write(filename)
+
+        # Return reference to the created Dfs2 file
+        # TODO - Dfs2(filename)
 
 
 class Mesh(_UnstructuredFile):

--- a/mikeio/dfsu.py
+++ b/mikeio/dfsu.py
@@ -1097,7 +1097,11 @@ class _UnstructuredGeometry:
 
         node_cellID = [
             list(np.argwhere(elem_table == i)[:, 0])
-            for i in np.unique(elem_table.reshape(-1,))
+            for i in np.unique(
+                elem_table.reshape(
+                    -1,
+                )
+            )
         ]
         node_centered_data = np.zeros(shape=nc.shape[0])
         for n, item in enumerate(node_cellID):
@@ -1534,8 +1538,7 @@ class _UnstructuredGeometry:
         return np.asarray(elem_table), ec, data
 
     def _get_boundary_polylines_uncategorized(self):
-        """Construct closed polylines for all boundary faces        
-        """
+        """Construct closed polylines for all boundary faces"""
         boundary_faces = self._get_boundary_faces()
         face_remains = boundary_faces.copy()
         polylines = []
@@ -1561,7 +1564,7 @@ class _UnstructuredGeometry:
         return polylines
 
     def _get_boundary_polylines(self):
-        """Get boundary polylines and categorize as inner or outer by 
+        """Get boundary polylines and categorize as inner or outer by
         assessing the signed area
         """
         polylines = self._get_boundary_polylines_uncategorized()
@@ -1593,8 +1596,7 @@ class _UnstructuredGeometry:
         return BoundaryPolylines(n_ext, poly_lines_ext, n_int, poly_lines_int)
 
     def _get_boundary_faces(self):
-        """Construct list of faces
-        """
+        """Construct list of faces"""
         element_table = self.geometry2d.element_table
 
         all_faces = []
@@ -1782,7 +1784,10 @@ class Dfsu(_UnstructuredFile):
         yc = np.zeros(self.n_elements)
         zc = np.zeros(self.n_elements)
         _, xc2, yc2, zc2 = DfsuUtil.CalculateElementCenterCoordinates(
-            self._source, to_dotnet_array(xc), to_dotnet_array(yc), to_dotnet_array(zc),
+            self._source,
+            to_dotnet_array(xc),
+            to_dotnet_array(yc),
+            to_dotnet_array(zc),
         )
         ec = np.column_stack([asNumpyArray(xc2), asNumpyArray(yc2), asNumpyArray(zc2)])
         return ec
@@ -2106,7 +2111,13 @@ class Dfsu(_UnstructuredFile):
         return Dataset(data_list, times, items_out)
 
     def write_header(
-        self, filename, start_time=None, dt=None, items=None, elements=None, title=None,
+        self,
+        filename,
+        start_time=None,
+        dt=None,
+        items=None,
+        elements=None,
+        title=None,
     ):
         """Write the header of a new dfsu file
 

--- a/mikeio/dfsu.py
+++ b/mikeio/dfsu.py
@@ -2380,8 +2380,8 @@ class Dfsu(_UnstructuredFile):
         Mesh._geometry_to_mesh(outfilename, geometry)
 
     def to_dfs2(
-        x0: = None,
-        y0: = None,
+        x0: float,
+        y0: float,
         dx: float,
         dy: float,
         nx: int = 20,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pathlib
+
+import mikeio
+import pytest
+
+_testdata_directory = pathlib.Path(__file__).parent.resolve() / "testdata"
+
+
+@pytest.fixture(scope="session")
+def testdata_directory() -> pathlib.Path:
+    return _testdata_directory
+
+
+@pytest.fixture(scope="function")
+def dfsu_hd2d(testdata_directory) -> mikeio.Dfsu:
+    return mikeio.Dfsu(filename=str(testdata_directory / "HD2D.dfsu"))

--- a/tests/test_dfsu.py
+++ b/tests/test_dfsu.py
@@ -1160,10 +1160,8 @@ def test_dfsu_to_dfs2(dfsu_hd2d, tmpdir):
 
     # Ensure all items are identical
     for i, dfsu_item in enumerate(dfsu_hd2d.items):
-        assert dfsu_item.data_value_type == dfs2.items[i].data_value_type
-        assert dfsu_item.name == dfs2.items[i].name
-        assert dfsu_item.type == dfs2.items[i].type
-        assert dfsu_item.unit == dfs2.items[i].unit
+        for parameter in ["data_value_type", "name", "type", "unit"]:
+            assert getattr(dfsu_item, parameter) == getattr(dfs2.items[i], parameter)
 
     # Check timesteps
     assert dfs2.timestep == dfsu_hd2d.timestep


### PR DESCRIPTION
This PR introduces a new method to the `Dfsu` class - `.to_dfs2`. This method provides an interface to convert `Dfsu` to `Dfs2` with similar functionality to what DHI MIKE has when creating DFS2 files from DFSU files.