### PR TITLE
Remove dead code from generic module

### DIFF
--- a/src/mikeio/generic.py
+++ b/src/mikeio/generic.py
@@ -128,9 +128,6 @@ def _clone(
             for item in source.ItemInfo:
                 builder.AddDynamicItem(item)
 
-        case int():
-            builder.AddDynamicItem(source.ItemInfo[items])
-
         case list():
             for item in items:
                 match item:


### PR DESCRIPTION
Removes unreachable `case int():` branch from `_clone()` function.

The code path was unreachable because:
- Function signature only accepts `Sequence[int]`, not bare `int`
- All callers use `_valid_item_numbers()` which returns a list
- No test coverage for this path