### PR TITLE
Only run tests on Windows before each release.

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -13,10 +13,9 @@ on:
 jobs:
   build:
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
         python-version: [3.9, "3.12"]
 
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,42 @@ on:
   workflow_dispatch:
     
 jobs:
-  deploy:
 
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.9, "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: chartboost/ruff-action@v1 # Fail fast if there are any linting errors
+      with:
+        version: 0.6.2 # consistent with pyproject.toml ?
+        src: mikeio # ignore notebooks
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov
+        
+    - name: Install mikeio
+      run: |
+        pip install .[test]
+    - name: Test with pytest
+      run: |
+        pytest --cov=mikeio tests --ignore tests/performance/ --ignore tests/notebooks/ --disable-warnings
+    - name: Test docstrings with doctest
+      run: make doctest
+    - name: Static type check
+      run: make typecheck
+
+  deploy:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing


### PR DESCRIPTION
OS specific functionality is handled by `mikecore`. MIKE IO as an abstraction on top of `mikecore` mainly deals with os-independent functionality. Thus it seems like a waste to run all tests on Windows on each commit. But still important to verify before each release.