### PR TITLE
Read items by name fix

### DIFF
--- a/mikeio/dfs.py
+++ b/mikeio/dfs.py
@@ -5,6 +5,7 @@ from typing import Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
+from copy import deepcopy
 from mikecore.DfsFactory import DfsFactory
 from mikecore.DfsFile import (
     DfsDynamicItemInfo,
@@ -76,6 +77,8 @@ def _valid_item_numbers(
     n_items_file = len(dfsItemInfo) - start_idx
     if items is None:
         return list(range(n_items_file))
+
+    items = deepcopy(items)
 
     if np.isscalar(items):
         if isinstance(items, str) and "*" in items:

--- a/tests/test_dfs0.py
+++ b/tests/test_dfs0.py
@@ -428,10 +428,12 @@ def test_read_dfs0_single_item_read_by_name():
 
     dfs0file = r"tests/testdata/random.dfs0"
 
+    items = ["NotFun", "VarFun01"]
     dfs = Dfs0(dfs0file)
-    res = dfs.read(["NotFun", "VarFun01"])  # reversed order compare to original file
+    res = dfs.read(items=items)  # reversed order compare to original file
     data = res.to_numpy()
 
+    assert items == ["NotFun", "VarFun01"]
     assert len(data) == 2
     assert res.items[0].name == "NotFun"
     assert res.items[0].type == EUMType.Water_Level


### PR DESCRIPTION
I get the to me unexpected behavior:
After reading items by name
```
items = ["NotFun", "VarFun01"]
dfs = Dfs0(dfs0file)
dfs.read(items=items) 
```
`items` is no longer equal `["NotFun", "VarFun01"]`