### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     version="1.0.a1",
     install_requires=[
         "mikecore>=0.2.0",
-        "numpy>=1.15.0.",  # first version with numpy.quantile
+        "numpy>=1.15.0",  # first version with numpy.quantile
         "pandas>1.0",
         "scipy>1.0",
         "pyyaml",


### PR DESCRIPTION
there was an additional `.` at the end of Numpy (`1.15.0.`) that created problems in conda, not allowing to create/export environments, and maybe some other problems.