### PR TITLE
Dtype dfs3 read

### DIFF
--- a/mikeio/dfs/_dfs2.py
+++ b/mikeio/dfs/_dfs2.py
@@ -200,7 +200,8 @@ class Dfs2(_Dfs123):
         area: array[float], optional
             Read only data inside (horizontal) area given as a
             bounding box (tuple with left, lower, right, upper) coordinates
-
+        dtype: class, optional
+            Define the dtype of the returned dataset (default = np.float32)
         Returns
         -------
         Dataset

--- a/mikeio/dfs/_dfs2.py
+++ b/mikeio/dfs/_dfs2.py
@@ -200,7 +200,7 @@ class Dfs2(_Dfs123):
         area: array[float], optional
             Read only data inside (horizontal) area given as a
             bounding box (tuple with left, lower, right, upper) coordinates
-        dtype: class, optional
+        dtype: data-type, optional
             Define the dtype of the returned dataset (default = np.float32)
         Returns
         -------

--- a/mikeio/dfs/_dfs3.py
+++ b/mikeio/dfs/_dfs3.py
@@ -188,6 +188,7 @@ class Dfs3(_Dfs123):
         area=None,
         layers=None,
         keepdims=False,
+        dtype=np.float32,
     ) -> Dataset:
         """
         Read data from a dfs3 file
@@ -204,6 +205,8 @@ class Dfs3(_Dfs123):
             in the returned Dataset? by default: False
         layers: int, str, list[int], optional
             Read only data for specific layers, by default None
+        dtype: class, optional
+            Define the dtype of the returned dataset (default = np.float32)
 
         Returns
         -------
@@ -250,7 +253,7 @@ class Dfs3(_Dfs123):
             shape = (nt, nz, yNum, xNum)
 
         for item in range(n_items):
-            data = np.ndarray(shape=shape, dtype=float)
+            data = np.ndarray(shape=shape, dtype=dtype)
             data_list.append(data)
 
         if single_time_selected and not keepdims:

--- a/mikeio/dfs/_dfs3.py
+++ b/mikeio/dfs/_dfs3.py
@@ -205,7 +205,7 @@ class Dfs3(_Dfs123):
             in the returned Dataset? by default: False
         layers: int, str, list[int], optional
             Read only data for specific layers, by default None
-        dtype: class, optional
+        dtype: data-type, optional
             Define the dtype of the returned dataset (default = np.float32)
 
         Returns

--- a/tests/test_dfs3.py
+++ b/tests/test_dfs3.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import numpy as np
 
 import mikeio
 from mikeio.spatial import GeometryUndefined
@@ -46,6 +47,12 @@ def test_dfs3_read():
     assert da.shape == (30, 10, 10, 10)  # t  # z  # y  # x
     assert da.dims == ("time", "z", "y", "x")
     assert da.name == "Item 1"
+    assert da.to_numpy().dtype == np.float32
+
+
+def test_dfs3_read_double_precision():
+    ds = mikeio.read("tests/testdata/Grid1.dfs3", dtype=np.float64)
+    assert ds[0].to_numpy().dtype == np.float64
 
 
 def test_dfs3_read_time():


### PR DESCRIPTION
Allow specification of dtype for Dfs3.read() (as implemented in Dfs2.read() )
As described in #558 