### PR TITLE
Create 1d dataset with default grid

### DIFF
--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -813,7 +813,7 @@ class DataArray(DataUtilsMixin, TimeSeries):
         if len(dims) > 1 and (
             geometry is None or isinstance(geometry, GeometryUndefined)
         ):
-            if len(dims) == 2:
+            if dims == ("time","x"):
                 return Grid1D(nx=shape[1], dx=1.0/(shape[1]-1))
             
             warnings.warn("Geometry is required for ndim >=1")

--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -813,7 +813,9 @@ class DataArray(DataUtilsMixin, TimeSeries):
         if len(dims) > 1 and (
             geometry is None or isinstance(geometry, GeometryUndefined)
         ):
-            # raise ValueError("Geometry is required for ndim >=1")
+            if len(dims) == 2:
+                return Grid1D(nx=shape[1], dx=1.0/(shape[1]-1))
+            
             warnings.warn("Geometry is required for ndim >=1")
 
         axis = 1 if "time" in dims else 0

--- a/mikeio/interpolation.py
+++ b/mikeio/interpolation.py
@@ -1,5 +1,5 @@
 import numpy as np
-from mikeio.eum import ItemInfo
+from .spatial.geometry import GeometryUndefined
 
 
 # class Interpolation2D:
@@ -88,7 +88,9 @@ def interp2d(data, elem_ids, weights=None, shape=None):
                     )
                 if shape:
                     idatitem = idatitem.reshape((nt, *shape))
-            interp_data_vars[key] = DataArray(data=idatitem, time=da.time, item=da.item)
+            
+            dims = ("time","element") # TODO is this the best?
+            interp_data_vars[key] = DataArray(data=idatitem, time=da.time, dims=dims, item=da.item, geometry=GeometryUndefined())
 
         new_ds = Dataset(interp_data_vars, validate=False)
         return new_ds

--- a/mikeio/spatial/grid_geometry.py
+++ b/mikeio/spatial/grid_geometry.py
@@ -54,6 +54,15 @@ def _print_axis_txt(name, x, dx) -> str:
 class Grid1D(_Geometry):
     """1D grid (node-based)
     axis is increasing and equidistant
+
+    Examples
+    --------
+    >>> mikeio.Grid1D(nx=3,dx=0.1)
+    <mikeio.Grid1D>
+    x: [0, 0.1, 0.2] (nx=3, dx=0.1)
+    >>> mikeio.Grid1D(x=[0.1, 0.5, 0.9])
+    <mikeio.Grid1D>
+    x: [0.1, 0.5, 0.9] (nx=3, dx=0.4)
     """
 
     _dx: float

--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -172,6 +172,16 @@ def test_data_0d(da0):
     assert "geometry" not in repr(da0)
 
 
+def test_create_data_1d_default_grid():
+    
+    da = mikeio.DataArray(
+            data=np.zeros((10, 5)),
+            time=pd.date_range(start="2000-01-01", freq="H", periods=10),
+            item=ItemInfo("Foo"),
+        )
+    assert isinstance(da.geometry, mikeio.Grid1D)
+
+
 def test_data_2d_no_geometry_not_allowed():
 
     nt = 10

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -29,10 +29,10 @@ def test_interp2d():
 
     elem_ids, weights = dfs.geometry.get_2d_interpolant(xy, n_nearest=1)
 
-    with pytest.warns(match="Geometry"):
-        dati = interp2d(ds, elem_ids, weights)
+    # with pytest.warns(match="Geometry"):
+    dati = interp2d(ds, elem_ids, weights)
     assert isinstance(dati, Dataset)
-    assert isinstance(dati.geometry, GeometryUndefined)  # TODO LineString?
+    assert isinstance(dati.geometry, GeometryUndefined)  # There is no suitable file format for this, thus no suitable geometry :-(
     assert np.all(dati.shape == (ds.n_timesteps, npts))
     assert dati[0].values[0, 0] == 8.262675285339355
 


### PR DESCRIPTION
The spatial information in a Dfs1 file is rarely used.

Thus it makes sense when creating a DataArray with dimensions (time,x) it defaults to a Grid1D where $x \in [0,1]$ 