### PR TITLE
dfsu3d to_mesh fix

### DIFF
--- a/mikeio/spatial/FM_geometry.py
+++ b/mikeio/spatial/FM_geometry.py
@@ -1388,16 +1388,24 @@ class GeometryFM(_Geometry):
         return mp
 
     def to_mesh(self, outfilename):
-
+        """Export geometry to new mesh file
+        
+        Parameters
+        ----------
+        outfilename : str
+            path to file to be written
+        """
         builder = MeshBuilder()
 
-        nc = self.node_coordinates
-        builder.SetNodes(nc[:, 0], nc[:, 1], nc[:, 2], self.codes)
-        # builder.SetNodeIds(self.node_ids+1)
-        # builder.SetElementIds(self.elements+1)
-        element_table_MZ = [np.asarray(row) + 1 for row in self.element_table]
+        geom2d = self._geometry2d
+
+        nc = geom2d.node_coordinates
+        builder.SetNodes(nc[:, 0], nc[:, 1], nc[:, 2], geom2d.codes)
+        # builder.SetNodeIds(geom2d.node_ids+1)
+        # builder.SetElementIds(geom2d.elements+1)
+        element_table_MZ = [np.asarray(row) + 1 for row in geom2d.element_table]
         builder.SetElements(element_table_MZ)
-        builder.SetProjection(self.projection_string)
+        builder.SetProjection(geom2d.projection_string)
         quantity = eumQuantity.Create(EUMType.Bathymetry, EUMUnit.meter)
         builder.SetEumQuantity(quantity)
         newMesh = builder.CreateMesh()

--- a/mikeio/spatial/FM_geometry.py
+++ b/mikeio/spatial/FM_geometry.py
@@ -1389,7 +1389,7 @@ class GeometryFM(_Geometry):
 
     def to_mesh(self, outfilename):
         """Export geometry to new mesh file
-        
+
         Parameters
         ----------
         outfilename : str

--- a/tests/test_dfsu_layered.py
+++ b/tests/test_dfsu_layered.py
@@ -522,15 +522,15 @@ def test_to_mesh_3d(tmpdir):
 
     dfs = mikeio.open(filename)
 
-    outfilename = os.path.join(tmpdir, "oresund.mesh")
-
+    outfilename = os.path.join(tmpdir, "oresund_from_dfs.mesh")
     dfs.to_mesh(outfilename)
-
     assert os.path.exists(outfilename)
-
     mesh = Mesh(outfilename)
 
-    assert True
+    outfilename = os.path.join(tmpdir, "oresund_from_geometry.mesh")
+    dfs.geometry.to_mesh(outfilename)
+    assert os.path.exists(outfilename)
+    mesh = Mesh(outfilename)
 
 
 def test_extract_surface_elevation_from_3d(tmpdir):


### PR DESCRIPTION
It was previously not possible to write a 3d GeometryFM object to a new mesh file. This PR fixes this. Thanks to @lezhongwen for pointing this out in https://github.com/DHI/mikeio/discussions/391. 