### PR TITLE
Pfs set nested path

### DIFF
--- a/mikeio/pfs/_pfssection.py
+++ b/mikeio/pfs/_pfssection.py
@@ -92,16 +92,12 @@ class PfsSection(SimpleNamespace, MutableMapping[str, Any]):
     def __setitem__(self, key: str, value: Any) -> None:
         SECTION_SEPARATOR = "/"
         subsections = key.split(SECTION_SEPARATOR)
-        if len(subsections) > 1:
-            # Traverse or create nested sections
-            current_section = self
-            for section in subsections[:-1]:
-                if not hasattr(current_section, section):
-                    current_section.__setattr__(section, PfsSection({}))
-                current_section = getattr(current_section, section)
-            current_section.__set_key_value(subsections[-1], value)
-        else:
-            self.__set_key_value(key, value)
+        current_section = self
+        for section in subsections[:-1]:
+            if not hasattr(current_section, section):
+                setattr(current_section, section, PfsSection({}))
+            current_section = getattr(current_section, section)
+        current_section.__set_key_value(subsections[-1], value)
 
     def __delitem__(self, key: str) -> None:
         if key in self.keys():

--- a/mikeio/pfs/_pfssection.py
+++ b/mikeio/pfs/_pfssection.py
@@ -90,7 +90,18 @@ class PfsSection(SimpleNamespace, MutableMapping[str, Any]):
         return item
 
     def __setitem__(self, key: str, value: Any) -> None:
-        self.__set_key_value(key, value)
+        SECTION_SEPARATOR = "/"
+        subsections = key.split(SECTION_SEPARATOR)
+        if len(subsections) > 1:
+            # Traverse or create nested sections
+            current_section = self
+            for section in subsections[:-1]:
+                if not hasattr(current_section, section):
+                    current_section.__setattr__(section, PfsSection({}))
+                current_section = getattr(current_section, section)
+            current_section.__set_key_value(subsections[-1], value)
+        else:
+            self.__set_key_value(key, value)
 
     def __delitem__(self, key: str) -> None:
         if key in self.keys():

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -1269,7 +1269,7 @@ EndSect  // Engine
     assert pfs.Engine.var == "x"
 
 
-def test_nested_path() -> None:
+def test_get_nested_path() -> None:
     text = """
 [foo]
     random = 1
@@ -1292,3 +1292,27 @@ EndSect
     assert pfs[part_of_the_path].baz.simple == 0
     # we can mix and match
     assert pfs["foo"]["bar/baz/simple"] == 0
+
+
+def test_set_nested_path() -> None:
+    text = """
+[foo]
+    random = 1
+    [bar]
+        speed = 'fast'
+        [baz]
+            simple = 0
+        EndSect
+    EndSect
+EndSect
+"""
+
+    pfs = mikeio.PfsDocument.from_text(text)
+    assert pfs.foo.bar.baz.simple == 0
+    path = "foo/bar/baz/simple"
+    pfs[path] = 1
+    assert pfs[path] == 1
+
+    pfs.foo["bar/bat"] = {"n": 5, "s": "foo"}
+    assert pfs.foo.bar.bat.n == 5
+    assert pfs.foo.bar.bat.s == "foo"


### PR DESCRIPTION
#812 added the ability to access parts of a PfsDocument using a nested path, e.g. 

```python
>>> pfs["foo/bar/baz"]
0
```

This PR extends the functionality to set values using a nested path.
```python
pfs["foo/bar/baz"] = 1
```