### PR TITLE
Use named arguments to isel/sel

### DIFF
--- a/mikeio/dataset/_dataarray.py
+++ b/mikeio/dataset/_dataarray.py
@@ -1899,7 +1899,10 @@ class DataArray:
         )  # Single-item Dataset (All info is contained in the DataArray, no need for additional info)
 
     def to_dfs(
-        self, filename: str | Path, dtype: str | np.dtype | DfsSimpleType | None = None
+        self,
+        filename: str | Path,
+        dtype: str | np.dtype | DfsSimpleType | None = None,
+        title: str = "",
     ) -> None:
         """Write data to a new dfs file.
 
@@ -1910,9 +1913,11 @@ class DataArray:
         dtype: str, np.dtype, DfsSimpleType, optional
             Dfs0 only: set the dfs data type of the written data
             to e.g. np.float64, by default: DfsSimpleType.Float (=np.float32)
+        title: str
+            Only used by dfs0
 
         """
-        self._to_dataset().to_dfs(filename, dtype)
+        self._to_dataset().to_dfs(filename, dtype, title)
 
     def to_dataframe(
         self, *, unit_in_name: bool = False, round_time: str | bool = "ms"

--- a/mikeio/dataset/_dataarray.py
+++ b/mikeio/dataset/_dataarray.py
@@ -586,8 +586,17 @@ class DataArray:
     def isel(
         self,
         idx: int | Sequence[int] | slice | None = None,
+        *,
+        time: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        z: int | None = None,
+        element: int | None = None,
+        node: int | None = None,
+        layer: int | None = None,
+        frequency: int | None = None,
+        direction: int | None = None,
         axis: int | str = 0,
-        **kwargs: Any,
     ) -> "DataArray":
         """Return a new DataArray whose data is given by
         integer indexing along the specified dimension(s).
@@ -621,8 +630,6 @@ class DataArray:
         element : int, optional
             Bounding box of coordinates (left lower and right upper)
             to be selected, by default None
-        **kwargs: Any
-            Not used
 
         Returns
         -------
@@ -655,10 +662,23 @@ class DataArray:
         ```
 
         """
-        if isinstance(self.geometry, Grid2D) and ("x" in kwargs and "y" in kwargs):
-            idx_x = kwargs["x"]
-            idx_y = kwargs["y"]
-            return self.isel(x=idx_x).isel(y=idx_y)
+        if isinstance(self.geometry, Grid2D) and (x is not None and y is not None):
+            return self.isel(x=x).isel(y=y)
+        kwargs = {
+            k: v
+            for k, v in dict(
+                time=time,
+                x=x,
+                y=y,
+                z=z,
+                element=element,
+                node=node,
+                layer=layer,
+                frequency=frequency,
+                direction=direction,
+            ).items()
+            if v is not None
+        }
         for dim in kwargs:
             if dim in self.dims:
                 axis = dim
@@ -835,13 +855,11 @@ class DataArray:
             if isinstance(idx, tuple):
                 # TODO: support for dfs3
                 assert len(idx) == 2
-                t_ax_offset = 1 if self._has_time_axis else 0
                 ii, jj = idx
                 if jj is not None:
-                    da = da.isel(idx=jj, axis=(0 + t_ax_offset))
+                    da = da.isel(y=jj)
                 if ii is not None:
-                    sp_axis = 0 if (jj is not None and len(jj) == 1) else 1
-                    da = da.isel(idx=ii, axis=(sp_axis + t_ax_offset))
+                    da = da.isel(x=ii)
             else:
                 da = da.isel(idx, axis="space")
 

--- a/mikeio/dataset/_dataarray.py
+++ b/mikeio/dataset/_dataarray.py
@@ -627,6 +627,14 @@ class DataArray:
             y index, by default None
         z : int, optional
             z index, by default None
+        layer: int, optional
+            layer index, only used in dfsu 3d
+        direction: int, optional
+            direction index, only used in sprectra
+        frequency: int, optional
+            frequencey index, only used in spectra
+        node: int, optional
+            node index, only used in spectra
         element : int, optional
             Bounding box of coordinates (left lower and right upper)
             to be selected, by default None

--- a/mikeio/dataset/_dataarray.py
+++ b/mikeio/dataset/_dataarray.py
@@ -24,7 +24,6 @@ from typing import (
 import numpy as np
 import pandas as pd
 from mikecore.DfsuFile import DfsuFileType
-from mikecore.DfsFile import DfsSimpleType
 
 from ..eum import EUMType, EUMUnit, ItemInfo
 from ._data_utils import _get_time_idx_list, _n_selected_timesteps

--- a/mikeio/dataset/_dataarray.py
+++ b/mikeio/dataset/_dataarray.py
@@ -1898,12 +1898,7 @@ class DataArray:
             {self.name: self}
         )  # Single-item Dataset (All info is contained in the DataArray, no need for additional info)
 
-    def to_dfs(
-        self,
-        filename: str | Path,
-        dtype: str | np.dtype | DfsSimpleType | None = None,
-        title: str = "",
-    ) -> None:
+    def to_dfs(self, filename: str | Path, **kwargs: Any) -> None:
         """Write data to a new dfs file.
 
         Parameters
@@ -1913,11 +1908,11 @@ class DataArray:
         dtype: str, np.dtype, DfsSimpleType, optional
             Dfs0 only: set the dfs data type of the written data
             to e.g. np.float64, by default: DfsSimpleType.Float (=np.float32)
-        title: str
-            Only used by dfs0
+        **kwargs: Any
+            additional arguments passed to the writing function, e.g. dtype for dfs0
 
         """
-        self._to_dataset().to_dfs(filename, dtype, title)
+        self._to_dataset().to_dfs(filename, **kwargs)
 
     def to_dataframe(
         self, *, unit_in_name: bool = False, round_time: str | bool = "ms"

--- a/mikeio/dataset/_dataset.py
+++ b/mikeio/dataset/_dataset.py
@@ -795,7 +795,6 @@ class Dataset:
         frequency: int | None = None,
         direction: int | None = None,
         axis: int | str = 0,
-        **kwargs: Any,
     ) -> "Dataset":
         """Return a new Dataset whose data is given by
         integer indexing along the specified dimension(s).
@@ -825,8 +824,14 @@ class Dataset:
         element : int, optional
             Bounding box of coordinates (left lower and right upper)
             to be selected, by default None
-        **kwargs: Any
-            Not used
+        layer: int, optional
+            layer index, only used in dfsu 3d
+        direction: int, optional
+            direction index, only used in sprectra
+        frequency: int, optional
+            frequencey index, only used in spectra
+        node: int, optional
+            node index, only used in spectra
 
         Returns
         -------

--- a/mikeio/dataset/_dataset.py
+++ b/mikeio/dataset/_dataset.py
@@ -461,7 +461,7 @@ class Dataset:
             else:
                 all_index = list(np.intersect1d(all_index, idx))
 
-        return self.isel(all_index, axis=0)
+        return self.isel(time=all_index)
 
     def flipud(self) -> "Dataset":
         """Flip data upside down (on first non-time axis)."""
@@ -669,7 +669,7 @@ class Dataset:
             time_steps = _get_time_idx_list(self.time, key)
             if _n_selected_timesteps(self.time, time_steps) == 0:
                 raise IndexError("No timesteps found!")
-            return self.isel(time_steps, axis=0)
+            return self.isel(time=time_steps)
         if isinstance(key, slice):
             if self._is_slice_time_slice(key):
                 try:
@@ -677,7 +677,7 @@ class Dataset:
                     time_steps = list(range(s.start, s.stop))
                 except ValueError:
                     time_steps = list(range(*key.indices(len(self.time))))
-                return self.isel(time_steps, axis=0)
+                return self.isel(time=time_steps)
 
         if self._multi_indexing_attempted(key):
             raise TypeError(

--- a/mikeio/dataset/_dataset.py
+++ b/mikeio/dataset/_dataset.py
@@ -1916,23 +1916,15 @@ class Dataset:
 
         return df
 
-    def to_dfs(
-        self,
-        filename: str | Path,
-        dtype: str | np.dtype | DfsSimpleType | None = None,
-        title: str = "",
-    ) -> None:
+    def to_dfs(self, filename: str | Path, **kwargs: Any) -> None:
         """Write dataset to a new dfs file.
 
         Parameters
         ----------
         filename: str
             full path to the new dfs file
-        dtype: str, np.dtype, DfsSimpleType, optional
-            Dfs0 only: set the dfs data type of the written data
-            to e.g. np.float64, by default: DfsSimpleType.Float (=np.float32)
-        title: str
-            Only used by dfs0
+        **kwargs: Any
+            additional arguments passed to the writing function, e.g. dtype for dfs0
 
         """
         filename = str(filename)
@@ -1943,10 +1935,10 @@ class Dataset:
         ):
             if self.ndim == 0:  # Not very common, but still...
                 self._validate_extension(filename, ".dfs0")
-                self._to_dfs0(filename=filename, dtype=dtype, title=title)
+                self._to_dfs0(filename=filename, **kwargs)
             elif self.ndim == 1 and self[0]._has_time_axis:
                 self._validate_extension(filename, ".dfs0")
-                self._to_dfs0(filename=filename, dtype=dtype, title=title)
+                self._to_dfs0(filename=filename, **kwargs)
             else:
                 raise ValueError("Cannot write Dataset with no geometry to file!")
         elif isinstance(self.geometry, Grid2D):

--- a/mikeio/dataset/_dataset.py
+++ b/mikeio/dataset/_dataset.py
@@ -784,6 +784,16 @@ class Dataset:
     def isel(
         self,
         idx: int | Sequence[int] | slice | None = None,
+        *,
+        time: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        z: int | None = None,
+        element: int | None = None,
+        node: int | None = None,
+        layer: int | None = None,
+        frequency: int | None = None,
+        direction: int | None = None,
         axis: int | str = 0,
         **kwargs: Any,
     ) -> "Dataset":
@@ -835,7 +845,24 @@ class Dataset:
         >>> ds3 = ds2.isel(elements=[100,200])
 
         """
-        res = [da.isel(idx=idx, axis=axis, **kwargs) for da in self]
+        # TODO deprecate idx, axis to prefer x= instead
+
+        res = [
+            da.isel(
+                idx=idx,
+                axis=axis,
+                time=time,
+                x=x,
+                y=y,
+                z=z,
+                element=element,
+                node=node,
+                frequency=frequency,
+                direction=direction,
+                layer=layer,
+            )
+            for da in self
+        ]
         return Dataset(data=res, validate=False)
 
     def sel(

--- a/mikeio/dataset/_dataset.py
+++ b/mikeio/dataset/_dataset.py
@@ -1917,7 +1917,10 @@ class Dataset:
         return df
 
     def to_dfs(
-        self, filename: str | Path, dtype: str | np.dtype | DfsSimpleType | None = None
+        self,
+        filename: str | Path,
+        dtype: str | np.dtype | DfsSimpleType | None = None,
+        title: str = "",
     ) -> None:
         """Write dataset to a new dfs file.
 
@@ -1928,6 +1931,8 @@ class Dataset:
         dtype: str, np.dtype, DfsSimpleType, optional
             Dfs0 only: set the dfs data type of the written data
             to e.g. np.float64, by default: DfsSimpleType.Float (=np.float32)
+        title: str
+            Only used by dfs0
 
         """
         filename = str(filename)
@@ -1938,10 +1943,10 @@ class Dataset:
         ):
             if self.ndim == 0:  # Not very common, but still...
                 self._validate_extension(filename, ".dfs0")
-                self._to_dfs0(filename, dtype)
+                self._to_dfs0(filename=filename, dtype=dtype, title=title)
             elif self.ndim == 1 and self[0]._has_time_axis:
                 self._validate_extension(filename, ".dfs0")
-                self._to_dfs0(filename, dtype)
+                self._to_dfs0(filename=filename, dtype=dtype, title=title)
             else:
                 raise ValueError("Cannot write Dataset with no geometry to file!")
         elif isinstance(self.geometry, Grid2D):
@@ -1970,11 +1975,14 @@ class Dataset:
             raise ValueError(f"File extension must be {valid_extension}")
 
     def _to_dfs0(
-        self, filename: str | Path, dtype: DfsSimpleType = DfsSimpleType.Float
+        self,
+        filename: str | Path,
+        dtype: DfsSimpleType = DfsSimpleType.Float,
+        title: str = "",
     ) -> None:
         from ..dfs._dfs0 import _write_dfs0
 
-        _write_dfs0(filename, self, dtype=dtype)
+        _write_dfs0(filename, self, dtype=dtype, title=title)
 
     def _to_dfs2(self, filename: str | Path) -> None:
         # assumes Grid2D geometry

--- a/mikeio/dfs/_dfs0.py
+++ b/mikeio/dfs/_dfs0.py
@@ -189,7 +189,7 @@ class Dfs0:
                 _, time_steps = _valid_timesteps(dfs.FileInfo, time)
 
         if time_steps:
-            ds = ds.isel(time_steps, axis=0)
+            ds = ds.isel(time=time_steps)
 
         if sel_time_step_str:
             parts = sel_time_step_str.split(",")

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -33,7 +33,7 @@ def test_read_dfs1():
 def test_dfs1_isel_t():
     ds = mikeio.read("tests/testdata/consistency/oresundHD.dfs1")
 
-    ds1 = ds.isel([0, 1], axis="t")
+    ds1 = ds.isel(time=[0, 1])
     assert ds1.dims == ("time", "x")
     assert isinstance(ds1.geometry, type(ds.geometry))
     assert ds1[0].values[0, 8] == pytest.approx(0.203246)
@@ -42,7 +42,7 @@ def test_dfs1_isel_t():
 def test_dfs1_isel_x():
     ds = mikeio.read("tests/testdata/consistency/oresundHD.dfs1")
 
-    ds1 = ds.isel(8, axis="x")
+    ds1 = ds.isel(x=8)
     assert ds1.dims == ("time",)
     assert isinstance(ds1.geometry, GeometryUndefined)
     assert ds1[0].isel(0, axis="time").values == pytest.approx(0.203246)

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -45,7 +45,7 @@ def test_dfs1_isel_x():
     ds1 = ds.isel(x=8)
     assert ds1.dims == ("time",)
     assert isinstance(ds1.geometry, GeometryUndefined)
-    assert ds1[0].isel(0, axis="time").values == pytest.approx(0.203246)
+    assert ds1[0].isel(time=0).values == pytest.approx(0.203246)
 
 
 def test_dfs1_sel_t():
@@ -63,13 +63,13 @@ def test_dfs1_sel_x():
     ds1 = ds.sel(x=7.8)
     assert ds1.dims == ("time",)
     assert isinstance(ds1.geometry, GeometryUndefined)
-    assert ds1[0].isel(0, axis="time").values == pytest.approx(0.203246)
+    assert ds1[0].isel(time=0).values == pytest.approx(0.203246)
 
     da: DataArray = ds[0]
     da1 = da.sel(x=7.8)
     assert da1.dims == ("time",)
     assert isinstance(ds1.geometry, GeometryUndefined)
-    assert da1.isel(0, axis="time").values == pytest.approx(0.203246)
+    assert da1.isel(time=0).values == pytest.approx(0.203246)
 
 
 def test_dfs1_interp_x():
@@ -78,7 +78,7 @@ def test_dfs1_interp_x():
     ds1 = ds.interp(x=7.75)
     assert ds1.dims == ("time",)
     assert isinstance(ds1.geometry, GeometryUndefined)
-    assert ds1[0].isel(0, axis="time").values == pytest.approx(0.20202248)
+    assert ds1[0].isel(time=0).values == pytest.approx(0.20202248)
 
 
 # Nice to have...

--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -592,35 +592,32 @@ def test_dropna(da2):
 def test_da_isel_space(da_grid2d):
     assert da_grid2d.geometry.nx == 7
     assert da_grid2d.geometry.ny == 14
-    da_sel = da_grid2d.isel(0, axis="y")
-    assert da_sel.dims[0][0] == "t"
-    assert da_sel.dims[1] == "x"
+    da_sel = da_grid2d.isel(y=0)
+    assert da_sel.dims == ("time", "x")
     assert isinstance(da_sel.geometry, mikeio.Grid1D)
 
-    da_sel = da_grid2d.isel(0, axis="x")
-    assert da_sel.dims[0][0] == "t"
-    assert da_sel.dims[1] == "y"
+    da_sel = da_grid2d.isel(x=0)
+    assert da_sel.dims == ("time", "y")
     assert isinstance(da_sel.geometry, mikeio.Grid1D)
 
-    da_sel = da_grid2d.isel(0, axis="t")
-    assert da_sel.dims[0] == "y"
-    assert da_sel.dims[1] == "x"
+    da_sel = da_grid2d.isel(time=0)
+    assert da_sel.dims == ("y", "x")
 
 
 def test_da_isel_empty(da_grid2d):
     with pytest.raises(ValueError):
-        da_grid2d.isel(slice(100, 200), axis="y")
+        da_grid2d.isel(y=slice(100, 200))
 
 
 def test_da_isel_space_multiple_elements(da_grid2d):
     assert da_grid2d.geometry.nx == 7
     assert da_grid2d.geometry.ny == 14
-    da_sel = da_grid2d.isel((0, 1, 2, 10), axis="y")
+    da_sel = da_grid2d.isel(x=(0, 1, 2, 10))
     assert da_sel.dims == ("time", "y", "x")
     assert da_sel.shape == (10, 4, 7)
     assert isinstance(da_sel.geometry, mikeio.spatial.GeometryUndefined)
 
-    da_sel = da_grid2d.isel(slice(None, 3), axis="x")
+    da_sel = da_grid2d.isel(x=slice(None, 3))
     assert da_sel.dims == ("time", "y", "x")
     assert da_sel.shape == (10, 14, 3)
     assert isinstance(da_sel.geometry, mikeio.Grid2D)
@@ -631,12 +628,10 @@ def test_da_isel_space_named_axis(da_grid2d: mikeio.DataArray):
     assert da_sel.dims[0] == "time"
 
     da_sel = da_grid2d.isel(x=0)
-    assert da_sel.dims[0] == "time"
-    assert da_sel.dims[1] == "y"
+    assert da_sel.dims == ("time", "y")
 
     da_sel = da_grid2d.isel(time=0)
-    assert da_sel.dims[0] == "y"
-    assert da_sel.dims[1] == "x"
+    assert da_sel.dims == ("y", "x")
 
 
 def test_da_isel_space_named_missing_axis(da_grid2d: mikeio.DataArray):

--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -612,7 +612,7 @@ def test_da_isel_empty(da_grid2d):
 def test_da_isel_space_multiple_elements(da_grid2d):
     assert da_grid2d.geometry.nx == 7
     assert da_grid2d.geometry.ny == 14
-    da_sel = da_grid2d.isel(x=(0, 1, 2, 10))
+    da_sel = da_grid2d.isel(y=(0, 1, 2, 10))
     assert da_sel.dims == ("time", "y", "x")
     assert da_sel.shape == (10, 4, 7)
     assert isinstance(da_sel.geometry, mikeio.spatial.GeometryUndefined)

--- a/tests/test_dfs0.py
+++ b/tests/test_dfs0.py
@@ -4,7 +4,6 @@ import pandas as pd
 import mikeio
 from mikeio import Dfs0, EUMType, EUMUnit, ItemInfo
 from mikecore.DfsFile import DataValueType
-from mikecore.DfsFileFactory import DfsFileFactory
 
 
 import pytest

--- a/tests/test_dfs0.py
+++ b/tests/test_dfs0.py
@@ -43,24 +43,6 @@ def test_write_float(tmp_path):
     assert fp.exists()
 
 
-def test_write_title(tmp_path) -> None:
-    fp = tmp_path / "zeros.dfs0"
-
-    nt = 100
-
-    da = mikeio.DataArray(
-        data=np.zeros([nt]),
-        time=pd.date_range("2000", periods=nt, freq="h"),
-    )
-
-    da.to_dfs(fp, title="Zeros")
-
-    dfs = DfsFileFactory.DfsGenericOpen(str(fp))
-
-    # TODO should we expose the title in MIKE IO?
-    assert dfs.FileInfo.FileTitle == "Zeros"
-
-
 def test_write_double(tmp_path):
     fp = tmp_path / "simple_float.dfs0"
 

--- a/tests/test_dfs0.py
+++ b/tests/test_dfs0.py
@@ -4,6 +4,7 @@ import pandas as pd
 import mikeio
 from mikeio import Dfs0, EUMType, EUMUnit, ItemInfo
 from mikecore.DfsFile import DataValueType
+from mikecore.DfsFileFactory import DfsFileFactory
 
 
 import pytest
@@ -40,6 +41,24 @@ def test_write_float(tmp_path):
     da.to_dfs(fp)
 
     assert fp.exists()
+
+
+def test_write_title(tmp_path) -> None:
+    fp = tmp_path / "zeros.dfs0"
+
+    nt = 100
+
+    da = mikeio.DataArray(
+        data=np.zeros([nt]),
+        time=pd.date_range("2000", periods=nt, freq="h"),
+    )
+
+    da.to_dfs(fp, title="Zeros")
+
+    dfs = DfsFileFactory.DfsGenericOpen(str(fp))
+
+    # TODO should we expose the title in MIKE IO?
+    assert dfs.FileInfo.FileTitle == "Zeros"
 
 
 def test_write_double(tmp_path):
@@ -307,7 +326,6 @@ def test_from_pandas_mapping_eum_types() -> None:
 
 
 def test_from_pandas_same_eum_type() -> None:
-
     df = pd.DataFrame(
         {"station_a": np.array([1, np.nan, 2]), "station_b": np.array([2, 3.0, -1.3])},
         index=pd.date_range("2001-01-01", periods=3, freq="h"),
@@ -741,7 +759,6 @@ def test_read_dfs0_with_non_unique_item_names():
 
 
 def test_non_equidistant_time_can_read_correctly_with_open(tmp_path):
-
     dfs = mikeio.open("tests/testdata/neq_daily_time_unit.dfs0")
     dfs.time
     ds = dfs.read()

--- a/tests/test_dfs1.py
+++ b/tests/test_dfs1.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import pytest
 import pandas as pd
@@ -14,7 +13,6 @@ def test_filenotexist():
 
 
 def test_repr():
-
     filename = r"tests/testdata/random.dfs1"
     dfs = mikeio.open(filename)
 
@@ -60,7 +58,6 @@ def test_read_write_properties(tmp_path):
 
 
 def test_read():
-
     filename = r"tests/testdata/random.dfs1"
     dfs = mikeio.open(filename)
 
@@ -70,7 +67,6 @@ def test_read():
 
 
 def test_read_item_names():
-
     filename = r"tests/testdata/random.dfs1"
     dfs = mikeio.open(filename)
 
@@ -80,7 +76,6 @@ def test_read_item_names():
 
 
 def test_read_time_steps():
-
     filename = r"tests/testdata/random.dfs1"
     dfs = mikeio.open(filename)
 
@@ -90,9 +85,8 @@ def test_read_time_steps():
 
 
 def test_write_some_time_steps_new_file(tmp_path):
-
     fp = tmp_path / "random.dfs1"
-    ds= mikeio.read("tests/testdata/random.dfs1", time=[0, 1, 2, 3, 4, 5])
+    ds = mikeio.read("tests/testdata/random.dfs1", time=[0, 1, 2, 3, 4, 5])
 
     data = ds[0].to_numpy()
     assert data.shape == (6, 3)  # time, x
@@ -107,7 +101,6 @@ def test_write_some_time_steps_new_file(tmp_path):
 
 
 def test_read_item_names_not_in_dataset_fails():
-
     filename = r"tests/testdata/random.dfs1"
     dfs = mikeio.open(filename)
 
@@ -116,7 +109,6 @@ def test_read_item_names_not_in_dataset_fails():
 
 
 def test_read_names_access():
-
     filename = r"tests/testdata/random.dfs1"
     dfs = mikeio.open(filename)
 
@@ -131,7 +123,6 @@ def test_read_names_access():
 
 
 def test_read_start_end_time():
-
     dfs = mikeio.open("tests/testdata/random.dfs1")
     ds = dfs.read()
 
@@ -140,7 +131,6 @@ def test_read_start_end_time():
 
 
 def test_read_start_end_time_relative_time():
-
     dfs = mikeio.open("tests/testdata/physical_basin_wave_maker_signal.dfs1")
     ds = dfs.read()
 
@@ -149,7 +139,6 @@ def test_read_start_end_time_relative_time():
 
 
 def test_get_time_axis_without_reading_data():
-
     dfs0file = r"tests/testdata/random.dfs1"
     dfs = mikeio.open(dfs0file)
     assert isinstance(dfs.time, pd.DatetimeIndex)
@@ -164,13 +153,12 @@ def test_get_time_axis_without_reading_data_relative():
 
 
 def test_select_point_dfs1_to_dfs0(tmp_path):
-
     outfilename = tmp_path / "vu_tide_hourly_p0.dfs0"
 
     ds = mikeio.read("tests/testdata/vu_tide_hourly.dfs1")
 
     assert ds.n_elements > 1
-    ds_0 = ds.isel(0, axis="space")
+    ds_0 = ds.isel(x=0)
     assert ds_0.n_elements == 1
     ds_0.to_dfs(outfilename)
 
@@ -180,7 +168,6 @@ def test_select_point_dfs1_to_dfs0(tmp_path):
 
 
 def test_select_point_and_single_step_dfs1_to_dfs0(tmp_path):
-
     outfilename = tmp_path / "vu_tide_hourly_p0.dfs0"
 
     ds = mikeio.read("tests/testdata/vu_tide_hourly.dfs1")
@@ -198,13 +185,12 @@ def test_select_point_and_single_step_dfs1_to_dfs0(tmp_path):
 
 
 def test_select_point_dfs1_to_dfs0_double(tmp_path):
-
     outfilename = tmp_path / "vu_tide_hourly_p0_dbl.dfs0"
 
     ds = mikeio.read("tests/testdata/vu_tide_hourly.dfs1")
 
     assert ds.n_elements > 1
-    ds_0 = ds.isel(0, axis="space")
+    ds_0 = ds.isel(x=0)
     assert ds_0.n_elements == 1
     ds_0.to_dfs(outfilename, dtype=np.float64)
 
@@ -214,7 +200,6 @@ def test_select_point_dfs1_to_dfs0_double(tmp_path):
 
 
 def test_interp_dfs1():
-
     ds = mikeio.read("tests/testdata/waterlevel_north.dfs1")
 
     da: mikeio.DataArray = ds.North_WL
@@ -238,7 +223,6 @@ def test_interp_dfs1():
 
 
 def test_interp_onepoint_dfs1():
-
     ds = mikeio.read("tests/testdata/nx1.dfs1")
     assert ds.geometry.nx == 1
 


### PR DESCRIPTION
Tired of seeing this every time I build the docs, indicating an inconsistency.
```
/home/jan/src/mikeio/mikeio/eum/_eum.py:1414: Parameter 'type' does not appear in the function signature
/home/jan/src/mikeio/mikeio/dataset/_dataarray.py:626: Parameter 'time' does not appear in the function signature
/home/jan/src/mikeio/mikeio/dataset/_dataarray.py:626: Parameter 'x' does not appear in the function signature
/home/jan/src/mikeio/mikeio/dataset/_dataarray.py:626: Parameter 'y' does not appear in the function signature
/home/jan/src/mikeio/mikeio/dataset/_dataarray.py:626: Parameter 'z' does not appear in the function signature
/home/jan/src/mikeio/mikeio/dataset/_dataarray.py:626: Parameter 'element' does not appear in the function signature
/home/jan/src/mikeio/mikeio/dataset/_dataarray.py:786: Parameter 'x' does not appear in the function signature
/home/jan/src/mikeio/mikeio/dataset/_dataarray.py:786: Parameter 'y' does not appear in the function signature
/home/jan/src/mikeio/mikeio/dataset/_dataarray.py:786: Parameter 'z' does not appear in the function signature
/home/jan/src/mikeio/mikeio/dataset/_dataarray.py:786: Parameter 'coords' does not appear in the function signature
/home/jan/src/mikeio/mikeio/dataset/_dataarray.py:786: Parameter 'area' does not appear in the function signature
/home/jan/src/mikeio/mikeio/dataset/_dataarray.py:786: Parameter 'layers' does not appear in the function signature
```