### PR TITLE
Pfs allow repeated keywords

### DIFF
--- a/mikeio/pfs.py
+++ b/mikeio/pfs.py
@@ -172,21 +172,6 @@ def parse_yaml_preserving_duplicates(src, unique_keywords=True):
     class PreserveDuplicatesLoader(yaml.loader.Loader):
         pass
 
-    # DOES NOT ALLOW DUPLICATES:
-    # def map_constructor_duplicates(loader, node, deep=False):
-    #     keys = [loader.construct_object(node, deep=deep) for node, _ in node.value]
-    #     vals = [loader.construct_object(node, deep=deep) for _, node in node.value]
-    #     key_count = Counter(keys)
-    #     data = {}
-    #     for key, val in zip(keys, vals):
-    #         if key_count[key] > 1:
-    #             if key not in data:
-    #                 data[key] = []
-    #             data[key].append(val)
-    #         else:
-    #             data[key] = val
-    #     return data
-
     def map_constructor_duplicates(loader, node, deep=False):
         keys = [loader.construct_object(node, deep=deep) for node, _ in node.value]
         vals = [loader.construct_object(node, deep=deep) for _, node in node.value]

--- a/mikeio/pfs.py
+++ b/mikeio/pfs.py
@@ -219,6 +219,7 @@ def parse_yaml_preserving_duplicates(src, unique_keywords=True):
                     data[key].append(val)
                 else:
                     warnings.warn(f"Keyword {key} defined multiple times. Value: {val}")
+                    data[key] = val
             else:
                 data[key] = val
         return data
@@ -230,7 +231,7 @@ def parse_yaml_preserving_duplicates(src, unique_keywords=True):
     )
     PreserveDuplicatesLoader.add_constructor(
         yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-        map_constructor_duplicate_sections,
+        constructor=constructor,
     )
     return yaml.load(src, PreserveDuplicatesLoader)
 

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -375,6 +375,34 @@ def test_non_unique_keywords():
     assert len(pfs.BoundaryExtractor.POINT_1) == 2
     assert isinstance(pfs.BoundaryExtractor.POINT_1[1], mikeio.PfsSection)
 
+    # last value will be kept
+    assert pfs.BoundaryExtractor.z_min == 19
+
+
+def test_non_unique_keywords_allowed():
+    fn = "tests/testdata/pfs/nonunique.pfs"
+    pfs = mikeio.Pfs(fn, unique_keywords=False)
+
+    assert len(pfs.BoundaryExtractor.POINT_1) == 2
+    assert isinstance(pfs.BoundaryExtractor.POINT_1[1], mikeio.PfsSection)
+
+    assert len(pfs.BoundaryExtractor.z_min) == 3
+    assert pfs.BoundaryExtractor.z_min == [-3000, 9, 19]
+
+
+def test_non_unique_keywords_read_write(tmpdir):
+    fn1 = "tests/testdata/pfs/nonunique.pfs"
+    pfs1 = mikeio.Pfs(fn1, unique_keywords=False)
+
+    fn2 = os.path.join(tmpdir.dirname, "nonunique_out.pfs")
+    pfs1.write(fn2)
+
+    pfs2 = mikeio.Pfs(fn2, unique_keywords=False)
+
+    d1 = pfs1.BoundaryExtractor.to_dict()
+    d2 = pfs2.BoundaryExtractor.to_dict()
+    assert d1 == d2
+
 
 def test_illegal_pfs():
     fn = "tests/testdata/pfs/illegal.pfs"

--- a/tests/testdata/pfs/nonunique.pfs
+++ b/tests/testdata/pfs/nonunique.pfs
@@ -12,6 +12,7 @@
   npoints_horizontal = 20
   npoints_vertical = 300
   fill = false
+  fill_list = false, 0
 
   [POINT_1]
     x = -12


### PR DESCRIPTION
Allow the user to select whether he/she wants to allow repeated keywords in the same PfsSection by introducing a new argument in read_pfs() `unique_keywords` by default True. Relevant for MIKE Zero Plot Composer where `unique_keywords` should be set to False. Closes #434 

Fixes also bug with repeated keywords when unique_keywords=True (as it was before). 