### PR TITLE
Discrete colorbar error - matplotlib 3.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
             "matplotlib",
             "jupyterlab",
         ],
-        "test": ["pytest", "matplotlib"],
+        "test": ["pytest", "matplotlib!=3.5.0"],
         "notebooks": [
             "nbformat",
             "nbconvert",

--- a/tests/test_dfsu_plot.py
+++ b/tests/test_dfsu_plot.py
@@ -58,7 +58,12 @@ def test_plot_dfsu_contour_mixedmesh():
     filename = os.path.join("tests", "testdata", "FakeLake.dfsu")
     msh = Mesh(filename)
     msh.plot(plot_type="contour", levels=5)
-    msh.plot(plot_type='contourf', title='contourf', show_mesh=False, levels=[-30,-24,-22,-10,-8])
+    msh.plot(
+        plot_type="contourf",
+        title="contourf",
+        show_mesh=False,
+        levels=[-30, -24, -22, -10, -8],
+    )
     assert True
 
 

--- a/tests/test_dfsu_plot.py
+++ b/tests/test_dfsu_plot.py
@@ -58,6 +58,7 @@ def test_plot_dfsu_contour_mixedmesh():
     filename = os.path.join("tests", "testdata", "FakeLake.dfsu")
     msh = Mesh(filename)
     msh.plot(plot_type="contour", levels=5)
+    msh.plot(plot_type='contourf', title='contourf', show_mesh=False, levels=[-30,-24,-22,-10,-8])
     assert True
 
 


### PR DESCRIPTION
After release of matplotlib 3.5.0 there is an error on using discrete levels on a contour plot.
Maybe related to: [Matplotlib 3.5 - Colorbars changes](https://matplotlib.org/3.5.0/api/prev_api_changes/api_changes_3.5.0.html#colorbars-now-have-pan-and-zoom-functionality)