### PR TITLE
Save vertical profile from sigma only dfsu 3d

### DIFF
--- a/mikeio/spatial/FM_geometry.py
+++ b/mikeio/spatial/FM_geometry.py
@@ -1258,11 +1258,8 @@ class GeometryFM(_Geometry):
             else:
                 geom._type = self._type
                 geom._n_layers = n_layers
-                if self._type == DfsuFileType.Dfsu3DSigma:
-                    geom._n_sigma = n_layers
-                else:
-                    lowest_sigma = self.n_layers - self.n_sigma_layers + 1
-                    geom._n_sigma = sum(unique_layer_ids >= lowest_sigma)
+                lowest_sigma = self.n_layers - self.n_sigma_layers
+                geom._n_sigma = sum(unique_layer_ids >= lowest_sigma)
 
                 # If source is sigma-z but output only has sigma layers
                 # then change type accordingly

--- a/mikeio/spatial/FM_geometry.py
+++ b/mikeio/spatial/FM_geometry.py
@@ -1258,8 +1258,11 @@ class GeometryFM(_Geometry):
             else:
                 geom._type = self._type
                 geom._n_layers = n_layers
-                lowest_sigma = self.n_layers - self.n_sigma_layers + 1
-                geom._n_sigma = sum(unique_layer_ids >= lowest_sigma)
+                if self._type == DfsuFileType.Dfsu3DSigma:
+                    geom._n_sigma = n_layers
+                else:
+                    lowest_sigma = self.n_layers - self.n_sigma_layers + 1
+                    geom._n_sigma = sum(unique_layer_ids >= lowest_sigma)
 
                 # If source is sigma-z but output only has sigma layers
                 # then change type accordingly

--- a/tests/test_dfsu_layered.py
+++ b/tests/test_dfsu_layered.py
@@ -147,12 +147,22 @@ def test_read_dfsu3d_column():
 
 def test_read_dfsu3d_column_save(tmpdir):
     filename = "tests/testdata/oresund_sigma_z.dfsu"
-    outfilename = os.path.join(tmpdir, "new_column.dfsu")
     dfs = mikeio.open(filename)
 
     (x, y) = (333934.1, 6158101.5)
 
     ds = dfs.read(x=x, y=y)  # all data in file
+    assert ds.geometry.n_sigma_layers == 4
+    assert ds.geometry.n_z_layers == 0
+    outfilename = os.path.join(tmpdir, "new_column.dfsu")
+    ds.to_dfs(outfilename)
+
+    (x, y) = (347698.5188405, 6221233.34815)
+
+    ds = dfs.read(x=x, y=y)  # all data in file
+    assert ds.geometry.n_sigma_layers == 4
+    assert ds.geometry.n_z_layers == 4
+    outfilename = os.path.join(tmpdir, "new_column_2.dfsu")
     ds.to_dfs(outfilename)
 
 

--- a/tests/test_dfsu_layered.py
+++ b/tests/test_dfsu_layered.py
@@ -170,8 +170,12 @@ def test_read_dfsu3d_columns_sigma_only():
 
 def test_read_dfsu3d_columns_sigma_only_save(tmpdir):
     dfs = mikeio.open("tests/testdata/basin_3d.dfsu")
-    outfilename = os.path.join(tmpdir, "new_column.dfsu")
+    assert dfs.geometry.n_sigma_layers == 10
+    assert dfs.geometry.n_z_layers == 0
     dscol = dfs.read(x=500, y=50)
+    assert dscol.geometry.n_sigma_layers == 10
+    assert dscol.geometry.n_z_layers == 0
+    outfilename = os.path.join(tmpdir, "new_column.dfsu")
     dscol.to_dfs(outfilename)
 
 

--- a/tests/test_dfsu_layered.py
+++ b/tests/test_dfsu_layered.py
@@ -145,6 +145,17 @@ def test_read_dfsu3d_column():
     assert dscol2._zn.shape == (ds.n_timesteps, 5 * 3)
 
 
+def test_read_dfsu3d_column_save(tmpdir):
+    filename = "tests/testdata/oresund_sigma_z.dfsu"
+    outfilename = os.path.join(tmpdir, "new_column.dfsu")
+    dfs = mikeio.open(filename)
+
+    (x, y) = (333934.1, 6158101.5)
+
+    ds = dfs.read(x=x, y=y)  # all data in file
+    ds.to_dfs(outfilename)
+
+
 def test_read_dfsu3d_columns_sigma_only():
     dfs = mikeio.open("tests/testdata/basin_3d.dfsu")
     dscol = dfs.read(x=500, y=50)
@@ -155,6 +166,13 @@ def test_read_dfsu3d_columns_sigma_only():
 
     dscol2 = dfs.read().sel(x=500, y=50)
     assert dscol.shape == dscol2.shape
+
+
+def test_read_dfsu3d_columns_sigma_only_save(tmpdir):
+    dfs = mikeio.open("tests/testdata/basin_3d.dfsu")
+    outfilename = os.path.join(tmpdir, "new_column.dfsu")
+    dscol = dfs.read(x=500, y=50)
+    dscol.to_dfs(outfilename)
 
 
 def test_read_dfsu3d_xyz():


### PR DESCRIPTION
Right after releasing v 1.0.2 I found another problem with profiles extracted from DfsuSigma files where number of sigma layers where incorrect and prevented saving them as a new Dfsu file.
![image](https://user-images.githubusercontent.com/614215/175378148-0d61620b-9e31-4178-bcdf-92aa4a2f84e9.png)
