### PR TITLE
fix a bug in reading and writing pfs with duplicate keywords

### DIFF
--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -326,7 +326,7 @@ def test_pfssection_to_dataframe():
 def test_hd_outputs():
 
     with pytest.warns(match="defined multiple times"):
-        pfs = mikeio.Pfs("tests/testdata/pfs/lake.m21fm")
+        pfs = mikeio.Pfs("tests/testdata/pfs/lake.m21fm", unique_keywords=False)
     df = pfs.HD.OUTPUTS.to_dataframe()
 
     assert df["file_name"][2] == "ts.dfs0"

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -324,7 +324,6 @@ def test_pfssection_to_dataframe():
 
 
 def test_hd_outputs():
-
     pfs = mikeio.Pfs("tests/testdata/pfs/lake.m21fm", unique_keywords=False)
     df = pfs.HD.OUTPUTS.to_dataframe()
 

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -325,8 +325,7 @@ def test_pfssection_to_dataframe():
 
 def test_hd_outputs():
 
-    with pytest.warns(match="defined multiple times"):
-        pfs = mikeio.Pfs("tests/testdata/pfs/lake.m21fm", unique_keywords=False)
+    pfs = mikeio.Pfs("tests/testdata/pfs/lake.m21fm", unique_keywords=False)
     df = pfs.HD.OUTPUTS.to_dataframe()
 
     assert df["file_name"][2] == "ts.dfs0"

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -114,9 +114,11 @@ def test_pfssection_copy(d1):
     assert sct3.key1 == 3
     assert sct1.key1 == 2
 
+
 def test_pfssection_len(d1):
     sct = mikeio.PfsSection(d1)
     assert len(sct) == 5
+
 
 def test_pfssection_contains(d1):
     sct = mikeio.PfsSection(d1)
@@ -579,3 +581,14 @@ EndSect  // DERIVED_VARIABLE_106
                     line.strip()
                     == "description = 'alfa_PC_T, ''light'' adjusted alfa_PC, ugC/gC*m2/uE'"
                 )
+
+
+def test_read_write_repeated_keyword_pfs(tmpdir):
+    pfs = mikeio.Pfs("tests/testdata/pfs/lake.m21fm", unique_keywords=False)
+    filename = os.path.join(tmpdir, "lake_out.m21fm")
+    pfs.write(filename)
+    pfs = mikeio.Pfs(filename, unique_keywords=False)
+    assert pfs.data.DOMAIN.BOUNDARY_NAMES[1].Touched == [0, "new"]
+    assert isinstance(pfs.data.DOMAIN.BOUNDARY_NAMES[1], mikeio.PfsSection)
+    assert isinstance(pfs.data.DOMAIN.BOUNDARY_NAMES, list)
+    assert isinstance(pfs.data.DOMAIN.BOUNDARY_NAMES[1].Touched, list)

--- a/tests/testdata/pfs/lake.m21fm
+++ b/tests/testdata/pfs/lake.m21fm
@@ -30,6 +30,7 @@
       minimum_layer_thickness_zlevel = 0.0
       type_of_mesh = 0
       type_of_gauss = 3
+      BOUNDARY_NAMES = 'something'
       [BOUNDARY_NAMES]
          Touched = 0
          MzSEPfsListItemCount = 1
@@ -37,7 +38,7 @@
             Touched = 0
             name = 'Code 2'
          EndSect  // CODE_2
-
+         Touched = 'new'
       EndSect  // BOUNDARY_NAMES
 
    EndSect  // DOMAIN


### PR DESCRIPTION
There was a case that there was two keywords that one only had a value and the second one was a PfsSection. In this situation the read pfs function reads the second occurrence as a dictionary and it writes back to file as dictionary again. That is been fixed here. 



