### PR TITLE
Fix numpy 2.4 type stub compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "mikeio"
 version = "3.1.0.dev1"
 dependencies = [
     "mikecore>=0.2.2",
-    "numpy>=1.22.0",
+    "numpy>=1.26.0",
     "pandas>=1.3",
     "matplotlib>=3.6.0",
     "scipy>=1.0",
@@ -39,20 +39,16 @@ classifiers = [
 ]
 
 [dependency-groups]
+test = ["pytest", "pytest-cov", "mypy==1.19.1", "shapely", "pyproj", "polars"]
+
 dev = [
-    "pytest",
+    {include-group = "test"},
     "quarto-cli",
     "quartodoc==0.9.1",
     "griffe==1.1.0",    # compatible with quartodoc 0.9.1
-    "shapely",
-    "pyproj",
     "netcdf4",
-    "polars",
     "ruff==0.6.2",
-    "mypy==1.16.1",
 ]
-
-test = ["pytest", "pytest-cov", "mypy==1.16.1", "shapely", "pyproj", "polars"]
 
 notebooks = [
     "nbformat",

--- a/src/mikeio/spatial/_FM_geometry_layered.py
+++ b/src/mikeio/spatial/_FM_geometry_layered.py
@@ -325,9 +325,9 @@ class _GeometryFMLayered(_GeometryFM):
         # fast path if no z-layers
         if self.n_z_layers == 0:
             return np.arange(
-                start=self.n_sigma_layers - 1,
-                stop=self.n_elements,
-                step=self.n_sigma_layers,
+                self.n_sigma_layers - 1,
+                self.n_elements,
+                self.n_sigma_layers,
             )
         else:
             # slow path

--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -875,7 +875,8 @@ class Grid2D(_Geometry):
         axis = axis + 2 if axis < 0 else axis
 
         if not np.isscalar(idx):
-            d = np.diff(idx)  # type: ignore
+            assert isinstance(idx, np.ndarray)
+            d = np.diff(idx)
             if np.any(d < 1) or not np.allclose(d, d[0]):
                 # non-equidistant grid is not supported by Dfs2
                 return GeometryUndefined()


### PR DESCRIPTION
## Summary
- Fix mypy errors caused by stricter type stubs in numpy 2.4
- Update minimum numpy to 1.26.0 (required for Python 3.12+ due to distutils removal)
- Update mypy to 1.19.1
- DRY dependency-groups: dev now includes test group