### PR TITLE
Validate projection string

### DIFF
--- a/mikeio/spatial/_geometry.py
+++ b/mikeio/spatial/_geometry.py
@@ -10,7 +10,8 @@ BoundingBox = namedtuple("BoundingBox", ["left", "bottom", "right", "top"])
 class _Geometry(ABC):
     def __init__(self, projection=None) -> None:
 
-        if not MapProjection.IsValid(projection):
+        # TODO should projection be a mandatory argument?
+        if projection and not MapProjection.IsValid(projection):
             raise ValueError(f"{projection=} is not a valid projection string")
 
         self._projstr = projection if projection else "LONG/LAT"

--- a/mikeio/spatial/_geometry.py
+++ b/mikeio/spatial/_geometry.py
@@ -2,11 +2,17 @@ from abc import ABC, abstractmethod
 
 from collections import namedtuple
 
+from mikecore.Projections import MapProjection
+
 BoundingBox = namedtuple("BoundingBox", ["left", "bottom", "right", "top"])
 
 
 class _Geometry(ABC):
     def __init__(self, projection=None) -> None:
+
+        if not MapProjection.IsValid(projection):
+            raise ValueError(f"{projection=} is not a valid projection string")
+
         self._projstr = projection if projection else "LONG/LAT"
 
     @property

--- a/tests/test_geometry_grid.py
+++ b/tests/test_geometry_grid.py
@@ -426,3 +426,9 @@ def test_grid2d_equality():
     g6 = Grid2D(dx=0.1, nx=2, dy=0.2, ny=4, y0=5)
 
     assert g5 != g6
+
+
+def test_bad_projection_raises_error():
+
+    with pytest.raises(ValueError, match="proj"):
+        Grid2D(nx=2, ny=2, dx=0.1, projection="Not a WKT projection string")


### PR DESCRIPTION
In the spirit of failing fast, validate that a projection string is acceptable by MIKE on creation of geometry instead on writing to disk.