### PR TITLE
Read corrupt dfs files

### DIFF
--- a/mikeio/__init__.py
+++ b/mikeio/__init__.py
@@ -71,6 +71,11 @@ def read(filename, *, items=None, time=None, keepdims=False, **kwargs) -> Datase
     layers: int, str or sequence, optional
         Dfs3/Dfsu-layered: read only data from specific layers,
         by default None (=all layers)
+    error_bad_data: bool, optional
+            raise error if data is corrupt, by default True,
+    fill_bad_data_value:
+            fill value for to impute corrupt data, used in conjunction with error_bad_data=False
+            default np.nan
 
     Returns
     -------
@@ -103,6 +108,8 @@ def read(filename, *, items=None, time=None, keepdims=False, **kwargs) -> Datase
     >>> ds = mikeio.read("MT3D_sigma_z.dfsu", elements=lst_of_elems)
     >>> ds = mikeio.read("MT3D_sigma_z.dfsu", layers="bottom")
     >>> ds = mikeio.read("MT3D_sigma_z.dfsu", layers=[-2,-1])
+    >>> ds = mikeio.read("HD2D.dfsu", error_bad_data=False) # replace corrupt data with np.nan
+    >>> ds = mikeio.read("HD2D.dfsu", error_bad_data=False, fill_bad_data_value=0.0) # replace corrupt data with 0.0
     """
 
     ext = os.path.splitext(filename)[1].lower()

--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -1627,7 +1627,7 @@ class DataArray(DataUtilsMixin, TimeSeries):
             zn=zn,
         )
 
-    def interp_na(self, axis="time", **kwargs):
+    def interp_na(self, axis="time", **kwargs) -> "DataArray":
         """Fill in NaNs by interpolating according to different methods.
 
         Wrapper of :py:meth:`xarray.DataArray.interpolate_na`"""

--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -1627,6 +1627,15 @@ class DataArray(DataUtilsMixin, TimeSeries):
             zn=zn,
         )
 
+    def interp_na(self, axis="time", **kwargs):
+        """Fill in NaNs by interpolating according to different methods.
+
+        Wrapper of :py:meth:`xarray.DataArray.interpolate_na`"""
+
+        xr_da = self.to_xarray().interpolate_na(dim=axis, **kwargs)
+        self.values = xr_da.values
+        return self
+
     def interp_like(
         self,
         other: Union["DataArray", Grid2D, GeometryFM, pd.DatetimeIndex],

--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -813,9 +813,9 @@ class DataArray(DataUtilsMixin, TimeSeries):
         if len(dims) > 1 and (
             geometry is None or isinstance(geometry, GeometryUndefined)
         ):
-            if dims == ("time","x"):
-                return Grid1D(nx=shape[1], dx=1.0/(shape[1]-1))
-            
+            if dims == ("time", "x"):
+                return Grid1D(nx=shape[1], dx=1.0 / (shape[1] - 1))
+
             warnings.warn("Geometry is required for ndim >=1")
 
         axis = 1 if "time" in dims else 0
@@ -1490,7 +1490,9 @@ class DataArray(DataUtilsMixin, TimeSeries):
             if isinstance(self.geometry, Grid2D):  # TODO DIY bilinear interpolation
                 xr_da = self.to_xarray()
                 dai = xr_da.interp(x=x, y=y).values
-                geometry = GeometryPoint2D(x=x, y=y, projection=self.geometry.projection)
+                geometry = GeometryPoint2D(
+                    x=x, y=y, projection=self.geometry.projection
+                )
             elif isinstance(self.geometry, Grid1D):
                 if interpolant is None:
                     interpolant = self.geometry.get_spatial_interpolant(coords)
@@ -1503,9 +1505,13 @@ class DataArray(DataUtilsMixin, TimeSeries):
                     )
                 dai = self.geometry.interp2d(self, *interpolant).flatten()
                 if z is None:
-                    geometry = GeometryPoint2D(x=x, y=y, projection=self.geometry.projection)
+                    geometry = GeometryPoint2D(
+                        x=x, y=y, projection=self.geometry.projection
+                    )
                 else:
-                    geometry = GeometryPoint3D(x=x, y=y, z=z, projection=self.geometry.projection)
+                    geometry = GeometryPoint3D(
+                        x=x, y=y, z=z, projection=self.geometry.projection
+                    )
 
             da = DataArray(
                 data=dai, time=self.time, geometry=geometry, item=deepcopy(self.item)

--- a/mikeio/dataarray.py
+++ b/mikeio/dataarray.py
@@ -1630,7 +1630,26 @@ class DataArray(DataUtilsMixin, TimeSeries):
     def interp_na(self, axis="time", **kwargs) -> "DataArray":
         """Fill in NaNs by interpolating according to different methods.
 
-        Wrapper of :py:meth:`xarray.DataArray.interpolate_na`"""
+        Wrapper of :py:meth:`xarray.DataArray.interpolate_na`
+        
+        Examples
+        --------
+
+        >>> time = pd.date_range("2000", periods=3, freq="D")
+        >>> da = mikeio.DataArray(data=np.array([0.0, np.nan, 2.0]), time=time)
+        >>> da
+        <mikeio.DataArray>
+        name: NoName
+        dims: (time:3)
+        time: 2000-01-01 00:00:00 - 2000-01-03 00:00:00 (3 records)
+        values: [0, nan, 2]
+        >>> da.interp_na()
+        <mikeio.DataArray>
+        name: NoName
+        dims: (time:3)
+        time: 2000-01-01 00:00:00 - 2000-01-03 00:00:00 (3 records)
+        values: [0, 1, 2]
+        """
 
         xr_da = self.to_xarray().interpolate_na(dim=axis, **kwargs)
         self.values = xr_da.values

--- a/mikeio/dataset.py
+++ b/mikeio/dataset.py
@@ -36,7 +36,7 @@ class _DatasetPlotter:
         else:
             raise ValueError(
                 "Could not plot Dataset. Try plotting one of its DataArrays instead..."
-            )        
+            )
 
     @staticmethod
     def _get_fig_ax(ax=None, figsize=None):
@@ -1151,6 +1151,13 @@ class Dataset(DataUtilsMixin, TimeSeries, collections.abc.MutableMapping):
             geometry=self.geometry,
             zn=zn,
         )
+
+    def interp_na(self, axis="time", **kwargs) -> "Dataset":
+        ds = self.copy()
+        for da in ds:
+            da.values = da.interp_na(axis=axis, **kwargs).values
+
+        return ds
 
     def interp_like(
         self,

--- a/mikeio/dfsu.py
+++ b/mikeio/dfsu.py
@@ -815,7 +815,7 @@ class _Dfsu(_UnstructuredFile, EquidistantTimeSeries):
                 dfs, d = _read_item_time_step(
                     dfs=dfs,
                     filename=self._filename,
-                    time=time,
+                    time=self.time,
                     item_numbers=item_numbers,
                     deletevalue=deletevalue,
                     shape=shape,

--- a/mikeio/dfsu.py
+++ b/mikeio/dfsu.py
@@ -808,8 +808,6 @@ class _Dfsu(_UnstructuredFile, EquidistantTimeSeries):
             data = np.ndarray(shape=shape, dtype=dtype)
             data_list.append(data)
 
-        t_seconds = np.zeros(n_steps, dtype=float)
-
         for i in trange(n_steps, disable=not self.show_progress):
             it = time_steps[i]
             for item in range(n_items):
@@ -835,9 +833,6 @@ class _Dfsu(_UnstructuredFile, EquidistantTimeSeries):
                 else:
                     data_list[item][i] = d
 
-            # t_seconds[i] = itemdata.Time
-
-        # time = pd.to_datetime(t_seconds, unit="s", origin=self.start_time)
         time = self.time[time_steps]
 
         dfs.Close()

--- a/mikeio/dfsu.py
+++ b/mikeio/dfsu.py
@@ -803,8 +803,15 @@ class _Dfsu(_UnstructuredFile, EquidistantTimeSeries):
             for item in range(n_items):
 
                 itemdata = dfs.ReadItemTimeStep(item_numbers[item] + 1, it)
-                d = itemdata.Data
-                d[d == deletevalue] = np.nan
+                if itemdata is not None:
+                    d = itemdata.Data
+                    d[d == deletevalue] = np.nan
+                else:
+                    print(f"Error reading: {self.time[it]}")
+                    d = np.zeros(shape[1])
+                    d[:] = np.nan
+                    dfs.Close()
+                    dfs = DfsuFile.Open(self._filename)
 
                 if elements is not None:
                     d = d[elements]
@@ -814,9 +821,10 @@ class _Dfsu(_UnstructuredFile, EquidistantTimeSeries):
                 else:
                     data_list[item][i] = d
 
-            t_seconds[i] = itemdata.Time
+            #t_seconds[i] = itemdata.Time
 
-        time = pd.to_datetime(t_seconds, unit="s", origin=self.start_time)
+        #time = pd.to_datetime(t_seconds, unit="s", origin=self.start_time)
+        time = self.time[time_steps]
 
         dfs.Close()
 

--- a/mikeio/dfsu.py
+++ b/mikeio/dfsu.py
@@ -808,6 +808,8 @@ class _Dfsu(_UnstructuredFile, EquidistantTimeSeries):
             data = np.ndarray(shape=shape, dtype=dtype)
             data_list.append(data)
 
+        time = self.time
+
         for i in trange(n_steps, disable=not self.show_progress):
             it = time_steps[i]
             for item in range(n_items):
@@ -815,7 +817,7 @@ class _Dfsu(_UnstructuredFile, EquidistantTimeSeries):
                 dfs, d = _read_item_time_step(
                     dfs=dfs,
                     filename=self._filename,
-                    time=self.time,
+                    time=time,
                     item_numbers=item_numbers,
                     deletevalue=deletevalue,
                     shape=shape,

--- a/mikeio/dfsu_layered.py
+++ b/mikeio/dfsu_layered.py
@@ -232,7 +232,7 @@ class DfsuLayered(_Dfsu):
                 dfs, d = _read_item_time_step(
                     dfs=dfs,
                     filename=self._filename,
-                    time=time,
+                    time=self.time,
                     item_numbers=item_numbers,
                     deletevalue=deletevalue,
                     shape=(data.shape[-1],),

--- a/mikeio/dfsu_layered.py
+++ b/mikeio/dfsu_layered.py
@@ -225,6 +225,8 @@ class DfsuLayered(_Dfsu):
         if single_time_selected and not keepdims:
             data = data[0]
 
+        time=self.time
+
         for i in trange(n_steps, disable=not self.show_progress):
             it = time_steps[i]
             for item in range(n_items):
@@ -232,7 +234,7 @@ class DfsuLayered(_Dfsu):
                 dfs, d = _read_item_time_step(
                     dfs=dfs,
                     filename=self._filename,
-                    time=self.time,
+                    time=time,
                     item_numbers=item_numbers,
                     deletevalue=deletevalue,
                     shape=(data.shape[-1],),

--- a/mikeio/dfsu_layered.py
+++ b/mikeio/dfsu_layered.py
@@ -222,8 +222,6 @@ class DfsuLayered(_Dfsu):
                 data = np.ndarray(shape=(n_steps, n_elems), dtype=dtype)
             data_list.append(data)
 
-        t_seconds = np.zeros(n_steps, dtype=float)
-
         if single_time_selected and not keepdims:
             data = data[0]
 
@@ -255,9 +253,6 @@ class DfsuLayered(_Dfsu):
                 else:
                     data_list[item][i] = d
 
-            # t_seconds[i] = itemdata.Time
-
-        # time = pd.to_datetime(t_seconds, unit="s", origin=self.start_time)
         time = self.time[time_steps]
 
         dfs.Close()

--- a/mikeio/dfsutil.py
+++ b/mikeio/dfsutil.py
@@ -8,11 +8,43 @@ from .custom_exceptions import ItemsError
 from mikecore.DfsFile import DfsDynamicItemInfo, DfsFileInfo
 
 
-def _fuzzy_item_search(*,dfsItemInfo: List[DfsDynamicItemInfo], search: str, start_idx:int=0):
+def _read_item_time_step(*,
+    dfs,
+    filename,
+    time,
+    item_numbers,
+    deletevalue,
+    shape,
+    item,
+    it,
+    error_bad_data=True,
+    fill_bad_data_value=np.nan,
+):
+    itemdata = dfs.ReadItemTimeStep(item_numbers[item] + 1, it)
+    if itemdata is not None:
+        d = itemdata.Data
+        d[d == deletevalue] = np.nan
+    else:
+        if error_bad_data:
+            raise ValueError(f"Error reading: {time[it]}")
+        else:
+            warnings.warn(f"Error reading: {time[it]}")
+            d = np.zeros(shape[1])
+            d[:] = fill_bad_data_value
+            dfs.Close()
+            dfs = DfsuFile.Open(filename)
+    return dfs, d
+
+
+def _fuzzy_item_search(
+    *, dfsItemInfo: List[DfsDynamicItemInfo], search: str, start_idx: int = 0
+):
     import fnmatch
 
     names = [info.Name for info in dfsItemInfo]
-    item_numbers = [i-start_idx for i, name in enumerate(names) if fnmatch.fnmatch(name, search)]
+    item_numbers = [
+        i - start_idx for i, name in enumerate(names) if fnmatch.fnmatch(name, search)
+    ]
     if len(item_numbers) == 0:
         raise KeyError(f"No items like: {search} found. Valid names are {names}")
     return item_numbers
@@ -30,7 +62,9 @@ def _valid_item_numbers(
 
     if np.isscalar(items):
         if isinstance(items, str) and "*" in items:
-            return _fuzzy_item_search(dfsItemInfo=dfsItemInfo, search=items, start_idx=start_idx)
+            return _fuzzy_item_search(
+                dfsItemInfo=dfsItemInfo, search=items, start_idx=start_idx
+            )
         else:
             items = [items]
 

--- a/mikeio/dfsutil.py
+++ b/mikeio/dfsutil.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import warnings
 from typing import Iterable, List, Tuple, Union
 import numpy as np
 import pandas as pd
@@ -6,9 +7,11 @@ from .eum import EUMType, EUMUnit, ItemInfo, TimeAxisType, ItemInfoList
 from .custom_exceptions import ItemsError
 
 from mikecore.DfsFile import DfsDynamicItemInfo, DfsFileInfo
+from mikecore.DfsFileFactory import DfsFileFactory
 
 
-def _read_item_time_step(*,
+def _read_item_time_step(
+    *,
     dfs,
     filename,
     time,
@@ -32,7 +35,7 @@ def _read_item_time_step(*,
             d = np.zeros(shape[1])
             d[:] = fill_bad_data_value
             dfs.Close()
-            dfs = DfsuFile.Open(filename)
+            dfs = DfsFileFactory.DfsGenericOpen(filename)
     return dfs, d
 
 

--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -173,12 +173,12 @@ def test_data_0d(da0):
 
 
 def test_create_data_1d_default_grid():
-    
+
     da = mikeio.DataArray(
-            data=np.zeros((10, 5)),
-            time=pd.date_range(start="2000-01-01", freq="H", periods=10),
-            item=ItemInfo("Foo"),
-        )
+        data=np.zeros((10, 5)),
+        time=pd.date_range(start="2000-01-01", freq="H", periods=10),
+        item=ItemInfo("Foo"),
+    )
     assert isinstance(da.geometry, mikeio.Grid1D)
 
 
@@ -1198,3 +1198,20 @@ def test_time_selection():
     with pytest.raises(IndexError):
         # not in time
         ds.sel(time="1997-09-15 00:00")
+
+
+def test_interp_na():
+    time = pd.date_range("2000", periods=5, freq="D")
+    da = mikeio.DataArray(
+        data=np.array([np.nan, 1.0, np.nan, np.nan, 4.0]),
+        time=time,
+        item=ItemInfo(name="Foo"),
+    )
+
+    dai = da.interp_na()
+    assert np.isnan(dai.to_numpy()[0])
+    assert dai.to_numpy()[2] == pytest.approx(2.0)
+
+    dai = da.interp_na(fill_value="extrapolate")
+    assert dai.to_numpy()[0] == pytest.approx(0.0)
+    assert dai.to_numpy()[2] == pytest.approx(2.0)

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -5,7 +5,7 @@ import pandas as pd
 import mikeio
 from mikeio import Dfsu
 from mikeio import generic
-from mikeio.generic import scale, diff, sum, extract, avg_time
+from mikeio.generic import scale, diff, sum, extract, avg_time, fill_corrupt
 import pytest
 
 
@@ -586,3 +586,15 @@ def test_dfs_ext_capitalisation(tmpdir):
     filename = os.path.join("tests", "testdata", "oresund_vertical_slice2.DFSU")
     ds = mikeio.open(filename)
     assert True
+
+
+def test_fill_corrupt_data(tmpdir):
+    """This test doesn't verify much..."""
+
+    infile = "tests/testdata/waves.dfs2"
+    outfile = os.path.join(tmpdir.dirname, "waves_subset.dfs2")
+
+    fill_corrupt(infilename=infile, outfilename=outfile)
+    orig = mikeio.read(infile)
+    extracted = mikeio.read(outfile)
+    assert extracted.n_timesteps == orig.n_timesteps

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -591,13 +591,11 @@ def test_dfs_ext_capitalisation(tmpdir):
 def test_fill_corrupt_data(tmpdir):
     """This test doesn't verify much..."""
 
-    # infile = "tests/testdata/waves.dfs2"
-    infile = "F:/2d.dfsu"
+    infile = "tests/testdata/waves.dfs2"
 
-    # outfile = os.path.join(tmpdir.dirname, "waves_subset.dfs2")
-    outfile = "F:/2d_testing.dfsu"
+    outfile = os.path.join(tmpdir.dirname, "waves_subset.dfs2")
 
-    fill_corrupt(infilename=infile, outfilename=outfile, items=[4, 5])
+    fill_corrupt(infilename=infile, outfilename=outfile, items=[1])
     orig = mikeio.read(infile)
     extracted = mikeio.read(outfile)
     assert extracted.n_timesteps == orig.n_timesteps

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -591,10 +591,13 @@ def test_dfs_ext_capitalisation(tmpdir):
 def test_fill_corrupt_data(tmpdir):
     """This test doesn't verify much..."""
 
-    infile = "tests/testdata/waves.dfs2"
-    outfile = os.path.join(tmpdir.dirname, "waves_subset.dfs2")
+    # infile = "tests/testdata/waves.dfs2"
+    infile = "F:/2d.dfsu"
 
-    fill_corrupt(infilename=infile, outfilename=outfile)
+    # outfile = os.path.join(tmpdir.dirname, "waves_subset.dfs2")
+    outfile = "F:/2d_testing.dfsu"
+
+    fill_corrupt(infilename=infile, outfilename=outfile, items=[4, 5])
     orig = mikeio.read(infile)
     extracted = mikeio.read(outfile)
     assert extracted.n_timesteps == orig.n_timesteps


### PR DESCRIPTION
Reading a corrupt timestep apparently messes up some internals.

A possible solution could be to close the dfs object and re-open it.

Not sure how to QA this PR☹️ But at least it should it not break any existing functionality.