### PR TITLE
Add title support for dfsu files

### DIFF
--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -1764,19 +1764,19 @@ class Dataset:
 
             case Grid2D():
                 self._validate_extension(filename, ".dfs2")
-                write_dfs2(filename, self)
+                write_dfs2(filename, self, **kwargs)
 
             case Grid3D():
                 self._validate_extension(filename, ".dfs3")
-                write_dfs3(filename, self)
+                write_dfs3(filename, self, **kwargs)
 
             case Grid1D():
                 self._validate_extension(filename, ".dfs1")
-                write_dfs1(filename, self)
+                write_dfs1(filename, self, **kwargs)
 
             case _GeometryFM():
                 self._validate_extension(filename, ".dfsu")
-                write_dfsu(filename, self)
+                write_dfsu(filename, self, **kwargs)
 
             case _:
                 raise NotImplementedError(

--- a/src/mikeio/dfsu/_layered.py
+++ b/src/mikeio/dfsu/_layered.py
@@ -51,6 +51,7 @@ class DfsuLayered:
         self._start_time = info.start_time
         self._timestep = info.timestep
         self._n_timesteps = info.n_timesteps
+        self._title = info.title
         self._geometry = self._read_geometry(self._filename)
         # 3d files have a zn item
         self._items = self._read_items(self._filename)
@@ -136,6 +137,11 @@ class DfsuLayered:
             raise NotImplementedError(
                 "Non-equidistant time axis. Read the data to get time."
             )
+
+    @property
+    def title(self) -> str:
+        """File title."""
+        return self._title
 
     @property
     def geometry(self) -> GeometryFM3D | GeometryFMVerticalProfile:

--- a/src/mikeio/dfsu/_spectral.py
+++ b/src/mikeio/dfsu/_spectral.py
@@ -46,6 +46,7 @@ class DfsuSpectral:
         self._start_time = info.start_time
         self._timestep = info.timestep
         self._n_timesteps = info.n_timesteps
+        self._title = info.title
         self._items = info.items
         self._geometry = self._read_geometry(self._filename)
 
@@ -136,6 +137,11 @@ class DfsuSpectral:
             raise NotImplementedError(
                 "Non-equidistant time axis. Read the data to get time."
             )
+
+    @property
+    def title(self) -> str:
+        """File title."""
+        return self._title
 
     @staticmethod
     def _read_geometry(

--- a/tests/test_dfsu2dh.py
+++ b/tests/test_dfsu2dh.py
@@ -1050,3 +1050,31 @@ def test_dfsu_to_xarray_has_element_coordinates() -> None:
     assert xr_da.x.values[example_quad_element] == approx(example_quad_coordinates[0])
     assert xr_da.y.values[example_quad_element] == approx(example_quad_coordinates[1])
     assert xr_da.z.values[example_quad_element] == approx(example_quad_coordinates[2])
+
+
+def test_write_dfsu_with_title(tmp_path: Path) -> None:
+    """Test writing a dfsu file with a custom title and reading it back."""
+    sourcefilename = "tests/testdata/HD2D.dfsu"
+    fp = tmp_path / "with_title.dfsu"
+
+    # Read source file
+    dfs = mikeio.Dfsu2DH(sourcefilename)
+    ds = dfs.read(items=[0])
+
+    # Write with custom title
+    custom_title = "Test DFSU with Custom Title"
+    ds.to_dfs(fp, title=custom_title)
+
+    # Read back and verify title
+    newdfs = mikeio.Dfsu2DH(fp)
+    assert newdfs.title == custom_title
+
+
+def test_read_dfsu_title(tmp_path: Path) -> None:
+    """Test reading the title from an existing dfsu file."""
+    sourcefilename = "tests/testdata/HD2D.dfsu"
+    dfs = mikeio.Dfsu2DH(sourcefilename)
+
+    # Dfsu files should have a title property
+    assert hasattr(dfs, "title")
+    assert isinstance(dfs.title, str)


### PR DESCRIPTION
## Summary

Adds the ability to read and write custom titles for dfsu files.

## Changes

- Add `title` property to all Dfsu classes (Dfsu2DH, DfsuLayered, DfsuSpectral)
- Add `title` parameter to `write_dfsu()` function
- Update `Dataset.to_dfs()` to pass kwargs for dfsu files
- Fix kwargs passing for dfs1, dfs2, and dfs3 files in `Dataset.to_dfs()`
- Add tests for title functionality

## Usage

```python
# Write with custom title
ds.to_dfs("output.dfsu", title="My Custom Title")

# Read title
dfs = mikeio.Dfsu2DH("file.dfsu")
print(dfs.title)
```

## Implementation Details

Implemented using TDD:
1. Wrote failing tests first
2. Implemented feature to make tests pass
3. All existing tests still pass