### PR TITLE
Time index fix

### DIFF
--- a/mikeio/dfs.py
+++ b/mikeio/dfs.py
@@ -97,7 +97,7 @@ class _Dfs123(TimeSeries):
 
             t_seconds[i] = itemdata.Time
 
-        time = [self.start_time + timedelta(seconds=t) for t in t_seconds]
+        time = pd.to_datetime(t_seconds, unit="s", origin=self.start_time)
 
         items = _get_item_info(self._dfs.ItemInfo, item_numbers)
 

--- a/mikeio/dfs0.py
+++ b/mikeio/dfs0.py
@@ -159,7 +159,10 @@ class Dfs0(TimeSeries):
         for i in range(matrix.shape[1]):
             data.append(matrix[:, i])
 
-        time = list(self.__get_time(raw_data))
+        t_seconds = raw_data[:, 0]
+        time = pd.to_datetime(t_seconds, unit="s", origin=self.start_time)
+        time = time.round(freq="ms")  # accept nothing finer than milliseconds
+
         items = list(self.__get_items())
 
         self._dfs.Close()
@@ -173,13 +176,6 @@ class Dfs0(TimeSeries):
         nan_indices = np.isclose(data, self._dfs.FileInfo.DeleteValueFloat, atol=1e-36)
         data[nan_indices] = np.nan
         return data
-
-    def __get_time(self, raw_data):
-        start_time = self.start_time
-
-        for t in range(self._n_timesteps):
-            t_sec = raw_data[t, self._time_column_index]
-            yield start_time + timedelta(seconds=t_sec)
 
     def __get_items(self):
         for i in range(self._n_items):
@@ -354,7 +350,7 @@ class Dfs0(TimeSeries):
 
         dfs.Close()
 
-    def to_dataframe(self, unit_in_name=False, round_time="s"):
+    def to_dataframe(self, unit_in_name=False, round_time="ms"):
         """
         Read data from the dfs0 file and return a Pandas DataFrame.
 

--- a/mikeio/dfsu.py
+++ b/mikeio/dfsu.py
@@ -2010,7 +2010,7 @@ class Dfsu(_UnstructuredFile, EquidistantTimeSeries):
 
             t_seconds[i] = itemdata.Time
 
-        time = [self.start_time + timedelta(seconds=tsec) for tsec in t_seconds]
+        time = pd.to_datetime(t_seconds, unit="s", origin=self.start_time)
 
         dfs.Close()
         return Dataset(data_list, time, items)


### PR DESCRIPTION
The use of Dfs0Util.ReadDfs0DataDouble() gives problems with rounding errors. 
 
![rounding_errors](https://user-images.githubusercontent.com/34088801/120294639-aefc1000-c2c6-11eb-967b-398b60a9e435.png)

This can be handled by rounding to milliseconds after converting to DateTimeIndex. This also reduces the need for having to-seconds rounding in to_dataframe() method. 

Furthermore, the previous time conversion with a generator and a list comprehension was found to be slow and has been been replaced by a fast pandas method. 