### PR TITLE
Pfs take first of repeated keywords

### DIFF
--- a/mikeio/pfs.py
+++ b/mikeio/pfs.py
@@ -203,8 +203,11 @@ def parse_yaml_preserving_duplicates(src, unique_keywords=True):
                         data[key] = []
                     data[key].append(val)
                 else:
-                    warnings.warn(f"Keyword {key} defined multiple times. Value: {val}")
-                    data[key] = val
+                    warnings.warn(
+                        f"Keyword {key} defined multiple times (first will be used). Value: {val}"
+                    )
+                    if key not in data:
+                        data[key] = val
             else:
                 data[key] = val
         return data

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -375,8 +375,8 @@ def test_non_unique_keywords():
     assert len(pfs.BoundaryExtractor.POINT_1) == 2
     assert isinstance(pfs.BoundaryExtractor.POINT_1[1], mikeio.PfsSection)
 
-    # last value will be kept
-    assert pfs.BoundaryExtractor.z_min == 19
+    # first value will be kept (like MIKE FM)
+    assert pfs.BoundaryExtractor.z_min == -3000
 
 
 def test_non_unique_keywords_allowed():


### PR DESCRIPTION
MIKE FM does not use repeated keywords. If the same keyword is defined in a section, the first one will be read. MIKE IO should have the same behaviour.