### PR TITLE
Fix aggregate with no time axis

### DIFF
--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -1041,6 +1041,14 @@ def test_daarray_aggregation():
     assert pytest.approx(da_ptp.values[0]) == 0.0529321208596229
 
 
+def test_daarray_aggregation_no_time():
+    filename = "tests/testdata/HD2D.dfsu"
+    ds = mikeio.read(filename, items=[3], time=-1)
+    da = ds["Current speed"]
+    assert da.dims == ("element",) 
+
+    assert da.max().values == pytest.approax(1.6463733)
+
 def test_daarray_aggregation_nan_versions():
 
     # TODO find better file, e.g. with flood/dry

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -770,6 +770,15 @@ def test_aggregation_workflows(tmpdir):
     assert os.path.isfile(outfilename)
 
 
+def test_aggregation_dataset_no_time():
+    filename = "tests/testdata/HD2D.dfsu"
+    dfs = mikeio.open(filename)
+    ds = dfs.read(time=-1, items=["Surface elevation", "Current speed"])
+    
+    ds2 = ds.max()
+    assert ds2["Current speed"].values == pytest.approax(1.6463733)
+
+
 def test_aggregations():
     filename = "tests/testdata/gebco_sound.dfs2"
     ds = mikeio.read(filename)


### PR DESCRIPTION
Dataset/DataArray aggregation methods such as .mean() does not work if the DataArray has no time axis. 