### PR TITLE
Fix MULTIPOLYGON quote handling in PFS parser

### DIFF
--- a/src/mikeio/pfs/_pfsdocument.py
+++ b/src/mikeio/pfs/_pfsdocument.py
@@ -361,9 +361,15 @@ class PfsDocument(PfsSection):
         ):
             return self._parse_token(value_str)
 
-        # Special case: MULTIPOLYGON
+        # Special case: MULTIPOLYGON - fast path for large coordinate strings
+        # Avoids expensive parsing but still strips quotes correctly
         if "MULTIPOLYGON" in value_str:
-            return value_str
+            s = value_str.strip()
+            if s.startswith("'") and s.endswith("'"):
+                return s[1:-1]
+            elif s.startswith('"') and s.endswith('"'):
+                return s[1:-1]
+            return s
 
         # Special case: values enclosed in double quotes should not be split
         # (even though they may contain commas)


### PR DESCRIPTION
## Summary

Fixes a regression bug in v3.0.0 (#866) where MULTIPOLYGON strings accumulate quotes on each read-write cycle.

The MULTIPOLYGON special case (added for performance in the PFS rewrite, related to issue #749) was returning raw strings without stripping quotes, causing:
- First read: `'MULTIPOLYGON...'` (quote preserved)  
- After write-read: `''MULTIPOLYGON...'` (quote doubled)
- Each cycle adds another layer of quotes

## Solution

Modified the MULTIPOLYGON fast path to strip quotes like other string values while maintaining the performance optimization.

## Testing the fix

Users can install this branch to test the fix:

```bash
pip install git+https://github.com/DHI/mikeio.git@fix/pfs_single_quote
```

Or with uv:

```bash
uv pip install git+https://github.com/DHI/mikeio.git@fix/pfs_single_quote
```