### PR TITLE
Add alias for _Dfsu

### DIFF
--- a/mikeio/__init__.py
+++ b/mikeio/__init__.py
@@ -19,8 +19,8 @@ from platform import architecture
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
 
-__version__ = "1.4.dev0"
-__dfs_version__: int = 140
+__version__ = "1.3.1"
+__dfs_version__: int = 130
 
 
 if "64" not in architecture()[0]:

--- a/mikeio/dfsu/__init__.py
+++ b/mikeio/dfsu/__init__.py
@@ -1,2 +1,6 @@
 from .dfsu import Mesh, _write_dfsu
 from .factory import Dfsu
+
+# Alias for fmskill
+from .dfsu import Dfsu2DH
+_Dfsu = Dfsu2DH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name="mikeio"
-version="1.4.dev0"
+version="1.3.1"
 dependencies = [
     "mikecore>=0.2.1",
     "numpy>=1.15.0",  # first version with numpy.quantile


### PR DESCRIPTION
`FMskill` uses _Dfsu which was removed in v 1.3

This PR adds a new _Dfsu alias in order to avoid errors here:
https://github.com/DHI/fmskill/blob/64a831cc814b0a4074aa9213de69fd7744d11dc0/fmskill/model/dfs.py#L48