### PR TITLE
Grid1D and Grid2d subsetting

### DIFF
--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -795,13 +795,15 @@ class DataArray(DataUtilsMixin, TimeSeries):
     ) -> "DataArray":
 
         # TODO: delegate select in space to geometry
+        t_ax = 1 if self.dims[0][0] == "t" else 0
 
         # select in space
         if (x is not None) or (y is not None) or (z is not None):
             if isinstance(self.geometry, Grid2D):  # TODO find out better way
                 i, j = self.geometry.find_index((x, y))
-                tmp = self.isel(idx=j[0], axis=1)
-                da = tmp.isel(idx=i[0], axis=1)
+                tmp = self.isel(idx=j[0], axis=(0 + t_ax))
+                sp_axis = 0 if len(j) == 1 else 1
+                da = tmp.isel(idx=i[0], axis=(sp_axis + t_ax))
             else:
                 idx = self.geometry.find_index(x=x, y=y, z=z)
                 da = self.isel(idx, axis="space")
@@ -817,10 +819,15 @@ class DataArray(DataUtilsMixin, TimeSeries):
                 raise ValueError("'layer' can only be selected from layered Dfsu data")
 
         if "area" in kwargs:
+            area = kwargs.pop("area")
             if isinstance(da.geometry, GeometryFM):
-                area = kwargs.pop("area")
                 idx = da.geometry._elements_in_area(area)
                 da = da.isel(idx, axis="space")
+            elif isinstance(da.geometry, Grid2D):
+                ii, jj = self.geometry.find_index(area=area)
+                tmp = self.isel(idx=jj, axis=(0 + t_ax))
+                sp_axis = 0 if len(jj) == 1 else 1
+                da = tmp.isel(idx=ii, axis=(sp_axis + t_ax))
             else:
                 raise ValueError("'area' can only be selected from Dfsu data")
 

--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -369,7 +369,7 @@ class DataArray(DataUtilsMixin, TimeSeries):
                 raise ValueError(
                     f"time missing from named dimensions {dims}! (number of timesteps: {self.n_timesteps})"
                 )
-            return dims
+            return tuple(dims)
 
     @staticmethod
     def _guess_dims(ndim, shape, n_timesteps, geometry):

--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -836,7 +836,9 @@ class DataArray(DataUtilsMixin, TimeSeries):
                 sp_axis = 0 if len(jj) == 1 else 1
                 da = tmp.isel(idx=ii, axis=(sp_axis + t_ax))
             else:
-                raise ValueError("'area' can only be selected from Dfsu data")
+                raise ValueError(
+                    "'area' can only be selected from Grid2D or flexible mesh data"
+                )
 
         if len(kwargs) > 0:
             args = ",".join(kwargs)

--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -656,7 +656,7 @@ class DataArray(DataUtilsMixin, TimeSeries):
             item=self.item,
             geometry=self.geometry,
             zn=self._zn,
-            dims=dims,
+            dims=tuple(dims),
         )
 
     # ============= Select/interp ===========

--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -800,7 +800,14 @@ class DataArray(DataUtilsMixin, TimeSeries):
         # select in space
         if (x is not None) or (y is not None) or (z is not None):
             if isinstance(self.geometry, Grid2D):  # TODO find out better way
-                i, j = self.geometry.find_index((x, y))
+                xy = np.column_stack((x, y))
+                if len(xy) > 1:
+                    raise NotImplementedError(
+                        "Grid2D does not support multiple point sel()"
+                    )
+                i, j = self.geometry.find_index(xy=xy)
+                if i == -1 or j == -1:
+                    return None
                 tmp = self.isel(idx=j[0], axis=(0 + t_ax))
                 sp_axis = 0 if len(j) == 1 else 1
                 da = tmp.isel(idx=i[0], axis=(sp_axis + t_ax))

--- a/mikeio/dataset.py
+++ b/mikeio/dataset.py
@@ -811,11 +811,27 @@ class Dataset(DataUtilsMixin, TimeSeries, collections.abc.MutableMapping):
         ds.sel(area=[1., 12., 2., 15.])
         """
 
+        # TODO: delegate select in space to geometry
+        t_ax = 1 if self.dims[0][0] == "t" else 0
+
         # select in space
         if (x is not None) or (y is not None) or (z is not None):
-            # idx = self.geometry.find_nearest_elements(x=x, y=y, z=z)
-            idx = self.geometry.find_index(x=x, y=y, z=z)
-            ds = self.isel(idx, axis="space")
+            if isinstance(self.geometry, Grid2D):  # TODO find out better way
+                xy = np.column_stack((x, y))
+                if len(xy) > 1:
+                    raise NotImplementedError(
+                        "Grid2D does not support multiple point sel()"
+                    )
+                i, j = self.geometry.find_index(xy=xy)
+                if i == -1 or j == -1:
+                    return None
+                tmp = self.isel(idx=j[0], axis=(0 + t_ax))
+                sp_axis = 0 if len(j) == 1 else 1
+                ds = tmp.isel(idx=i[0], axis=(sp_axis + t_ax))
+            else:
+                # idx = self.geometry.find_nearest_elements(x=x, y=y, z=z)
+                idx = self.geometry.find_index(x=x, y=y, z=z)
+                ds = self.isel(idx, axis="space")
         else:
             ds = self
 
@@ -828,12 +844,19 @@ class Dataset(DataUtilsMixin, TimeSeries, collections.abc.MutableMapping):
                 raise ValueError("'layer' can only be selected from layered Dfsu data")
 
         if "area" in kwargs:
+            area = kwargs.pop("area")
             if isinstance(ds.geometry, GeometryFM):
-                area = kwargs.pop("area")
                 idx = ds.geometry._elements_in_area(area)
                 ds = ds.isel(idx, axis="space")
+            elif isinstance(ds.geometry, Grid2D):
+                ii, jj = self.geometry.find_index(area=area)
+                tmp = self.isel(idx=jj, axis=(0 + t_ax))
+                sp_axis = 0 if len(jj) == 1 else 1
+                ds = tmp.isel(idx=ii, axis=(sp_axis + t_ax))
             else:
-                raise ValueError("'area' can only be selected from Dfsu data")
+                raise ValueError(
+                    "'area' can only be selected from Grid2D or flexible mesh data"
+                )
 
         if len(kwargs) > 0:
             args = ",".join(kwargs)

--- a/mikeio/dfs2.py
+++ b/mikeio/dfs2.py
@@ -133,8 +133,8 @@ class Dfs2(_Dfs123):
                         dy=self._dy,
                         nx=self._nx,
                         ny=self._ny,
-                        x0=self._longitude,
-                        y0=self._latitude,
+                        x0=self._x0 + self._longitude,
+                        y0=self._y0 + self._latitude,
                         projection=self._projstr,
                     )
             else:

--- a/mikeio/dfs2.py
+++ b/mikeio/dfs2.py
@@ -202,7 +202,9 @@ class Dfs2(_Dfs123):
             Read only selected items, by number (0-based), or by name
         time: str, int or list[int], optional
             Read only selected times
-        area:
+        area: array[float], optional
+            Read only data inside (horizontal) area given as a
+            bounding box (tuple with left, lower, right, upper) coordinates
 
         Returns
         -------

--- a/mikeio/dfs2.py
+++ b/mikeio/dfs2.py
@@ -6,11 +6,14 @@ from mikecore.DfsFile import DfsSimpleType, DfsFile
 from mikecore.DfsFileFactory import DfsFileFactory
 from mikecore.DfsFactory import DfsBuilder, DfsFactory
 from mikecore.Projections import Cartography
+import pandas as pd
+from tqdm import tqdm
 
 from .dfs import _Dfs123
 from .dataset import Dataset
 from .eum import TimeStepUnit
 from .spatial.grid_geometry import Grid2D
+from .dfsutil import _valid_item_numbers, _valid_timesteps, _get_item_info
 
 
 def write_dfs2(filename: str, ds: Dataset, title="") -> None:
@@ -188,6 +191,83 @@ class Dfs2(_Dfs123):
             self._is_equidistant = False
 
         self._read_header()
+
+    def read(self, *, items=None, time=None, area=None, time_steps=None) -> Dataset:
+        """
+        Read data from a dfs2 file
+
+        Parameters
+        ---------
+        items: list[int] or list[str], optional
+            Read only selected items, by number (0-based), or by name
+        time: str, int or list[int], optional
+            Read only selected times
+        area:
+
+        Returns
+        -------
+        Dataset
+        """
+        if time_steps is not None:
+            warnings.warn(
+                FutureWarning(
+                    "time_steps have been renamed to time, and will be removed in a future release"
+                )
+            )
+            time = time_steps
+
+        self._open()
+
+        item_numbers = _valid_item_numbers(self._dfs.ItemInfo, items)
+        n_items = len(item_numbers)
+        items = _get_item_info(self._dfs.ItemInfo, item_numbers)
+
+        time_steps = _valid_timesteps(self._dfs.FileInfo, time)
+        nt = len(time_steps)
+        single_time_selected = np.isscalar(time) if time is not None else False
+
+        if area is not None:
+            take_subset = True
+            ii, jj = self.geometry.find_index(area=area)
+            shape = (nt, len(jj), len(ii))
+            geometry = self.geometry._index_to_geometry(ii, jj)
+        else:
+            take_subset = False
+            shape = (nt, self._ny, self._nx)
+            geometry = self.geometry
+
+        if single_time_selected:
+            shape = shape[1:]
+
+        data_list = [
+            np.ndarray(shape=shape, dtype=self._dtype) for item in range(n_items)
+        ]
+
+        t_seconds = np.zeros(len(time_steps))
+
+        for i, it in enumerate(tqdm(time_steps, disable=not self.show_progress)):
+            for item in range(n_items):
+
+                itemdata = self._dfs.ReadItemTimeStep(item_numbers[item] + 1, int(it))
+                d = itemdata.Data
+
+                d[d == self.deletevalue] = np.nan
+                d = d.reshape(self._ny, self._nx)
+
+                if take_subset:
+                    d = np.take(np.take(d, jj, axis=0), ii, axis=-1)
+
+                if single_time_selected:
+                    data_list[item] = d
+                else:
+                    data_list[item][i] = d
+
+            t_seconds[i] = itemdata.Time
+
+        self._dfs.Close()
+
+        time = pd.to_datetime(t_seconds, unit="s", origin=self.start_time)
+        return Dataset(data_list, time=time, items=items, geometry=geometry)
 
     def find_nearest_elements(
         self,

--- a/mikeio/spatial/FM_geometry.py
+++ b/mikeio/spatial/FM_geometry.py
@@ -978,7 +978,7 @@ class GeometryFM(_Geometry):
             x0, y0, x1, y1 = area
             xc = self._geometry2d.element_coordinates[:, 0]
             yc = self._geometry2d.element_coordinates[:, 1]
-            mask = (xc > x0) & (xc < x1) & (yc > y0) & (yc < y1)
+            mask = (xc >= x0) & (xc <= x1) & (yc >= y0) & (yc <= y1)
         elif self._area_is_polygon(area):
             polygon = np.array(area)
             xy = self._geometry2d.element_coordinates[:, :2]

--- a/mikeio/spatial/grid_geometry.py
+++ b/mikeio/spatial/grid_geometry.py
@@ -504,12 +504,7 @@ class Grid2D(_Geometry):
     def _bbox_to_index(self, bbox):
         assert len(bbox) == 4, "area most be a bounding box of coordinates"
         x0, y0, x1, y1 = bbox
-        if (
-            x0 > self.x1
-            or y0 > self.y1
-            or x1 < self.x0
-            or y1 < self.y0
-        ):
+        if x0 > self.x1 or y0 > self.y1 or x1 < self.x0 or y1 < self.y0:
             warnings.warn("No elements in bbox")
             return None, None
 
@@ -555,6 +550,15 @@ class Grid2D(_Geometry):
         else:
             nc = np.column_stack([self.x[idx] * np.ones_like(self.y), self.y])
             return Grid1D(x=self.y, projection=self.projection, node_coordinates=nc)
+
+    def _index_to_geometry(self, ii, jj):
+        di = np.diff(ii)
+        dj = np.diff(jj)
+        if (np.any(di < 1) or not np.allclose(di, di[0])) or (np.any(dj < 1) or not np.allclose(dj, dj[0])):
+            warnings.warn("Axis not equidistant! Will return GeometryUndefined()")
+            return GeometryUndefined()
+        else:
+            return Grid2D(x=self.x[ii], y=self.x[jj], projection=self.projection)
 
     def _to_element_table(self, index_base=0):
 

--- a/mikeio/spatial/grid_geometry.py
+++ b/mikeio/spatial/grid_geometry.py
@@ -554,7 +554,9 @@ class Grid2D(_Geometry):
     def _index_to_geometry(self, ii, jj):
         di = np.diff(ii)
         dj = np.diff(jj)
-        if (np.any(di < 1) or not np.allclose(di, di[0])) or (np.any(dj < 1) or not np.allclose(dj, dj[0])):
+        if (np.any(di < 1) or not np.allclose(di, di[0])) or (
+            np.any(dj < 1) or not np.allclose(dj, dj[0])
+        ):
             warnings.warn("Axis not equidistant! Will return GeometryUndefined()")
             return GeometryUndefined()
         else:

--- a/mikeio/spatial/grid_geometry.py
+++ b/mikeio/spatial/grid_geometry.py
@@ -503,29 +503,21 @@ class Grid2D(_Geometry):
 
     def _bbox_to_index(self, bbox):
         assert len(bbox) == 4, "area most be a bounding box of coordinates"
+        x0, y0, x1, y1 = bbox
         if (
-            bbox[0] > self.x1
-            or bbox[1] > self.y1
-            or bbox[2] < self.x0
-            or bbox[3] < self.y0
+            x0 > self.x1
+            or y0 > self.y1
+            or x1 < self.x0
+            or y1 < self.y0
         ):
             warnings.warn("No elements in bbox")
             return None, None
 
-        # lower left corner
-        i1 = (np.abs(self.x - bbox[0])).argmin()
-        i1 = 0 if bbox[0] < self.x0 else i1
-        j1 = (np.abs(self.y - bbox[1])).argmin()
-        j1 = 0 if bbox[1] < self.y0 else j1
+        mask = (self.x >= x0) & (self.x <= x1)
+        ii = np.where(mask)[0]
+        mask = (self.y >= y0) & (self.y <= y1)
+        jj = np.where(mask)[0]
 
-        # upper right corner
-        i2 = (np.abs(self.x - bbox[2])).argmin()
-        i2 = (self.nx - 1) if bbox[2] > self.x1 else i2
-        j2 = (np.abs(self.y - bbox[3])).argmin()
-        j2 = (self.ny - 1) if bbox[3] > self.y1 else j2
-
-        ii = list(range(i1, i2))
-        jj = list(range(j1, j2))
         return ii, jj
 
     def _xy_to_index(self, xy):

--- a/mikeio/spatial/grid_geometry.py
+++ b/mikeio/spatial/grid_geometry.py
@@ -512,9 +512,13 @@ class Grid2D(_Geometry):
     def isel(self, idx, axis):
 
         if not np.isscalar(idx):
-            x = self.x if axis == 1 else self.x[idx]
-            y = self.y if axis == 0 else self.y[idx]
-            return Grid2D(x=x, y=y, projection=self.projection)
+            d = np.diff(idx)
+            if np.any(d < 1) or not np.allclose(d, d[0]):
+                return GeometryUndefined()
+            else:
+                x = self.x if axis == 0 else self.x[idx]
+                y = self.y if axis == 1 else self.y[idx]
+                return Grid2D(x=x, y=y, projection=self.projection)
 
         if axis == 0:
             # y is first axis! if we select an element from y-axis (axis 0),

--- a/mikeio/spatial/grid_geometry.py
+++ b/mikeio/spatial/grid_geometry.py
@@ -2,13 +2,19 @@ from typing import Tuple
 import numpy as np
 from mikecore.eum import eumQuantity
 from mikecore.MeshBuilder import MeshBuilder
-from .geometry import _Geometry, GeometryUndefined, BoundingBox
+from .geometry import (
+    _Geometry,
+    GeometryPoint2D,
+    GeometryPoint3D,
+    GeometryUndefined,
+    BoundingBox,
+)
 from ..eum import EUMType, EUMUnit
 
 
 def _check_equidistant(x: np.ndarray) -> None:
     d = np.diff(x)
-    if not np.allclose(d, d[0]):
+    if len(d) > 0 and not np.allclose(d, d[0]):
         raise NotImplementedError("values must be equidistant")
 
 
@@ -22,6 +28,7 @@ class Grid1D(_Geometry):
         projection="NON-UTM",
         origin: Tuple[float, float] = (0.0, 0.0),
         orientation=0.0,
+        node_coordinates=None,
     ):
         """Create equidistant 1D spatial geometry"""
         self._projection = projection
@@ -32,20 +39,23 @@ class Grid1D(_Geometry):
         if x is not None:
             x = np.asarray(x)
             _check_equidistant(x)
-            if x[0] > x[-1]:
+            if len(x) > 1 and x[0] > x[-1]:
                 raise ValueError("x values must be increasing")
 
             self._x = x
-            self._nx = len(self._x)
+            self._dx = x[1] - x[0] if len(x) > 1 else 1.0
         else:
             if n is None:
                 raise ValueError("n must be provided")
             if dx is None:
                 raise ValueError("dx must be provided")
-            self._nx = n
             self._dx = dx
             x1 = x0 + dx * (n - 1)
             self._x = np.linspace(x0, x1, n)
+
+        if node_coordinates is not None and len(node_coordinates) != self.n:
+            raise ValueError("Length of node_coordinates must be n")
+        self._nc = node_coordinates
 
     def __repr__(self):
         out = []
@@ -100,7 +110,7 @@ class Grid1D(_Geometry):
     @property
     def n(self) -> int:
         """number of grid points"""
-        return self._nx
+        return len(self._x)
 
     @property
     def origin(self) -> Tuple[float, float]:
@@ -110,13 +120,26 @@ class Grid1D(_Geometry):
     def orientation(self) -> float:
         return self._orientation
 
-    def isel(self, idx, axis):
+    def isel(self, idx, axis=0):
 
         if not np.isscalar(idx):
-            # TODO: return reduced Grid1D
-            return GeometryUndefined()
+            nc = None if self._nc is None else self._nc[idx, :]
+            return Grid1D(
+                x=self.x[idx],
+                projection=self.projection,
+                origin=self.origin,
+                orientation=self.orientation,
+                node_coordinates=nc,
+            )
 
-        return GeometryUndefined()
+        if self._nc is None:
+            return GeometryUndefined()
+        else:
+            coords = self._nc[idx, :]
+            if len(coords) == 3:
+                return GeometryPoint3D(*coords)
+            else:
+                return GeometryPoint2D(*coords)
 
 
 class Grid2D(_Geometry):
@@ -270,6 +293,8 @@ class Grid2D(_Geometry):
         >>> g = Grid2D(x, y)
 
         """
+        # TODO: remove shape argument or issue warning
+
         self.orientation = 0.0
         self._projection = projection
         self._projstr = projection  # TODO handle other types than string
@@ -394,19 +419,19 @@ class Grid2D(_Geometry):
         _check_equidistant(x)
         _check_equidistant(y)
 
-        if x[0] > x[-1]:
+        if len(x) > 1 and x[0] > x[-1]:
             raise ValueError("x values must be increasing")
 
-        if y[0] > y[-1]:
+        if len(y) > 1 and y[0] > y[-1]:
             raise ValueError("y values must be increasing")
 
         self._x0 = x[0]
         self._nx = len(x)
-        self._dx = x[1] - x[0]
+        self._dx = x[1] - x[0] if len(x) > 1 else 1.0
 
         self._y0 = y[0]
         self._ny = len(y)
-        self._dy = y[1] - y[0]
+        self._dy = y[1] - y[0] if len(y) > 1 else 1.0
 
     def _create_from_nx_ny_dx_dy(self, x0, dx, nx, y0, dy, ny):
         if nx is None:
@@ -487,25 +512,18 @@ class Grid2D(_Geometry):
     def isel(self, idx, axis):
 
         if not np.isscalar(idx):
-            # TODO: return reduced Grid2D
-            return GeometryUndefined()
+            x = self.x if axis == 1 else self.x[idx]
+            y = self.y if axis == 0 else self.y[idx]
+            return Grid2D(x=x, y=y, projection=self.projection)
 
         if axis == 0:
             # y is first axis! if we select an element from y-axis (axis 0),
             # we return a "copy" of the x-axis
-            return Grid1D(
-                x0=self.x0,
-                dx=self.dx,
-                n=self.nx,
-                projection=self._projection,
-            )
+            nc = np.column_stack([self.x, self.y[idx] * np.ones_like(self.x)])
+            return Grid1D(x=self.x, projection=self.projection, node_coordinates=nc)
         else:
-            return Grid1D(
-                x0=self.y0,
-                dx=self.dy,
-                n=self.ny,
-                projection=self._projection,
-            )
+            nc = np.column_stack([self.x[idx] * np.ones_like(self.y), self.y])
+            return Grid1D(x=self.y, projection=self.projection, node_coordinates=nc)
 
     def _to_element_table(self, index_base=0):
 

--- a/mikeio/spatial/grid_geometry.py
+++ b/mikeio/spatial/grid_geometry.py
@@ -511,12 +511,18 @@ class Grid2D(_Geometry):
         ):
             warnings.warn("No elements in bbox")
             return None, None
-        i1, j1 = self._xy_to_index(bbox[:2])
-        i1, j1 = max(i1[0], 0), max(j1[0], 0)
 
-        i2, j2 = self._xy_to_index(bbox[2:])
-        i2 = (self.nx - 1) if i2[0] == -1 else i2[0]
-        j2 = (self.ny - 1) if j2[0] == -1 else j2[0]
+        # lower left corner
+        i1 = (np.abs(self.x - bbox[0])).argmin()
+        i1 = 0 if bbox[0] < self.x0 else i1
+        j1 = (np.abs(self.y - bbox[1])).argmin()
+        j1 = 0 if bbox[1] < self.y0 else j1
+
+        # upper right corner
+        i2 = (np.abs(self.x - bbox[2])).argmin()
+        i2 = (self.nx - 1) if bbox[2] > self.x1 else i2
+        j2 = (np.abs(self.y - bbox[3])).argmin()
+        j2 = (self.ny - 1) if bbox[3] > self.y1 else j2
 
         ii = list(range(i1, i2))
         jj = list(range(j1, j2))

--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -5,7 +5,7 @@ import pytest
 
 import mikeio
 from mikeio.eum import EUMType, ItemInfo
-from mikeio.spatial.geometry import GeometryPoint3D, GeometryUndefined
+from mikeio.spatial.geometry import GeometryPoint2D, GeometryPoint3D, GeometryUndefined
 
 
 @pytest.fixture
@@ -456,15 +456,15 @@ def test_dataarray_grid2d_repr(da_grid2d):
     assert "values" not in repr(da_grid2d)
 
     da = da_grid2d[:, -1]
-    assert "Grid1D" in repr(da)
+    assert "geometry: Grid1D" in repr(da)
     assert "values" not in repr(da)
 
     da = da_grid2d[:, -1, 0]
-    assert "geometry" not in repr(da)
+    assert "geometry: GeometryPoint2D" in repr(da)
     assert "values" in repr(da)
 
     da = da_grid2d[0, 0, 0]
-    assert "geometry" not in repr(da)
+    assert "geometry: GeometryPoint2D" in repr(da)
     assert "values" in repr(da)
 
 
@@ -484,11 +484,11 @@ def test_dataarray_grid2d_indexing(da_grid2d):
     assert isinstance(da[0, :, :].geometry, mikeio.Grid2D)
     assert isinstance(da[0, 0, :].geometry, mikeio.Grid1D)
     assert isinstance(da[:, :, 0].geometry, mikeio.Grid1D)
-    assert isinstance(da[:, -1, 0].geometry, GeometryUndefined)
+    assert isinstance(da[:, -1, 0].geometry, GeometryPoint2D)
 
     # TODO: slices in other than the time direction will give GeometryUndefined
-    assert isinstance(da[:, 2:5, 0].geometry, GeometryUndefined)
-    assert isinstance(da[:, 2:5, 0:4].geometry, GeometryUndefined)
+    assert isinstance(da[:, 2:5, 0].geometry, mikeio.Grid1D)
+    assert isinstance(da[:, 2:5, 0:4].geometry, mikeio.Grid2D)
 
 
 def test_dataarray_getitem_time(da_grid2d):

--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -603,7 +603,29 @@ def test_da_sel_layer():
     assert da3.geometry.n_elements == 3700
 
 
-def test_da_sel_area_2d():
+def test_da_sel_xy_grid2d(da_grid2d):
+    # Grid2D(x0=10.0, dx=0.1, nx=7, ny=14, dy=1.0, y0=-10.0),
+    da = da_grid2d
+    da1 = da.sel(x=10.4, y=0.0)
+    assert isinstance(da1.geometry, GeometryPoint2D)
+    assert da1.geometry.x == 10.4
+    assert da1.geometry.y == 0.0
+    assert np.all(da1.to_numpy() == da.to_numpy()[:, 10, 4])
+
+    da2 = da.sel(x=100.4, y=0.0)
+
+
+def test_da_sel_multi_xy_grid2d(da_grid2d):
+    # Grid2D(x0=10.0, dx=0.1, nx=7, ny=14, dy=1.0, y0=-10.0),
+    da = da_grid2d
+    xx = [10.3, 10.5, 10.4]
+    yy = [-1.0, 1.0, -9.0]
+    # TODO: not implemented:
+    # da1 = da.sel(x=xx, y=yy)
+    # assert da1.shape == (10, 3)
+
+
+def test_da_sel_area_dfsu2d():
     filename = "tests/testdata/FakeLake.dfsu"
     da = mikeio.read(filename, items=0)[0]
 
@@ -614,6 +636,25 @@ def test_da_sel_area_2d():
     area = (-0.1, 0.15, 0.0, 0.2)
     da1 = da.sel(area=area)
     assert da1.geometry.n_elements == 14
+
+
+def test_da_sel_area_grid2d():
+    filename = "tests/testdata/gebco_sound.dfs2"
+    da = mikeio.read(filename, items=0)[0]
+    assert da.dims == ("time", "y", "x")
+
+    bbox = [12.4, 55.2, 22.0, 55.6]
+
+    da1 = da.sel(area=bbox)
+    assert da1.geometry.nx == 168
+    assert da1.geometry.ny == 96
+
+    das = da.squeeze()
+    assert das.dims == ("y", "x")
+
+    da = das.sel(area=bbox)
+    assert da1.geometry.nx == 168
+    assert da1.geometry.ny == 96
 
 
 def test_da_sel_area_and_xy_not_ok():

--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -562,7 +562,7 @@ def test_da_isel_space_multiple_elements(da_grid2d):
     da_sel = da_grid2d.isel(slice(None, 3), axis="x")
     assert da_sel.dims == ("time", "y", "x")
     assert da_sel.shape == (10, 14, 3)
-    assert isinstance(da_sel.geometry, GeometryUndefined)
+    assert isinstance(da_sel.geometry, mikeio.Grid2D)
 
 
 def test_da_isel_space_named_axis(da_grid2d: mikeio.DataArray):

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -202,6 +202,20 @@ def test_read_temporal_subset_slice():
     assert len(ds.time) == 13
 
 
+def test_read_area_subset():
+
+    filename = r"tests/testdata/eq.dfs2"
+
+    bbox = [10, 4, 12, 7]
+    ds = mikeio.read(filename, area=bbox)
+    assert ds.shape == (25, 4, 3)
+
+    g = ds.geometry
+    assert g.ny == 4
+    assert g.nx == 3
+    assert isinstance(g, Grid2D)
+
+
 def test_read_numbered_access(dfs2_random_2items):
 
     dfs = dfs2_random_2items

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -15,6 +15,7 @@ from mikeio.custom_exceptions import (
     DataDimensionMismatch,
     ItemsError,
 )
+from mikeio.spatial.geometry import GeometryPoint2D
 from mikeio.spatial.grid_geometry import Grid2D
 
 
@@ -205,8 +206,8 @@ def test_read_temporal_subset_slice():
 def test_read_area_subset():
 
     filename = r"tests/testdata/eq.dfs2"
-
     bbox = [10, 4, 12, 7]
+
     ds = mikeio.read(filename, area=bbox)
     assert ds.shape == (25, 4, 3)
 
@@ -214,6 +215,15 @@ def test_read_area_subset():
     assert g.ny == 4
     assert g.nx == 3
     assert isinstance(g, Grid2D)
+
+    ds1 = mikeio.read(filename)
+    ds2 = ds1.sel(area=bbox)
+    assert ds2.shape == (25, 4, 3)
+    assert ds2[0].values[4, 2, 1] == ds[0].values[4, 2, 1]
+
+    da2 = ds1[0].sel(area=bbox)
+    assert da2.shape == (25, 4, 3)
+    assert da2.values[4, 2, 1] == ds[0].values[4, 2, 1]
 
 
 def test_read_numbered_access(dfs2_random_2items):
@@ -395,9 +405,21 @@ def test_write_some_time_step(tmpdir):
 
 def test_find_by_x_y():
     ds = mikeio.read("tests/testdata/gebco_sound.dfs2")
+
+    ds_point = ds.sel(x=12.74792, y=55.865)
+    assert ds_point[0].values[0] == pytest.approx(-43.0)
+    assert isinstance(ds_point.geometry, GeometryPoint2D)
+
     da = ds.Elevation
     da_point = da.sel(x=12.74792, y=55.865)
     assert da_point.values[0] == pytest.approx(-43.0)
+    assert isinstance(da_point.geometry, GeometryPoint2D)
+    assert da_point.geometry.x == ds_point.geometry.x
+
+    xx = [12.74, 12.39]
+    yy = [55.78, 54.98]
+    with pytest.raises(NotImplementedError):
+        da.sel(x=xx, y=yy)
 
 
 def test_interp_to_x_y():


### PR DESCRIPTION
* [x] Grid1D optional node_coordinates
* [x] Grid1D.isel() w multiple (equidistant) index return new Grid1D
* [x] Grid2D.isel() w multiple (equidistant) index return new Grid2D
* [x] DataArray with Grid2D: sel()/isel() methods will return PointGeometry with correct coordinate info (thanks to _nc on Grid1D)
* [x] Dfs2 read method to take area argument 
* [ ] Dfs2 read method to take j- an k- index arguments

Things to consider:

* Should we generally use the names j- and k- to refer to the first and second index following MIKE standard? 
* Should the Grid1D node coordinates be public
* polygon in area selection should crop to its bounding box and then making everything outside the polygon np.nan. In that way it would be simple to calculate statistics only over water. 
* What to do with origo and axis in 2dv dfs2 files? They are still common in MIKE3 modelling. TODO: add one as test data
* Remove origo from x0,y0 ? 
* Special class Grid2DRotated() 

![image](https://user-images.githubusercontent.com/34088801/162609067-0a52ad57-467b-4c09-a213-aa10e885ac4e.png)

![image](https://user-images.githubusercontent.com/34088801/162609241-4c0dc2db-fb1b-484e-b550-0ad3fd05b309.png)
