### PR TITLE
Well Known Text for Points

### DIFF
--- a/mikeio/spatial/geometry.py
+++ b/mikeio/spatial/geometry.py
@@ -4,8 +4,9 @@ from collections import namedtuple
 
 BoundingBox = namedtuple("BoundingBox", ["left", "bottom", "right", "top"])
 
+
 class _Geometry(ABC):
-    def __init__(self, projection:str = "NON-UTM") -> None:
+    def __init__(self, projection: str = "NON-UTM") -> None:
         self._projstr = projection
 
     @property
@@ -34,7 +35,6 @@ class _Geometry(ABC):
         pass
 
 
-
 class GeometryUndefined:
     def __repr__(self):
         return "GeometryUndefined()"
@@ -46,12 +46,25 @@ class GeometryPoint2D(_Geometry):
         self.x = x
         self.y = y
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"GeometryPoint2D(x={self.x}, y={self.y})"
 
+    def __str__(self) -> str:
+        return self.wkt
+
     @property
-    def ndim(self):
+    def wkt(self) -> str:
+        return f"POINT ({self.x} {self.y})"
+
+    @property
+    def ndim(self) -> int:
+        """Geometry dimension"""
         return 0
+
+    def to_shapely(self):
+        from shapely.geometry import Point
+
+        return Point(self.x, self.y)
 
 
 class GeometryPoint3D(_Geometry):
@@ -65,6 +78,18 @@ class GeometryPoint3D(_Geometry):
     def __repr__(self):
         return f"GeometryPoint3D(x={self.x}, y={self.y}, z={self.z})"
 
+    def __str__(self) -> str:
+        return self.wkt
+
     @property
-    def ndim(self):
+    def wkt(self) -> str:
+        return f"POINT Z ({self.x} {self.y} {self.z})"
+
+    @property
+    def ndim(self) -> int:
         return 0
+
+    def to_shapely(self):
+        from shapely.geometry import Point
+
+        return Point(self.x, self.y, self.z)

--- a/mikeio/spatial/geometry.py
+++ b/mikeio/spatial/geometry.py
@@ -49,8 +49,9 @@ class GeometryPoint2D(_Geometry):
     def __repr__(self) -> str:
         return f"GeometryPoint2D(x={self.x}, y={self.y})"
 
-    def __str__(self) -> str:
-        return self.wkt
+    # TODO should we use wkt here
+    # def __str__(self) -> str:
+    #    return self.wkt
 
     @property
     def wkt(self) -> str:
@@ -77,9 +78,6 @@ class GeometryPoint3D(_Geometry):
 
     def __repr__(self):
         return f"GeometryPoint3D(x={self.x}, y={self.y}, z={self.z})"
-
-    def __str__(self) -> str:
-        return self.wkt
 
     @property
     def wkt(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = ["pytest",
        "netcdf4",
        "matplotlib"]
 
-test = ["pytest", "pytest-cov", "matplotlib!=3.5.0", "xarray","mypy"]
+test = ["pytest", "pytest-cov", "matplotlib!=3.5.0", "xarray","mypy","shapely"]
 
 notebooks= [
             "nbformat",

--- a/tests/spatial/test_point.py
+++ b/tests/spatial/test_point.py
@@ -6,7 +6,6 @@ from mikeio.spatial.geometry import GeometryPoint2D, GeometryPoint3D
 def test_point2d_wkt():
     p = GeometryPoint2D(10, 20)
     assert p.wkt == "POINT (10 20)"
-    assert str(p) == "POINT (10 20)"
 
     p = GeometryPoint2D(x=-5642.5, y=120.1)
     assert p.wkt == "POINT (-5642.5 120.1)"
@@ -15,8 +14,6 @@ def test_point2d_wkt():
 def test_point3d_wkt():
     p = GeometryPoint3D(10, 20, 30)
     assert p.wkt == "POINT Z (10 20 30)"
-
-    assert str(p) == "POINT Z (10 20 30)"
 
 
 def test_point2d_to_shapely():

--- a/tests/spatial/test_point.py
+++ b/tests/spatial/test_point.py
@@ -1,0 +1,36 @@
+from mikeio.spatial.geometry import GeometryPoint2D, GeometryPoint3D
+
+# https://www.ogc.org/standard/sfa/
+
+
+def test_point2d_wkt():
+    p = GeometryPoint2D(10, 20)
+    assert p.wkt == "POINT (10 20)"
+    assert str(p) == "POINT (10 20)"
+
+    p = GeometryPoint2D(x=-5642.5, y=120.1)
+    assert p.wkt == "POINT (-5642.5 120.1)"
+
+
+def test_point3d_wkt():
+    p = GeometryPoint3D(10, 20, 30)
+    assert p.wkt == "POINT Z (10 20 30)"
+
+    assert str(p) == "POINT Z (10 20 30)"
+
+
+def test_point2d_to_shapely():
+    p = GeometryPoint2D(10, 20)
+    sp = p.to_shapely()
+    assert sp.x == 10
+    assert sp.y == 20
+    assert sp.wkt == p.wkt
+
+
+def test_point3d_to_shapely():
+    p = GeometryPoint3D(10, 20, -1)
+    sp = p.to_shapely()
+    assert sp.x == 10
+    assert sp.y == 20
+    assert sp.z == -1
+    assert sp.wkt == p.wkt


### PR DESCRIPTION
https://www.ogc.org/standard/sfa/

The Shapely library is the Python wrapper for the GEOS library, which is a standard in geospatial analysis.

At this point we don't want to depend upon the shapely library (and it's dependencies), but if the user has it installed, we can easily convert mikeio points to shapely points.