### PR TITLE
Fix poor performance of read of many-item-dfs0

### DIFF
--- a/tests/performance/test_performance_dfs0.py
+++ b/tests/performance/test_performance_dfs0.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from mikeio import Dfs0
 
 
-def test_simple_write_big_file(tmpdir):
+def test_write_long_dfs0(tmpdir):
 
     filename = os.path.join(tmpdir.dirname, "big.dfs0")
 
@@ -17,15 +17,10 @@ def test_simple_write_big_file(tmpdir):
     assert os.path.exists(filename)
 
 
-def test_simple_write_read_big_file(tmpdir):
+def test_read_long_dfs0(tmpdir):
 
     filename = os.path.join(tmpdir.dirname, "big.dfs0")
-
     nt = 10_000_000
-    data = [np.random.random([nt])]
-    start_time = datetime(2001, 1, 1)
-    Dfs0().write(filename=filename, data=data, start_time=start_time)
-
     assert os.path.exists(filename)
 
     dfs = Dfs0(filename=filename)
@@ -38,8 +33,8 @@ def test_write_many_items_dfs0(tmpdir):
 
     filename = os.path.join(tmpdir.dirname, "many_items.dfs0")
 
-    n_items = 800
-    nt = 1000
+    n_items = 10_000
+    nt = 200
     data = [np.random.random([nt]) for _ in range(n_items)]
     start_time = datetime(2001, 1, 1)
     Dfs0().write(filename=filename, data=data, start_time=start_time)
@@ -51,8 +46,8 @@ def test_read_many_items_dfs0(tmpdir):
 
     filename = os.path.join(tmpdir.dirname, "many_items.dfs0")
 
-    n_items = 800
-    nt = 1000
+    n_items = 10_000
+    nt = 200
     assert os.path.exists(filename)
 
     dfs = Dfs0(filename=filename)
@@ -66,7 +61,7 @@ def test_write_read_many_items_dfs0_pandas(tmpdir):
 
     filename = os.path.join(tmpdir.dirname, "even_more_items.dfs0")
 
-    n_items = 100_000  # pandas can read more...
+    n_items = 100_000  # pandas can read more then Dataset...
     nt = 20
     data = [np.random.random([nt]) for _ in range(n_items)]
     start_time = datetime(2001, 1, 1)

--- a/tests/performance/test_performance_dfs0.py
+++ b/tests/performance/test_performance_dfs0.py
@@ -1,7 +1,6 @@
 import os
 import numpy as np
-
-import pytest
+from datetime import datetime
 
 from mikeio import Dfs0
 
@@ -10,15 +9,10 @@ def test_simple_write_big_file(tmpdir):
 
     filename = os.path.join(tmpdir.dirname, "big.dfs0")
 
-    data = []
-
     nt = 10_000_000
-    d = np.random.random([nt])
-    data.append(d)
-
-    dfs = Dfs0()
-
-    dfs.write(filename=filename, data=data)
+    data = [np.random.random([nt])]
+    start_time = datetime(2001, 1, 1)
+    Dfs0().write(filename=filename, data=data, start_time=start_time)
 
     assert os.path.exists(filename)
 
@@ -27,15 +21,10 @@ def test_simple_write_read_big_file(tmpdir):
 
     filename = os.path.join(tmpdir.dirname, "big.dfs0")
 
-    data = []
-
     nt = 10_000_000
-    d = np.random.random([nt])
-    data.append(d)
-
-    dfs = Dfs0()
-
-    dfs.write(filename=filename, data=data)
+    data = [np.random.random([nt])]
+    start_time = datetime(2001, 1, 1)
+    Dfs0().write(filename=filename, data=data, start_time=start_time)
 
     assert os.path.exists(filename)
 
@@ -43,3 +32,50 @@ def test_simple_write_read_big_file(tmpdir):
     ds = dfs.read()
 
     assert len(ds.time) == nt
+
+
+def test_write_many_items_dfs0(tmpdir):
+
+    filename = os.path.join(tmpdir.dirname, "many_items.dfs0")
+
+    n_items = 800
+    nt = 1000
+    data = [np.random.random([nt]) for _ in range(n_items)]
+    start_time = datetime(2001, 1, 1)
+    Dfs0().write(filename=filename, data=data, start_time=start_time)
+
+    assert os.path.exists(filename)
+
+
+def test_read_many_items_dfs0(tmpdir):
+
+    filename = os.path.join(tmpdir.dirname, "many_items.dfs0")
+
+    n_items = 800
+    nt = 1000
+    assert os.path.exists(filename)
+
+    dfs = Dfs0(filename=filename)
+    ds = dfs.read()
+
+    assert len(ds.time) == nt
+    assert ds.n_items == n_items
+
+
+def test_write_read_many_items_dfs0_pandas(tmpdir):
+
+    filename = os.path.join(tmpdir.dirname, "even_more_items.dfs0")
+
+    n_items = 100_000  # pandas can read more...
+    nt = 20
+    data = [np.random.random([nt]) for _ in range(n_items)]
+    start_time = datetime(2001, 1, 1)
+    Dfs0().write(filename=filename, data=data, start_time=start_time)
+
+    assert os.path.exists(filename)
+
+    dfs = Dfs0(filename=filename)
+    df = dfs.to_dataframe()
+
+    assert len(df) == nt
+    assert len(df.columns) == n_items


### PR DESCRIPTION
Closes #358 

The overhead of creating DataArrays for every item seems to be too big for Dfs0s with many items (e.g. +1000 items). 