### PR TITLE
Make scipy optional

### DIFF
--- a/mikeio/dfsu_layered.py
+++ b/mikeio/dfsu_layered.py
@@ -3,7 +3,6 @@ import pandas as pd
 import warnings
 from tqdm import trange
 from functools import wraps
-from scipy.spatial import cKDTree
 
 from mikecore.DfsuFile import DfsuFile, DfsuFileType
 from .dfsu import _Dfsu
@@ -391,6 +390,9 @@ class Dfsu3D(DfsuLayered):
         --------
         >>> dfsu.extract_surface_elevation_from_3d('ex_surf.dfsu')
         """
+
+        from scipy.spatial import cKDTree
+       
         # validate input
         assert (
             self._type == DfsuFileType.Dfsu3DSigma

--- a/mikeio/spatial/FM_geometry.py
+++ b/mikeio/spatial/FM_geometry.py
@@ -2,7 +2,6 @@ from typing import Sequence, Union
 import warnings
 import numpy as np
 from collections import namedtuple
-from scipy.spatial import cKDTree
 from mikecore.DfsuFile import DfsuFileType
 from mikecore.eum import eumQuantity
 from mikecore.MeshBuilder import MeshBuilder
@@ -669,6 +668,8 @@ class GeometryFM(_Geometry):
         return interp2d(data, elem_ids, weights, shape)
 
     def _create_tree2d(self):
+        from scipy.spatial import cKDTree
+        
         xy = self._geometry2d.element_coordinates[:, :2]
         self._tree2d = cKDTree(xy)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setuptools.setup(
         "mikecore>=0.2.1",
         "numpy>=1.15.0",  # first version with numpy.quantile
         "pandas>1.3",
-        "scipy>1.0",
         "PyYAML",
         "tqdm",
         "xarray",
@@ -29,7 +28,7 @@ setuptools.setup(
             "matplotlib",
             "jupyterlab",
         ],
-        "test": ["pytest", "matplotlib!=3.5.0", "xarray"],
+        "test": ["pytest", "matplotlib!=3.5.0", "xarray", "scipy>1.0"],
         "notebooks": [
             "nbformat",
             "nbconvert",


### PR DESCRIPTION
Scipy is currently the largest dependancy of MIKE IO (in MB) and is *only* used for:
* Interpolation in time
* Search trees

Thus, I suggest to make it optional similar to how xarray stays slim and uses [optional dependencies](https://docs.xarray.dev/en/stable/getting-started-guide/installing.html#optional-dependencies).


$ pip install mikeio

Downloading mikeio-1.2.1-py3-none-any.whl (196 kB)
Downloading mikecore-0.2.1-py3-none-any.whl (17.1 MB)
Downloading numpy-1.23.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.1 MB)
Downloading PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (682 kB)
Downloading xarray-2022.10.0-py3-none-any.whl (947 kB)
Downloading scipy-1.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (**33.7 MB**)
Downloading tqdm-4.64.1-py2.py3-none-any.whl (78 kB)
Downloading pandas-1.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.1 MB)
...