### PR TITLE
Grid 2D create with nx, ny

### DIFF
--- a/mikeio/dfs2.py
+++ b/mikeio/dfs2.py
@@ -131,7 +131,8 @@ class Dfs2(_Dfs123):
                     self.geometry = Grid2D(
                         dx=self._dx,
                         dy=self._dy,
-                        shape=(self._nx, self._ny),
+                        nx=self._nx,
+                        ny=self._ny,
                         x0=self._longitude,
                         y0=self._latitude,
                         projection=self._projstr,
@@ -141,7 +142,8 @@ class Dfs2(_Dfs123):
                 self.geometry = Grid2D(
                     dx=self._dx,
                     dy=self._dy,
-                    shape=(self._nx, self._ny),
+                    nx=self._nx,
+                    ny=self._ny,
                     x0=self._x0,
                     y0=self._y0,
                     projection=self._projstr,

--- a/mikeio/spatial/grid_geometry.py
+++ b/mikeio/spatial/grid_geometry.py
@@ -239,20 +239,14 @@ class Grid2D(_Geometry):
             grid resolution in x-direction (or in x- and y-direction)
         dy : float, optional
             grid resolution in y-direction
-        shape : (int, int), optional
-            tuple with nx and ny describing number of points in each direction
-            one of them can be None, in which case the value will be inferred
-        projection_string
+        projection: str, optional
+            default 'LONG/LAT'
 
         Examples
         --------
         >>> g = Grid2D(dx=0.25, nx=5, ny=10)
-        >>> g = Grid2D(dx=0.25, shape=(5,10))
-
         >>> g = Grid2D(bbox=[0,0,10,20], dx=0.25)
-
-        >>> g = Grid2D(bbox=[0,0,10,20], shape=(5,10))
-
+        >>> g = Grid2D(bbox=[0,0,10,20], nx==5, ny=10)
         >>> x = np.linspace(0.0, 1000.0, 201)
         >>> y = [0, 2.0]
         >>> g = Grid2D(x, y)
@@ -295,8 +289,6 @@ class Grid2D(_Geometry):
             self._create_in_bbox(bbox, dxdy, shape)
         elif (x is not None) and (y is not None):
             self._create_from_x_and_y(x, y)
-        elif (shape is not None) and (dx is not None):
-            self._create_from_nx_ny_dx_dy(x0, dx, shape[0], y0, dy, shape[1])
         elif (nx is not None) and (ny is not None):
             self._create_from_nx_ny_dx_dy(x0=x0, dx=dx, nx=nx, y0=y0, dy=dy, ny=ny)
         else:

--- a/mikeio/spatial/grid_geometry.py
+++ b/mikeio/spatial/grid_geometry.py
@@ -221,6 +221,8 @@ class Grid2D(_Geometry):
         shape=None,
         x0=None,
         y0=None,
+        nx=None,
+        ny=None,
         projection="LONG/LAT",
     ):
         """create 2d grid
@@ -244,6 +246,7 @@ class Grid2D(_Geometry):
 
         Examples
         --------
+        >>> g = Grid2D(dx=0.25, nx=5, ny=10)
         >>> g = Grid2D(dx=0.25, shape=(5,10))
 
         >>> g = Grid2D(bbox=[0,0,10,20], dx=0.25)
@@ -294,8 +297,12 @@ class Grid2D(_Geometry):
             self._create_from_x_and_y(x, y)
         elif (shape is not None) and (dx is not None):
             self._create_from_nx_ny_dx_dy(x0, dx, shape[0], y0, dy, shape[1])
+        elif (nx is not None) and (ny is not None):
+            self._create_from_nx_ny_dx_dy(x0=x0, dx=dx, nx=nx, y0=y0, dy=dy, ny=ny)
         else:
-            raise ValueError("Please provide either bbox or both x and y")
+            raise ValueError(
+                "Please provide either bbox or both x and y, or x0, dx, nx, y0, dy, ny"
+            )
 
     def _create_in_bbox(self, bbox, dxdy=None, shape=None):
         """create 2d grid in bounding box, specifying spacing or shape

--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -48,7 +48,7 @@ def da_grid2d():
         data=np.zeros([nt, ny, nx]) + 0.1,
         time=pd.date_range(start=datetime(2000, 1, 1), freq="S", periods=nt),
         item=ItemInfo("Foo"),
-        geometry=mikeio.Grid2D(x0=1000.0, dx=10.0, shape=(nx, ny), dy=1.0, y0=-10.0),
+        geometry=mikeio.Grid2D(x0=1000.0, dx=10.0, nx=nx, ny=ny, dy=1.0, y0=-10.0),
     )
 
     return da
@@ -240,7 +240,7 @@ def test_dataarray_init_grid2d():
     ny, nx = 7, 5
     time = pd.date_range(start=datetime(2000, 1, 1), freq="S", periods=nt)
     data = np.zeros([nt, ny, nx]) + 0.1
-    g = mikeio.Grid2D(dx=0.5, shape=(nx, ny))
+    g = mikeio.Grid2D(dx=0.5, nx=nx, ny=ny)
     da = mikeio.DataArray(data=data, time=time, geometry=g)
     assert da.ndim == 3
     assert da.dims == ("time", "y", "x")

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -163,7 +163,7 @@ def test_write_projected(tmpdir):
     x0 = 308124
     y0 = 6098907
 
-    grid = Grid2D(shape=(nx, ny), x0=x0, y0=y0, dx=100, dy=100, projection="UTM-33")
+    grid = Grid2D(nx=nx, ny=ny, x0=x0, y0=y0, dx=100, dy=100, projection="UTM-33")
     da = mikeio.DataArray(
         data=d, time=pd.date_range("2012-1-1", freq="s", periods=100), geometry=grid
     )

--- a/tests/test_geometry_Grid2D.py
+++ b/tests/test_geometry_Grid2D.py
@@ -7,6 +7,20 @@ from mikeio import Mesh
 from mikeio import Grid2D
 
 
+def test_create_nx_ny():
+
+    g = Grid2D(x0=180.0, y0=-90.0, dx=0.25, dy=0.25, nx=1440, ny=721)
+    assert g.nx == 1440
+
+
+def test_create_nx_missing_ny():
+
+    with pytest.raises(ValueError) as excinfo:
+        Grid2D(x0=180.0, y0=-90.0, dx=0.25, dy=0.25, nx=100)
+
+    assert "ny" in str(excinfo.value)
+
+
 def test_x_y():
     x0 = 2.0
     x1 = 8.0


### PR DESCRIPTION
Creating a Grid2D like this:
```
Grid2D(shape=(10,2),..)
```
is intuitive with `shape=(nx,ny)`, except that it matches poorly with the shape of the data where the `shape=(nt,ny,nx)` 😕 

Thus in the spirit of explicit is better than explicit (and a Grid2D doesn't accept anything else than 2d anyway):
```
Grid2D(nx=10, ny=2,...)
```
