### PR TITLE
Abstract base class as contract for common props

### DIFF
--- a/mikeio/base.py
+++ b/mikeio/base.py
@@ -1,0 +1,40 @@
+from abc import ABC, abstractmethod
+
+
+class TimeSeries(ABC):
+    @property
+    @abstractmethod
+    def start_time(self):
+        pass
+
+    @property
+    @abstractmethod
+    def end_time(self):
+        pass
+
+    @property
+    @abstractmethod
+    def n_timesteps(self):
+        pass
+
+    @property
+    @abstractmethod
+    def deletevalue(self):
+        pass
+
+    @property
+    @abstractmethod
+    def n_items(self):
+        pass
+
+    @property
+    @abstractmethod
+    def items(self):
+        pass
+
+
+class EquidistantTimeSeries(TimeSeries):
+    @property
+    @abstractmethod
+    def timestep(self):
+        pass

--- a/mikeio/dataset.py
+++ b/mikeio/dataset.py
@@ -7,8 +7,13 @@ from scipy.interpolate import interp1d
 from copy import deepcopy
 from mikeio.eum import EUMType, ItemInfo
 
+from .base import TimeSeries
 
-class Dataset:
+
+class Dataset(TimeSeries):
+
+    deletevalue = 1.0e-35
+
     """Dataset
 
     Attributes
@@ -89,6 +94,8 @@ class Dataset:
         items: Union[List[ItemInfo], List[EUMType]],
     ):
 
+        self._deletevalue = Dataset.deletevalue
+
         if isinstance(time, str):
             # default single-step time
             time = self.create_time(time)
@@ -127,7 +134,7 @@ class Dataset:
             if isinstance(item, EUMType):
                 items[i] = ItemInfo(item)
 
-        self.items = items
+        self._items = items
 
     def __repr__(self):
 
@@ -724,6 +731,10 @@ class Dataset:
         return len(self.items)
 
     @property
+    def items(self):
+        return self._items
+
+    @property
     def shape(self):
         """Shape of each item"""
         return self.data[self._first_non_z_item].shape
@@ -741,3 +752,8 @@ class Dataset:
         if self.n_timesteps > 1:
             n_elem = int(n_elem / self.n_timesteps)
         return n_elem
+
+    @property
+    def deletevalue(self):
+        """File delete value"""
+        return self._deletevalue

--- a/mikeio/dfs.py
+++ b/mikeio/dfs.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timedelta
+from abc import abstractmethod
+
 import warnings
 import numpy as np
 import pandas as pd
 from tqdm import tqdm, trange
 from .dataset import Dataset
+from .base import TimeSeries
 
 from .dotnet import (
     to_dotnet_datetime,
@@ -22,7 +25,7 @@ from DHI.Generic.MikeZero.DFS import (
 )
 
 
-class _Dfs123:
+class _Dfs123(TimeSeries):
 
     _filename = None
     _projstr = None
@@ -316,8 +319,7 @@ class _Dfs123:
 
     @property
     def end_time(self):
-        """File end time
-        """
+        """File end time"""
         if self._end_time is None:
             self._end_time = self.read([0]).time[-1].to_pydatetime()
 
@@ -351,3 +353,9 @@ class _Dfs123:
     def orientation(self):
         """North to Y orientation"""
         return self._orientation
+
+    @property
+    @abstractmethod
+    def dx(self):
+        """Step size in x direction"""
+        pass

--- a/mikeio/dfs0.py
+++ b/mikeio/dfs0.py
@@ -21,9 +21,10 @@ from .dfsutil import _valid_item_numbers, _get_item_info
 from .dataset import Dataset
 from .eum import TimeStepUnit, EUMType, EUMUnit, ItemInfo, TimeAxisType
 from .helpers import safe_length
+from .base import TimeSeries
 
 
-class Dfs0:
+class Dfs0(TimeSeries):
 
     _start_time = None
     _n_items = None
@@ -227,7 +228,9 @@ class Dfs0:
             newitem = builder.CreateDynamicItemBuilder()
             quantity = eumQuantity.Create(item.type, item.unit)
             newitem.Set(
-                item.name, quantity, dtype_dfs,
+                item.name,
+                quantity,
+                dtype_dfs,
             )
 
             if item.data_value_type is not None:
@@ -415,6 +418,15 @@ class Dfs0:
     def start_time(self):
         """File start time"""
         return self._start_time
+
+    @property
+    def end_time(self):
+        return self._end_time
+
+    @property
+    def n_timesteps(self):
+        """Number of time steps"""
+        return self._n_timesteps
 
 
 def series_to_dfs0(


### PR DESCRIPTION
To ensure consistent naming of properties across classes.

Now it is clear that:
- `Dataset`
- `Dfs0`
- `Dfs1`
- `Dfs2`
- `Dfsu`

all have the same properties like  `start_time` and `end_time`.
