### PR TITLE
Slim source dist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+exclude = ["notebooks", "tests"]
+
 [project]
 name="mikeio"
 version="1.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-exclude = ["notebooks", "tests"]
+exclude = ["notebooks", "tests", "images"]
 
 [project]
 name="mikeio"


### PR DESCRIPTION
By removing:
* Notebooks
* Tests (testdata)
* Images

From the source distribution that is uploaded to PyPI. The wheel file is already slim.