### PR TITLE
DataArray/Dataset ptp (range)

### DIFF
--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -1750,6 +1750,21 @@ class DataArray(DataUtilsMixin, TimeSeries):
         """
         return self.aggregate(axis=axis, func=np.std, **kwargs)
 
+    def ptp(self, axis="time", **kwargs) -> "DataArray":
+        """Range (max - min) a.k.a Peak to Peak along an axis
+
+        Parameters
+        ----------
+        axis: (int, str, None), optional
+            axis number or "time" or "space", by default "time"=0
+
+        Returns
+        -------
+        DataArray
+            array with peak to peak values
+        """
+        return self.aggregate(axis=axis, func=np.ptp, **kwargs)        
+
     def average(self, weights, axis="time", **kwargs) -> "DataArray":
         """Compute the weighted average along the specified axis.
 

--- a/mikeio/dataset.py
+++ b/mikeio/dataset.py
@@ -1545,6 +1545,20 @@ class Dataset(DataUtilsMixin, TimeSeries, collections.abc.MutableMapping):
         """
         return self.aggregate(axis=axis, func=np.std, **kwargs)
 
+    def ptp(self, axis="time", **kwargs) -> "Dataset":
+        """Range (max - min) a.k.a Peak to Peak along an axis
+        Parameters
+        ----------
+        axis: (int, str, None), optional
+            axis number or "time" or "space", by default "time"=0
+
+        Returns
+        -------
+        DataArray
+            array with peak to peak values
+        """
+        return self.aggregate(axis=axis, func=np.ptp, **kwargs) 
+
     def average(self, weights, axis="time", **kwargs) -> "Dataset":
         """Compute the weighted average along the specified axis.
 

--- a/mikeio/dataset.py
+++ b/mikeio/dataset.py
@@ -1554,8 +1554,8 @@ class Dataset(DataUtilsMixin, TimeSeries, collections.abc.MutableMapping):
 
         Returns
         -------
-        DataArray
-            array with peak to peak values
+        Dataset
+            dataset with peak to peak values
         """
         return self.aggregate(axis=axis, func=np.ptp, **kwargs) 
 

--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -1010,6 +1010,13 @@ def test_daarray_aggregation():
     assert len(da_std.time) == 1
     assert pytest.approx(da_std.values[0]) == 0.015291579
 
+    da_ptp = da.ptp(name="peak to peak (max - min)")
+    assert isinstance(da_std, mikeio.DataArray)
+    assert da_ptp.geometry == da.geometry
+    assert da_ptp.start_time == da.start_time
+    assert len(da_ptp.time) == 1
+    assert pytest.approx(da_ptp.values[0]) == 0.0529321208596229
+
 
 def test_daarray_aggregation_nan_versions():
 


### PR DESCRIPTION
Range (max - min) is an intuitive measure of dispersion, but since range already has a different meaning in python and NumPy, Numpy uses the name [ptp](https://numpy.org/doc/stable/reference/generated/numpy.ptp.html) instead which is now available as a method on the DataArray and Dataset classes.

Below is a illustration of range vs standard deviation (another popular measure of dispersion)
![image](https://user-images.githubusercontent.com/614215/183092572-8f60aede-5ffe-4710-8810-1f29e1906971.png)
