### PR TITLE
Indicate that MIKE IO uses type hints

### DIFF
--- a/mikeio/__init__.py
+++ b/mikeio/__init__.py
@@ -5,23 +5,6 @@ from platform import architecture
 from collections.abc import Sequence
 from typing import Any
 
-# PEP0440 compatible formatted version, see:
-# https://www.python.org/dev/peps/pep-0440/
-#
-# Generic release markers:
-#   X.Y
-#   X.Y.Z   # For bugfix releases
-#
-# Admissible pre-release markers:
-#   X.YaN   # Alpha release
-#   X.YbN   # Beta release
-#   X.YrcN  # Release Candidate
-#   X.Y     # Final release
-#
-# Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
-# 'X.Y.dev0' is the canonical version of 'X.Y.dev'
-#
-
 try:
     # read version from installed package
     __version__ = version("mikeio")
@@ -29,8 +12,6 @@ except PackageNotFoundError:
     # package is not installed
     __version__ = "dev"
 
-# __version__ = "2.2.dev2"  # TODO use git hash instead for dev version?
-# __version__ = "1.5.0"
 __dfs_version__: int = 220
 
 
@@ -39,16 +20,17 @@ if "64" not in architecture()[0]:
 
 from .dataset import DataArray, Dataset, from_pandas, from_polars
 from .dfs import Dfs0, Dfs1, Dfs2, Dfs3
-from .dfsu import Dfsu, Mesh
+from .dfsu import Dfsu, Mesh, Dfsu2DH, Dfsu2DV, Dfsu3D, DfsuSpectral
 from .eum import EUMType, EUMUnit, ItemInfo
 from .pfs import PfsDocument, PfsSection, read_pfs
 
-# Grid geometries are imported into the main module, since they are used to create dfs files
-# Other geometries are available in the spatial module
 from .spatial import (
     Grid1D,
     Grid2D,
     Grid3D,
+    GeometryFM2D,
+    GeometryFM3D,
+    GeometryFMVerticalProfile,
 )
 
 from .xyz import read_xyz
@@ -142,11 +124,15 @@ def read(
         raise ValueError("mikeio.read() is only supported for Dfs files")
 
     dfs = open(filename)
+    if isinstance(dfs, Mesh):
+        raise ValueError("mikeio.read() is not supported for Mesh files")
 
     return dfs.read(items=items, time=time, keepdims=keepdims, **kwargs)
 
 
-def open(filename: str | Path, **kwargs: Any) -> Any:
+def open(
+    filename: str | Path, **kwargs: Any
+) -> Dfs0 | Dfs1 | Dfs2 | Dfs3 | Dfsu2DH | Dfsu2DV | Dfsu3D | DfsuSpectral | Mesh:
     """Open a dfs/mesh file (and read the header).
 
     The typical workflow for small dfs files is to read all data
@@ -208,6 +194,10 @@ __all__ = [
     "Dfs2",
     "Dfs3",
     "Dfsu",
+    "Dfsu2DH",
+    "Dfsu2DV",
+    "Dfsu3D",
+    "DfsuSpectral",
     "Mesh",
     "EUMType",
     "EUMUnit",
@@ -219,6 +209,9 @@ __all__ = [
     "Grid1D",
     "Grid2D",
     "Grid3D",
+    "GeometryFM2D",
+    "GeometryFM3D",
+    "GeometryFMVerticalProfile",
     "read_xyz",
     "read",
     "open",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build]
+include = ["mikeio"]
+
 [tool.hatch.build.targets.sdist]
 exclude = ["notebooks", "tests", "images", ".github", "docs", ".devcontainer", "*.md", "*.txt", ".gitattributes"]
 
@@ -16,7 +19,11 @@ dependencies = [
     "scipy>=1.0",
     "PyYAML",
     "tqdm",
-    "xarray",
+    "xarray==2024.11.0",
+    "h5netcdf>=1.4.1",
+    "hatchling>=1.26.3",
+    "build>=1.2.2.post1",
+    "twine>=5.1.1",
 ]
 
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,21 @@ build-backend = "hatchling.build"
 include = ["mikeio"]
 
 [tool.hatch.build.targets.sdist]
-exclude = ["notebooks", "tests", "images", ".github", "docs", ".devcontainer", "*.md", "*.txt", ".gitattributes"]
+exclude = [
+    "notebooks",
+    "tests",
+    "images",
+    ".github",
+    "docs",
+    ".devcontainer",
+    "*.md",
+    "*.txt",
+    ".gitattributes",
+]
 
 [project]
-name="mikeio"
-version="2.2.dev3"
+name = "mikeio"
+version = "2.2.dev3"
 dependencies = [
     "mikecore>=0.2.1",
     "numpy>=1.22.0",
@@ -19,19 +29,15 @@ dependencies = [
     "scipy>=1.0",
     "PyYAML",
     "tqdm",
-    "xarray==2024.11.0",
-    "h5netcdf>=1.4.1",
-    "hatchling>=1.26.3",
-    "build>=1.2.2.post1",
-    "twine>=5.1.1",
+    "xarray",
 ]
 
 authors = [
-  { name="Henrik Andersson",email="jan@dhigroup.com"},
-  { name = "Jesper Sandvig Mariegaard", email="jem@dhigroup.com" }
+    { name = "Henrik Andersson", email = "jan@dhigroup.com" },
+    { name = "Jesper Sandvig Mariegaard", email = "jem@dhigroup.com" },
 ]
-description="A package that uses the DHI dfs libraries to create, write and read dfs and mesh files."
-license="BSD-3-Clause"
+description = "A package that uses the DHI dfs libraries to create, write and read dfs and mesh files."
+license = "BSD-3-Clause"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
@@ -48,34 +54,43 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest",
-       "quarto-cli",
-       "quartodoc==0.9.1",
-       "shapely",
-       "pyproj",
-       "xarray",
-       "netcdf4",
-       "rasterio",
-       "polars",
-       "ruff==0.6.2",
-       "mypy==1.11.1",
-       ]
+dev = [
+    "pytest",
+    "quarto-cli",
+    "quartodoc==0.9.1",
+    "shapely",
+    "pyproj",
+    "xarray",
+    "netcdf4",
+    "rasterio",
+    "polars",
+    "ruff==0.6.2",
+    "mypy==1.11.1",
+]
 
-test = ["pytest", "pytest-cov", "xarray","mypy==1.11.1","shapely","pyproj", "polars"]
+test = [
+    "pytest",
+    "pytest-cov",
+    "xarray",
+    "mypy==1.11.1",
+    "shapely",
+    "pyproj",
+    "polars",
+]
 
-notebooks= [
-            "nbformat",
-            "nbconvert",
-            "jupyter",
-            "xarray",
-            "netcdf4",
-            "rasterio",
-            "geopandas",
-            "scikit-learn",
-            "matplotlib",
-            "folium",
-            "mapclassify",
-        ]
+notebooks = [
+    "nbformat",
+    "nbconvert",
+    "jupyter",
+    "xarray",
+    "netcdf4",
+    "rasterio",
+    "geopandas",
+    "scikit-learn",
+    "matplotlib",
+    "folium",
+    "mapclassify",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/DHI/mikeio"
@@ -87,4 +102,14 @@ notebooks= [
 # ignore long lines
 ignore = ["E501", "E741"]
 
-select = ["D100", "D101", "D102", "D103", "D202", "D212", "D413", "D415", "D417"]
+select = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D202",
+    "D212",
+    "D413",
+    "D415",
+    "D417",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
-include = ["mikeio"]
+license-files = { paths = ["License.txt"] }
 
 [tool.hatch.build.targets.sdist]
 exclude = [


### PR DESCRIPTION
Enables derived package to use type checkers (e.g. mypy, pyright) to find bugs:
https://typing.readthedocs.io/en/latest/spec/distributing.html#packaging-typed-libraries

```python
import mikeio

def main(ds: mikeio.Dataset):
    print(ds.item[0])
```

**Before:**  😢
```bash
$ mypy hello.py
hello.py:1: error: Skipping analyzing "mikeio": module is installed, but missing library stubs or py.typed marker  [import-untyped]
hello.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

**After:** 😄 

```bash
$ mypy hello.py
hello.py:4: error: "Dataset" has no attribute "item"; maybe "items"?  [attr-defined]
Found 1 error in 1 file (checked 1 source file)
```

![image](https://github.com/user-attachments/assets/4b52d833-e28a-4bab-9a12-fa3a49e07421)

