### PR TITLE
Simplify Dataset

### DIFF
--- a/mikeio/dataset/_dataarray.py
+++ b/mikeio/dataset/_dataarray.py
@@ -347,7 +347,7 @@ class DataArray:
                 raise ValueError("zn can only be provided for layered dfsu data")
         return zn
 
-    def _is_compatible(self, other: "DataArray", raise_error: bool = False) -> bool:
+    def _is_compatible(self, other: "DataArray") -> bool:
         """check if other DataArray has equivalent dimensions, time and geometry."""
         problems = []
         assert isinstance(other, DataArray)
@@ -376,7 +376,7 @@ class DataArray:
         if self.dims != other.dims:
             problems.append("Dimension names (dims) must be the same")
 
-        if raise_error and len(problems) > 0:
+        if len(problems) > 0:
             raise ValueError(", ".join(problems))
 
         return len(problems) == 0

--- a/mikeio/dataset/_dataset.py
+++ b/mikeio/dataset/_dataset.py
@@ -99,7 +99,7 @@ class Dataset:
         if validate:
             first, *rest = data_vars.values()
             for da in rest:
-                first._is_compatible(da, raise_error=True)
+                first._is_compatible(da)
 
         self._data_vars = data_vars
 
@@ -566,6 +566,7 @@ class Dataset:
 
         raise TypeError(f"indexing with a {type(key)} is not (yet) supported")
 
+    # deprecated
     def _is_slice_time_slice(self, s: slice) -> bool:
         if (s.start is None) and (s.stop is None):
             return False
@@ -577,6 +578,7 @@ class Dataset:
                 return False
         return True
 
+    # deprecated
     def _is_key_time(self, key: Any) -> bool:
         if isinstance(key, slice):
             return False
@@ -592,7 +594,6 @@ class Dataset:
 
         return False  # type: ignore
 
-    # TODO change this to return a single type
     def _key_to_str(self, key: Any) -> Any:
         """Translate item selection key to str (or list[str])."""
         if isinstance(key, str):

--- a/mikeio/dataset/_dataset.py
+++ b/mikeio/dataset/_dataset.py
@@ -8,7 +8,6 @@ from typing import (
     Iterator,
     Literal,
     Mapping,
-    MutableMapping,
     Sequence,
     Any,
     overload,

--- a/mikeio/dataset/_dataset.py
+++ b/mikeio/dataset/_dataset.py
@@ -101,6 +101,8 @@ class Dataset:
             for da in rest:
                 first._is_compatible(da, raise_error=True)
 
+        self._data_vars = data_vars
+
         for key, value in data_vars.items():
             self._set_name_attr(key, value)
         self.plot = _DatasetPlotter(self)

--- a/mikeio/dataset/_dataset.py
+++ b/mikeio/dataset/_dataset.py
@@ -213,13 +213,11 @@ class Dataset:
     @property
     def start_time(self) -> datetime:
         """First time instance (as datetime)."""
-        # TODO: use pd.Timestamp instead
         return self.time[0].to_pydatetime()  # type: ignore
 
     @property
     def end_time(self) -> datetime:
         """Last time instance (as datetime)."""
-        # TODO: use pd.Timestamp instead
         return self.time[-1].to_pydatetime()  # type: ignore
 
     @property
@@ -300,15 +298,6 @@ class Dataset:
     @property
     def _zn(self) -> np.ndarray | None:
         return self[0]._zn
-
-    # TODO: remove this
-    @property
-    def n_elements(self) -> int:
-        """Number of spatial elements/points."""
-        n_elem = int(np.prod(self.shape))
-        if self.n_timesteps > 1:
-            n_elem = int(n_elem / self.n_timesteps)
-        return n_elem
 
     def describe(self, **kwargs: Any) -> pd.DataFrame:
         """Generate descriptive statistics.

--- a/mikeio/dataset/_dataset.py
+++ b/mikeio/dataset/_dataset.py
@@ -569,27 +569,20 @@ class Dataset:
         item_name = value.name
 
         if isinstance(key, int):
-            is_replacement = not insert
-            if is_replacement:
-                key_str = self.names[key]
-                self._data_vars[key_str] = value
-            else:
+            if insert:
                 if item_name in self.names:
                     raise ValueError(
                         f"Item name {item_name} already in Dataset ({self.names})"
                     )
-                all_keys = list(self._data_vars.keys())
-                all_keys.insert(key, item_name)
-
-                data_vars = {}
-                for k in all_keys:
-                    if k in self._data_vars.keys():
-                        data_vars[k] = self._data_vars[k]
-                    else:
-                        data_vars[k] = value
-                self._data_vars = data_vars
-
-            self._set_name_attr(item_name, value)
+                keys = list(self._data_vars.keys())
+                keys.insert(key, item_name)
+                values = list(self._data_vars.values())
+                values.insert(key, value)
+                self._data_vars = dict(zip(keys, values))
+            else:
+                key_str = self.names[key]
+                self._data_vars[key_str] = value
+                self._set_name_attr(item_name, value)
         else:
             if key != item_name:
                 value.name = key

--- a/mikeio/dfs/_dfs0.py
+++ b/mikeio/dfs/_dfs0.py
@@ -19,7 +19,7 @@ from ..eum import EUMType, EUMUnit, ItemInfo, TimeStepUnit, ItemInfoList
 from .._time import DateTimeSelector
 
 
-def _write_dfs0(
+def write_dfs0(
     filename: str | Path,
     dataset: Dataset,
     title: str = "",
@@ -402,7 +402,7 @@ def dataframe_to_dfs0(
         for d, item in zip(data, items)
     }
     ds = Dataset(das)
-    _write_dfs0(filename=filename, dataset=ds, title=title, dtype=dtype)
+    write_dfs0(filename=filename, dataset=ds, title=title, dtype=dtype)
 
 
 # Monkey patching onto Pandas classes

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -988,7 +988,6 @@ def test_properties_dfs2() -> None:
     assert ds.n_timesteps == 1
     assert ds.n_items == 1
     assert np.all(ds.shape == (1, 264, 216))
-    assert ds.n_elements == (264 * 216)
     assert ds.is_equidistant
 
 
@@ -1002,7 +1001,6 @@ def test_properties_dfsu() -> None:
     assert ds.timestep == (3 * 3600)
     assert ds.n_items == 2
     assert np.all(ds.shape == (3, 441))
-    assert ds.n_elements == 441
     assert ds.is_equidistant
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1411,6 +1411,16 @@ def test_incompatible_data_not_allowed() -> None:
     assert "shape" in str(excinfo.value).lower()
 
 
+def test_setitem_incompatible_data_not_allowed() -> None:
+    ds1 = mikeio.read("tests/testdata/HD2D.dfsu")
+    da2 = mikeio.read("tests/testdata/oresundHD_run1.dfsu")[1]
+
+    with pytest.raises(ValueError) as excinfo:
+        ds1["foo"] = da2
+
+    assert "shape" in str(excinfo.value).lower()
+
+
 def test_xzy_selection() -> None:
     # select in space via x,y,z coordinates test
     filename = "tests/testdata/oresund_sigma_z.dfsu"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -117,15 +117,6 @@ def test_remove(ds1: Dataset) -> None:
     assert len(ds1) == 0
 
 
-def test_set_item_overwrites_existing_item() -> None:
-    ds = mikeio.read("tests/testdata/NorthSea_HD_and_windspeed.dfsu")
-    assert ds.n_items == 2
-    ws2 = ds["Wind speed"].copy()
-    ws2.values = np.clip(ws2.to_numpy(), 1, 18)
-    ds["Wind speed"] = ws2
-    assert ds.n_items == 2
-
-
 def test_index_with_attribute() -> None:
     nt = 10
     d = np.zeros([nt, 100, 30]) + 1.0

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1006,29 +1006,6 @@ def test_properties_dfsu() -> None:
     assert ds.is_equidistant
 
 
-def test_create_empty_data() -> None:
-    ne = 34
-    d = mikeio.Dataset.create_empty_data(n_elements=ne)
-    assert len(d) == 1
-    assert d[0].shape == (1, ne)
-
-    nt = 100
-    d = mikeio.Dataset.create_empty_data(n_timesteps=nt, shape=(3, 4, 6))
-    assert len(d) == 1
-    assert d[0].shape == (nt, 3, 4, 6)
-
-    ni = 4
-    d = mikeio.Dataset.create_empty_data(n_items=ni, n_elements=ne)
-    assert len(d) == ni
-    assert d[-1].shape == (1, ne)
-
-    with pytest.raises(Exception):
-        d = mikeio.Dataset.create_empty_data()
-
-    with pytest.raises(Exception):
-        d = mikeio.Dataset.create_empty_data(n_elements=None, shape=None)
-
-
 def test_create_infer_name_from_eum() -> None:
     nt = 100
     d = np.random.uniform(size=nt)

--- a/tests/test_dfs1.py
+++ b/tests/test_dfs1.py
@@ -153,29 +153,12 @@ def test_get_time_axis_without_reading_data_relative() -> None:
     assert len(dfs.time) == 200
 
 
-def test_select_point_dfs1_to_dfs0(tmp_path: Path) -> None:
-    outfilename = tmp_path / "vu_tide_hourly_p0.dfs0"
-
-    ds = mikeio.read("tests/testdata/vu_tide_hourly.dfs1")
-
-    assert ds.n_elements > 1
-    ds_0 = ds.isel(x=0)
-    assert ds_0.n_elements == 1
-    ds_0.to_dfs(outfilename)
-
-    dsnew = mikeio.read(outfilename)
-
-    assert dsnew.n_timesteps == ds.n_timesteps
-
-
 def test_select_point_and_single_step_dfs1_to_dfs0(tmp_path: Path) -> None:
     outfilename = tmp_path / "vu_tide_hourly_p0.dfs0"
 
     ds = mikeio.read("tests/testdata/vu_tide_hourly.dfs1")
 
-    assert ds.n_elements > 1
     ds_0 = ds.isel(0, axis="space")
-    assert ds_0.n_elements == 1
     ds_0_0 = ds_0.isel(0)
     assert ds_0_0.n_timesteps == 1
     ds_0_0.to_dfs(outfilename)
@@ -183,21 +166,6 @@ def test_select_point_and_single_step_dfs1_to_dfs0(tmp_path: Path) -> None:
     dsnew = mikeio.read(outfilename)
 
     assert dsnew.n_timesteps == 1
-
-
-def test_select_point_dfs1_to_dfs0_double(tmp_path: Path) -> None:
-    outfilename = tmp_path / "vu_tide_hourly_p0_dbl.dfs0"
-
-    ds = mikeio.read("tests/testdata/vu_tide_hourly.dfs1")
-
-    assert ds.n_elements > 1
-    ds_0 = ds.isel(x=0)
-    assert ds_0.n_elements == 1
-    ds_0.to_dfs(outfilename, dtype=np.float64)
-
-    dsnew = mikeio.read(outfilename)
-
-    assert dsnew.n_timesteps == ds.n_timesteps
 
 
 def test_interp_dfs1() -> None:

--- a/tests/test_dfsu3d.py
+++ b/tests/test_dfsu3d.py
@@ -193,7 +193,7 @@ def test_flip_column_upside_down() -> None:
     assert dscol.geometry.element_coordinates[0, 2] == pytest.approx(-7.0)
     assert dscol.isel(time=-1)["Temperature"].values[0] == pytest.approx(17.460058)
 
-    idx = list(reversed(range(dscol.n_elements)))
+    idx = list(reversed(range(dscol.geometry.n_elements)))
 
     dscol_ud = dscol.isel(element=idx)
 
@@ -231,7 +231,7 @@ def test_read_dfsu3d_columns_sigma_only() -> None:
     dfs = mikeio.Dfsu3D("tests/testdata/basin_3d.dfsu")
     dscol = dfs.read(x=500, y=50)
     assert isinstance(dscol.geometry, GeometryFMVerticalColumn)
-    assert dscol.n_elements == 10
+    assert dscol.geometry.n_elements == 10
     assert dscol.n_items == dfs.n_items
     assert dscol["U velocity"].isel(time=-1)[-1].values == pytest.approx(0.363413)
 


### PR DESCRIPTION
**Overall Purpose:**  
This PR simplifies the Dataset class and its related logic, focusing on cleaner initialization and removal of deprecated and redundant code. 

**Key Changes:**

- **Dataset Initialization:**
  - The Dataset class now only accepts a Mapping or Sequence of DataArrays or a single DataArray. The previous support for initializing with raw numpy arrays is removed.
  - The deprecated and more complex multi-overload __init__ signature is replaced with a simpler one.

- **Removal of Deprecated Features:**
  - All code related to initializing a Dataset from a list of numpy arrays is removed, including related warnings and overloads.
  - Functions and properties like create_empty_data, n_elements (on Dataset), and multi-indexing guards are deleted.

**Impact:**  
These changes modernize and simplify the Dataset component, making it easier to maintain and less error-prone, while removing legacy support and cleaning up the public and internal API. This may introduce minor breaking changes for users relying on deprecated features.
