### PR TITLE
Default to float32, and allow float64

### DIFF
--- a/mikeio/__init__.py
+++ b/mikeio/__init__.py
@@ -66,26 +66,34 @@ def read(filename, *, items=None, time_steps=None, time=None, **kwargs) -> Datas
     return dfs.read(items=items, time_steps=time_steps, time=time, **kwargs)
 
 
-def open(filename: str):
+def open(filename: str, **kwargs):
+    """Open a dfs/mesh file
+
+    Examples
+    --------
+    >>> dfs = mikeio.open("wl.dfs1")
+    >>> dfs = mikeio.open("HD2D.dfsu")
+    >>> dfs = mikeio.open("HD2D.dfsu", dtype=np.float64)
+    """
     _, ext = os.path.splitext(filename)
 
     if ext == ".dfs0":
-        return Dfs0(filename)
+        return Dfs0(filename, **kwargs)
 
     elif ext == ".dfs1":
-        return Dfs1(filename)
+        return Dfs1(filename, **kwargs)
 
     elif ext == ".dfs2":
-        return Dfs2(filename)
+        return Dfs2(filename, **kwargs)
 
     elif ext == ".dfs3":
-        return Dfs3(filename)
+        return Dfs3(filename, **kwargs)
 
     elif ext == ".dfsu":
-        return Dfsu(filename)
+        return Dfsu(filename, **kwargs)
 
     elif ext == ".mesh":
-        return Mesh(filename)
+        return Mesh(filename, **kwargs)
 
     else:
         raise Exception(f"{ext} is an unsupported extension")

--- a/mikeio/dfs.py
+++ b/mikeio/dfs.py
@@ -20,7 +20,7 @@ class _Dfs123(TimeSeries):
 
     show_progress = False
 
-    def __init__(self, filename=None, dtype=np.float64):
+    def __init__(self, filename=None, dtype=np.float32):
         self._filename = str(filename)
         self._projstr = None
         self._start_time = None

--- a/mikeio/dfs1.py
+++ b/mikeio/dfs1.py
@@ -13,7 +13,7 @@ from .spatial.grid_geometry import Grid1D
 class Dfs1(_Dfs123):
     _ndim = 1
 
-    def __init__(self, filename=None, dtype=np.float64):
+    def __init__(self, filename=None, dtype=np.float32):
         super(Dfs1, self).__init__(filename, dtype)
 
         self._dx = None

--- a/mikeio/dfs3.py
+++ b/mikeio/dfs3.py
@@ -15,7 +15,7 @@ from .dfs import _Dfs123
 
 
 class Dfs3(_Dfs123):
-    def __init__(self, filename=None, dtype=np.float64):
+    def __init__(self, filename=None, dtype=np.float32):
         super(Dfs3, self).__init__(filename, dtype)
         if filename:
             self._read_dfs3_header()

--- a/mikeio/dfsu.py
+++ b/mikeio/dfsu.py
@@ -633,7 +633,7 @@ class _UnstructuredFile:
 
 
 class _Dfsu(_UnstructuredFile, EquidistantTimeSeries):
-    def __init__(self, filename, dfs=None, dtype=np.float64):
+    def __init__(self, filename, dfs=None, dtype=np.float32):
         """
         Create a Dfsu object
 
@@ -643,7 +643,7 @@ class _Dfsu(_UnstructuredFile, EquidistantTimeSeries):
             dfsu or mesh filename
         dfs :
         dtype: np.dtype, optional
-            default np.float64, valid options are np.float32, np.float64
+            default np.float32, valid options are np.float32, np.float64
         """
         if dtype not in [np.float32, np.float64]:
             raise ValueError("Invalid data type. Choose np.float32 or np.float64")

--- a/mikeio/generic.py
+++ b/mikeio/generic.py
@@ -603,7 +603,7 @@ def avg_time(infilename: str, outfilename: str, skipna=True):
         indata = indatatime.Data
         has_value = indata != deletevalue
         indata[~has_value] = np.nan
-        outdatalist.append(indata.astype(np.float64))
+        outdatalist.append(indata.astype(np.float32))
         step0 = np.zeros_like(indata, dtype=np.int32)
         step0[has_value] = 1
         steps_list.append(step0)

--- a/tests/test_dfsu.py
+++ b/tests/test_dfsu.py
@@ -70,13 +70,16 @@ def test_read_single_precision():
     assert ds[0].dtype == np.float32
 
 
-def test_read_double_precision_open():
+def test_read_precision_open():
     filename = "tests/testdata/HD2D.dfsu"
-    dfs = mikeio.open(filename, dtype=np.float64)
 
+    dfs = mikeio.open(filename)
     ds = dfs.read(items=1)
+    assert ds[0].dtype == np.float32
 
-    assert len(ds) == 1
+    # Double precision
+    dfs = mikeio.open(filename, dtype=np.float64)
+    ds = dfs.read(items=1)
     assert ds[0].dtype == np.float64
 
 

--- a/tests/test_dfsu.py
+++ b/tests/test_dfsu.py
@@ -70,6 +70,16 @@ def test_read_single_precision():
     assert ds[0].dtype == np.float32
 
 
+def test_read_double_precision_open():
+    filename = "tests/testdata/HD2D.dfsu"
+    dfs = mikeio.open(filename, dtype=np.float64)
+
+    ds = dfs.read(items=1)
+
+    assert len(ds) == 1
+    assert ds[0].dtype == np.float64
+
+
 def test_read_int_not_accepted():
     filename = "tests/testdata/HD2D.dfsu"
     with pytest.raises(Exception):


### PR DESCRIPTION
Data is typically stored as float32 (single precision). Change default behaviour to read without conversion to float64 unless explicitly requested.
