### PR TITLE
Make setting of DataValueType for DFS0 consistent with other methods

### DIFF
--- a/mikeio/dfs0.py
+++ b/mikeio/dfs0.py
@@ -30,7 +30,6 @@ class Dfs0:
     _dt = None
     _is_equidistant = None
     _title = None
-    _data_value_type = None
     _items = None
 
     def __init__(self, filename=None):
@@ -185,7 +184,8 @@ class Dfs0:
             name = self._dfs.ItemInfo[i].Name
             item_type = EUMType(self._dfs.ItemInfo[i].Quantity.Item)
             unit = EUMUnit(self._dfs.ItemInfo[i].Quantity.Unit)
-            yield ItemInfo(name, item_type, unit)
+            value_type = self._dfs.ItemInfo[i].ValueType
+            yield ItemInfo(name, item_type, unit, data_value_type=value_type)
 
     @staticmethod
     def _to_dfs_datatype(dtype):

--- a/mikeio/dfs0.py
+++ b/mikeio/dfs0.py
@@ -230,8 +230,8 @@ class Dfs0:
                 item.name, quantity, dtype_dfs,
             )
 
-            if self._data_value_type is not None:
-                newitem.SetValueType(self._data_value_type[i])
+            if item.data_value_type is not None:
+                newitem.SetValueType(item.data_value_type)
             else:
                 newitem.SetValueType(DataValueType.Instantaneous)
 
@@ -255,7 +255,6 @@ class Dfs0:
         datetimes=None,
         items=None,
         title="",
-        data_value_type=None,
         dtype=None,
     ):
         """
@@ -279,8 +278,6 @@ class Dfs0:
             List of ItemInfo corresponding to a variable types (ie. Water Level).
         title: str, optional
             title, default blank
-        data_value_type: list[DataValueType], optional
-            DataValueType default DataValueType.INSTANTANEOUS
         dtype : np.dtype, optional
             default np.float32
 
@@ -289,7 +286,6 @@ class Dfs0:
         self._title = title
         self._timeseries_unit = timeseries_unit
         self._dtype = dtype
-        self._data_value_type = data_value_type
 
         if isinstance(data, Dataset):
             self._items = data.items
@@ -428,12 +424,11 @@ def series_to_dfs0(
     unit=None,
     items=None,
     title=None,
-    data_value_type=None,
     dtype=None,
 ):
 
     df = pd.DataFrame(self)
-    df.to_dfs0(filename, itemtype, unit, items, title, data_value_type, dtype)
+    df.to_dfs0(filename, itemtype, unit, items, title, dtype)
 
 
 def dataframe_to_dfs0(
@@ -443,7 +438,6 @@ def dataframe_to_dfs0(
     unit=None,
     items=None,
     title=None,
-    data_value_type=None,
     dtype=None,
 ):
     """
@@ -461,8 +455,6 @@ def dataframe_to_dfs0(
         Different types, units for each items, similar to `create`
     title: str, optional
         Title of dfs0 file
-    data_value_type: list[DataValueType], optional
-            DataValueType default DataValueType.INSTANTANEOUS
     dtype : np.dtype, optional
             default np.float32
     """
@@ -495,7 +487,6 @@ def dataframe_to_dfs0(
             datetimes=self.index,
             items=items,
             title=title,
-            data_value_type=data_value_type,
             dtype=dtype,
         )
     else:  # equidistant
@@ -508,7 +499,6 @@ def dataframe_to_dfs0(
             dt=dt,
             items=items,
             title=title,
-            data_value_type=data_value_type,
             dtype=dtype,
         )
 

--- a/tests/test_dfs0.py
+++ b/tests/test_dfs0.py
@@ -538,3 +538,55 @@ def test_read_relative_time_axis():
 
     ds = dfs0.read()
     assert len(ds) == 5
+
+
+def test_write_accumulated_datatype(tmpdir):
+    filename = os.path.join(tmpdir.dirname, "simple.dfs0")
+
+    data = []
+    d = np.random.random([100, 2, 3])
+    data.append(d)
+
+    dfs = Dfs0()
+
+    dfs.write(
+        filename=filename,
+        data=data,
+        start_time=datetime.datetime(2012, 1, 1),
+        dt=12,
+        items=[
+            ItemInfo(
+                "testing water level",
+                EUMType.Water_Level,
+                EUMUnit.meter,
+                data_value_type="MeanStepBackward",
+            )
+        ],
+        title="test dfs0",
+    )
+
+    newdfs = Dfs0(filename)
+    assert newdfs.items[0].data_value_type == 3
+
+
+def test_write_default_datatype(tmpdir):
+    filename = os.path.join(tmpdir.dirname, "simple.dfs0")
+
+    data = []
+    d = np.random.random([100, 2, 3])
+    data.append(d)
+
+    dfs = Dfs0()
+
+    dfs.write(
+        filename=filename,
+        data=data,
+        start_time=datetime.datetime(2012, 1, 1),
+        dt=12,
+        items=[ItemInfo("testing water level", EUMType.Water_Level, EUMUnit.meter)],
+        title="test dfs0",
+    )
+
+    newdfs = Dfs0(filename)
+    assert newdfs.items[0].data_value_type == 0
+

--- a/tests/test_dfs0.py
+++ b/tests/test_dfs0.py
@@ -10,6 +10,9 @@ from datetime import timedelta
 
 import pytest
 
+from DHI.Generic.MikeZero.DFS import (
+    DataValueType
+)
 
 def test_repr():
     filename = os.path.join("tests", "testdata", "da_diagnostic.dfs0")
@@ -211,9 +214,8 @@ def test_write_equidistant_calendar(tmpdir):
     start_time = datetime.datetime(2017, 1, 1)
     timeseries_unit = 1402
     title = "Hello Test"
-    items = [ItemInfo("VarFun01", 100000, 1000), ItemInfo("NotFun", 100000, 1000)]
+    items = [ItemInfo("VarFun01", 100000, 1000, data_value_type=0), ItemInfo("NotFun", 100000, 1000, data_value_type=1)]
 
-    data_value_type = [0, 1]  # TODO add data_value_type to ItemInfo
     dt = 5
     dfs = Dfs0()
     dfs.write(
@@ -224,7 +226,6 @@ def test_write_equidistant_calendar(tmpdir):
         dt=dt,
         items=items,
         title=title,
-        data_value_type=data_value_type,
     )
 
 
@@ -240,8 +241,7 @@ def test_write_non_equidistant_calendar(tmpdir):
     for i in range(1000):
         time_vector.append(start_time + datetime.timedelta(hours=i * 0.1))
     title = "Hello Test"
-    items = [ItemInfo("VarFun01", 100000, 1000), ItemInfo("NotFun", 100000, 1000)]
-    data_value_type = [0, 1]
+    items = [ItemInfo("VarFun01", 100000, 1000, 0), ItemInfo("NotFun", 100000, 1000, 1)]
 
     dfs = Dfs0()
     dfs.write(
@@ -250,7 +250,6 @@ def test_write_non_equidistant_calendar(tmpdir):
         datetimes=time_vector,
         items=items,
         title=title,
-        data_value_type=data_value_type,
     )
 
     assert os.path.exists(dfs0file)
@@ -347,6 +346,7 @@ def test_write_from_data_frame(tmpdir):
     assert len(ds.items) == 5
     assert ds.items[0].type == EUMType.Concentration
     assert ds.items[0].unit == EUMUnit.gram_per_meter_pow_3
+    assert ds.items[0].data_value_type == 0
 
 
 def test_write_from_data_frame_monkey_patched(tmpdir):
@@ -544,7 +544,7 @@ def test_write_accumulated_datatype(tmpdir):
     filename = os.path.join(tmpdir.dirname, "simple.dfs0")
 
     data = []
-    d = np.random.random([100, 2, 3])
+    d = np.random.random(100)
     data.append(d)
 
     dfs = Dfs0()
@@ -553,16 +553,15 @@ def test_write_accumulated_datatype(tmpdir):
         filename=filename,
         data=data,
         start_time=datetime.datetime(2012, 1, 1),
-        dt=12,
         items=[
             ItemInfo(
                 "testing water level",
                 EUMType.Water_Level,
                 EUMUnit.meter,
-                data_value_type="MeanStepBackward",
+                data_value_type="MeanStepBackward"
             )
         ],
-        title="test dfs0",
+        title="test dfs0"
     )
 
     newdfs = Dfs0(filename)
@@ -573,7 +572,7 @@ def test_write_default_datatype(tmpdir):
     filename = os.path.join(tmpdir.dirname, "simple.dfs0")
 
     data = []
-    d = np.random.random([100, 2, 3])
+    d = np.random.random(100)
     data.append(d)
 
     dfs = Dfs0()
@@ -589,4 +588,3 @@ def test_write_default_datatype(tmpdir):
 
     newdfs = Dfs0(filename)
     assert newdfs.items[0].data_value_type == 0
-


### PR DESCRIPTION
* Change how DataValueType is passed for DFS0 to be through ItemInfo list instead of as separate argument to be consistent with other dfs formats
* Respect DataValueType information in DFS0 files when reading with mikeio.read
* close #184 