### PR TITLE
Pfs modify float explicit

### DIFF
--- a/mikeio/pfs.py
+++ b/mikeio/pfs.py
@@ -77,7 +77,7 @@ class Pfs:
             "time_step_frequency",
         ]
         rows = []
-        index = range(1, n+1)
+        index = range(1, n + 1)
         for i in range(n):
             output = sub[f"OUTPUT_{i+1}"]
             row = {key: output[key] for key in sel_keys}
@@ -117,7 +117,6 @@ class Pfs:
 
             if s[-1] == "]":
                 s = s.replace("]", ":")
-
 
         s = s.replace("//", "").replace("|", "")
 
@@ -276,20 +275,32 @@ class Parameter:
         else:
             return par.ToString()
 
-    def modify(self, value: Union[int, float, str]):
+    def modify(self, value: Union[int, float, str], valuetype=None):
 
         par = self._parameter
 
+        if valuetype is int:
+            par.ModifyIntParameter(value)
+            return
+        elif valuetype is float:
+            par.ModifyDoubleParameter(value)
+            return
+
         if par.IsInt():
             par.ModifyIntParameter(value)
-        elif par.IsDouble():
+            return
+        if par.IsDouble():
             par.ModifyDoubleParameter(value)
+            return
         elif par.IsFilename():
             par.ModifyFileNameParameter(value)
+            return
         elif par.IsClob():
-            return par.ModifyClobParameter(value)
+            par.ModifyClobParameter(value)
+            return
         else:
-            return par.ModifyStringParameter(value)
+            par.ModifyStringParameter(value)
+            return
 
 
 class Section:
@@ -313,4 +324,3 @@ class Section:
 
     def __getitem__(self, key):
         return self.keyword(key)
-

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -139,7 +139,6 @@ def test_sw_set_end_time(tmpdir):
     assert pfs.section("TIME")["number_of_time_steps"].value == 720
 
     pfs.write(os.path.join(tmpdir, "lake_new.sw"))
-    print("Done")
 
 
 def test_sw_modify_and_write(tmpdir):

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -138,6 +138,9 @@ def test_sw_set_end_time(tmpdir):
     assert pfs.end_time == new_end_time
     assert pfs.section("TIME")["number_of_time_steps"].value == 720
 
+    pfs.write(os.path.join(tmpdir, "lake_new.sw"))
+    print("Done")
+
 
 def test_sw_modify_and_write(tmpdir):
 
@@ -150,6 +153,11 @@ def test_sw_modify_and_write(tmpdir):
 
     # modify parameter without needing to specify that the float is a float...
     wind_section["Charnock_parameter"] = 0.02
+
+    wind_section["Charnock_parameter"] = 1.0
+
+    # Force parameter to be interpreted as float to avoid interpreting 1.0 as integer
+    wind_section["Charnock_parameter"].modify(0.1, float)
 
     # modify a filename
     pfs.section("DOMAIN")["file_name"] = "tests\\testdata\\odense_rough.mesh"
@@ -167,4 +175,3 @@ def test_sw_modify_and_write(tmpdir):
     outfilename = os.path.join(tmpdir.dirname, "lake_mod.sw")
 
     pfs.write(outfilename)
-


### PR DESCRIPTION
In the current implementation of the PFSCore class (wrapping the MIKE SDK), it tries to cleverly find the type of parameter to use the appropriate method, but in case of ambiguity such as 1.0, which can be interpreted both as integer and float, this goes wrong.

So it can now be explicitly forced to be interpreted as a float.