### PR TITLE
dataset concatenation single timestep

### DIFF
--- a/mikeio/dataset.py
+++ b/mikeio/dataset.py
@@ -1243,9 +1243,9 @@ class Dataset(DataUtilsMixin, TimeSeries, collections.abc.MutableMapping):
 
     def _concat_time(self, other, copy=True) -> "Dataset":
         self._check_all_items_match(other)
-        if not np.all(self.shape[1:] == other.shape[1:]):
+        if not np.all(self.shape[1:] == other.shape[1:]): # CHECK DOES NOT WORK FOR SINGLE TIMESTEPS AS TIME DIM IS DROPPED
             raise ValueError("Shape of the datasets must match (except time dimension)")
-        if "time" not in self.dims:
+        if "time" not in self.dims: # DIM CHECK DOES NOT WORK. USE ATTRIBUTE CHECK INSTEAD?
             raise ValueError(
                 "Datasets cannot be concatenated as they have no time axis!"
             )

--- a/mikeio/dataset.py
+++ b/mikeio/dataset.py
@@ -1245,10 +1245,12 @@ class Dataset(DataUtilsMixin, TimeSeries, collections.abc.MutableMapping):
         self._check_all_items_match(other)
         # assuming time is always first dimension we can skip / keep it by bool
         start_dim = int("time" in self.dims)
-        if not np.all(self.shape[start_dim:] == other.shape[int("time" in other.dims):]):  
-        #if not np.all(self.shape[1:] == other.shape[1:]):  
+        if not np.all(
+            self.shape[start_dim:] == other.shape[int("time" in other.dims) :]
+        ):
+            # if not np.all(self.shape[1:] == other.shape[1:]):
             raise ValueError("Shape of the datasets must match (except time dimension)")
-        if hasattr(self, "time"): # using attribute instead of dim checking. Works
+        if hasattr(self, "time"):  # using attribute instead of dim checking. Works
             ds = self.copy() if copy else self
         else:
             raise ValueError(
@@ -1266,7 +1268,7 @@ class Dataset(DataUtilsMixin, TimeSeries, collections.abc.MutableMapping):
         idx1 = np.where(~df12["idx1"].isna())
         idx2 = np.where(~df12["idx2"].isna())
         for j in range(ds.n_items):
-        #    # if there is an overlap "other" data will be used!
+            #    # if there is an overlap "other" data will be used!
             newdata[j][idx1] = ds[j].to_numpy()
             newdata[j][idx2] = other[j].to_numpy()
 

--- a/mikeio/dataset.py
+++ b/mikeio/dataset.py
@@ -1274,7 +1274,7 @@ class Dataset(DataUtilsMixin, TimeSeries, collections.abc.MutableMapping):
 
         zn = None
         if self._zn is not None:
-            zshape = (len(newtime), self._zn.shape[1])
+            zshape = (len(newtime), self._zn.shape[start_dim])
             zn = np.zeros(shape=zshape, dtype=self._zn.dtype)
             zn[idx1, :] = self._zn
             zn[idx2, :] = other._zn

--- a/mikeio/dataset.py
+++ b/mikeio/dataset.py
@@ -1243,12 +1243,15 @@ class Dataset(DataUtilsMixin, TimeSeries, collections.abc.MutableMapping):
 
     def _concat_time(self, other, copy=True) -> "Dataset":
         self._check_all_items_match(other)
-        if not np.all(self.shape[1:] == other.shape[1:]): # CHECK DOES NOT WORK FOR SINGLE TIMESTEPS AS TIME DIM IS DROPPED
+        if not np.all(self.shape[1:] == other.shape[1:]):  # CHECK DOES NOT WORK FOR SINGLE TIMESTEPS AS TIME DIM IS DROPPED
             raise ValueError("Shape of the datasets must match (except time dimension)")
-        if "time" not in self.dims: # DIM CHECK DOES NOT WORK. USE ATTRIBUTE CHECK INSTEAD?
+        if hasattr(self, "time"): # using attribute instead of dim checking. Works
+            ds = self.copy() if copy else self
+        else:
             raise ValueError(
-                "Datasets cannot be concatenated as they have no time axis!"
+                "Datasets cannot be concatenated as they have no time attribute!"
             )
+
         ds = self.copy() if copy else self
 
         s1 = pd.Series(np.arange(len(ds.time)), index=ds.time, name="idx1")

--- a/mikeio/generic.py
+++ b/mikeio/generic.py
@@ -326,9 +326,9 @@ def concat(infilenames: List[str], outfilename: str, keep="last") -> None:
     The list of input files have to be sorted, i.e. in chronological order
     """
 
-    dfs_i_a = DfsFileFactory.DfsGenericOpen(infilenames[0])
+    dfs_i_a = DfsFileFactory.DfsGenericOpen(str(infilenames[0]))
 
-    dfs_o = _clone(infilenames[0], outfilename)
+    dfs_o = _clone(str(infilenames[0]), str(outfilename))
 
     n_items = len(dfs_i_a.ItemInfo)
     dfs_i_a.Close()
@@ -337,7 +337,7 @@ def concat(infilenames: List[str], outfilename: str, keep="last") -> None:
 
     for i, infilename in enumerate(tqdm(infilenames, disable=not show_progress)):
 
-        dfs_i = DfsFileFactory.DfsGenericOpen(infilename)
+        dfs_i = DfsFileFactory.DfsGenericOpen(str(infilename))
         t_axis = dfs_i.FileInfo.TimeAxis
         n_time_steps = t_axis.NumberOfTimeSteps
         dt = t_axis.TimeStep
@@ -353,7 +353,7 @@ def concat(infilenames: List[str], outfilename: str, keep="last") -> None:
         if keep == "last":
 
             if i < (len(infilenames) - 1):
-                dfs_n = DfsFileFactory.DfsGenericOpen(infilenames[i + 1])
+                dfs_n = DfsFileFactory.DfsGenericOpen(str(infilenames[i + 1]))
                 nf = dfs_n.FileInfo.TimeAxis.StartDateTime
                 next_start_time = datetime(
                     nf.year, nf.month, nf.day, nf.hour, nf.minute, nf.second
@@ -455,7 +455,7 @@ def extract(
     >>> extract('f_in.dfsu', 'f_out.dfsu', items="Salinity")
     >>> extract('f_in.dfsu', 'f_out.dfsu', end='2018-2-1 00:00', items="Salinity")
     """
-    dfs_i = DfsFileFactory.DfsGenericOpenEdit(infilename)
+    dfs_i = DfsFileFactory.DfsGenericOpenEdit(str(infilename))
 
     is_layered_dfsu = dfs_i.ItemInfo[0].Name == "Z coordinate"
 
@@ -472,8 +472,8 @@ def extract(
         item_numbers.insert(0, 0)
 
     dfs_o = _clone(
-        infilename,
-        outfilename,
+        str(infilename),
+        str(outfilename),
         start_time=file_start_new,
         timestep=timestep,
         items=item_numbers,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1260,7 +1260,7 @@ def test_concat_dataarray_by_time():
 
 def test_concat_by_time():
     ds1 = mikeio.read("tests/testdata/tide1.dfs1")
-    ds2 = mikeio.read("tests/testdata/tide2.dfs1") + 0.5  # add offset
+    ds2 = mikeio.read("tests/testdata/tide2.dfs1", time=0) + 0.5  # add offset
     ds3 = mikeio.Dataset.concat([ds1, ds2])
 
     assert isinstance(ds3, mikeio.Dataset)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1260,7 +1260,7 @@ def test_concat_dataarray_by_time():
 
 def test_concat_by_time():
     ds1 = mikeio.read("tests/testdata/tide1.dfs1")
-    ds2 = mikeio.read("tests/testdata/tide2.dfs1", time=0) + 0.5  # add offset
+    ds2 = mikeio.read("tests/testdata/tide2.dfs1") + 0.5  # add offset
     ds3 = mikeio.Dataset.concat([ds1, ds2])
 
     assert isinstance(ds3, mikeio.Dataset)
@@ -1298,7 +1298,7 @@ def test_concat_by_time_inconsistent_shape_not_possible():
 # TODO: implement this
 def test_concat_by_time_no_time():
     ds1 = mikeio.read("tests/testdata/tide1.dfs1", time=0)
-    ds2 = mikeio.read("tests/testdata/tide2.dfs1", time=1)
+    ds2 = mikeio.read("tests/testdata/tide2.dfs1", time=1) 
     with pytest.raises(ValueError, match="no time axis"):
         mikeio.Dataset.concat([ds1, ds2])
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1298,9 +1298,10 @@ def test_concat_by_time_inconsistent_shape_not_possible():
 # TODO: implement this
 def test_concat_by_time_no_time():
     ds1 = mikeio.read("tests/testdata/tide1.dfs1", time=0)
-    ds2 = mikeio.read("tests/testdata/tide2.dfs1", time=1) 
-    with pytest.raises(ValueError, match="no time axis"):
-        mikeio.Dataset.concat([ds1, ds2])
+    ds2 = mikeio.read("tests/testdata/tide2.dfs1", time=1)
+    ds3 = mikeio.Dataset.concat([ds1, ds2])
+
+    assert ds3.n_timesteps == 2
 
 
 def test_concat_by_time_2():

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1409,6 +1409,18 @@ def test_concat_dfsu3d():
     assert np.all(ds3._zn == ds._zn)
 
 
+def test_concat_dfsu3d_single_timesteps():
+    filename = "tests/testdata/basin_3d.dfsu"
+    ds = mikeio.read(filename)
+    ds1 = mikeio.read(filename, time=0)
+    ds2 = mikeio.read(filename, time=2)
+    ds3 = mikeio.Dataset.concat([ds1, ds2])
+
+    assert ds1.n_items == ds2.n_items == ds3.n_items
+    assert ds3.start_time == ds.start_time
+    assert ds3.end_time == ds.end_time
+
+
 def test_merge_same_name_error():
     filename = "tests/testdata/HD2D.dfsu"
     ds1 = mikeio.read(filename, items=0)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1417,8 +1417,21 @@ def test_concat_dfsu3d_single_timesteps():
     ds3 = mikeio.Dataset.concat([ds1, ds2])
 
     assert ds1.n_items == ds2.n_items == ds3.n_items
-    assert ds3.start_time == ds.start_time
-    assert ds3.end_time == ds.end_time
+    assert ds3.start_time == ds1.start_time
+    assert ds3.end_time == ds2.end_time
+
+
+def test_concat_dfs2_single_timesteps():
+    filename = "tests/testdata/single_row.dfs2"
+    ds = mikeio.read(filename)
+    ds1 = mikeio.read(filename, time=0)
+    ds2 = mikeio.read(filename, time=2)
+    ds3 = mikeio.Dataset.concat([ds1, ds2])
+
+    assert ds1.n_items == ds2.n_items == ds3.n_items
+    assert ds3.start_time == ds1.start_time
+    assert ds3.end_time == ds2.end_time
+    assert ds3.n_timesteps == 2
 
 
 def test_merge_same_name_error():


### PR DESCRIPTION
modified dataset test to concatenate file with single timestep. When concantenating will result in error in shape check as well as dims check as time dimension is dropped for single timestep datasets and not available for checking.
