### PR TITLE
Add title attribute to Dataset and DFS file readers

### DIFF
--- a/docs/user-guide/dfs0.qmd
+++ b/docs/user-guide/dfs0.qmd
@@ -92,6 +92,17 @@ ds_typed
 ```
 
 
+## File title
+
+DFS files have a title field shown e.g. in MIKE Zero. The title is read from the file and preserved through processing. You can set it before writing:
+
+```{python}
+ds = mikeio.read("mauna_loa_co2.dfs0")
+ds.title = "Mauna Loa CO2"
+ds.to_dfs("mauna_loa_co2.dfs0")
+```
+
+
 ## Accumulated datavalue type
 
 Some dfs0 items use an accumulated data value type rather than the default instantaneous type. This is common for precipitation data and can be specified using the `data_value_type` argument of [](`mikeio.ItemInfo`). Refer to the [MIKE documentation](https://doc.mikepoweredbydhi.help/webhelp/2026/timeserieseditor/TSEdit/TSEdit/TS_Types_graphical_representation.htm) for guidance on which type to use for your setup.

--- a/src/mikeio/dataset/_dataarray.py
+++ b/src/mikeio/dataset/_dataarray.py
@@ -1837,20 +1837,18 @@ class DataArray:
             {self.name: self}
         )  # Single-item Dataset (All info is contained in the DataArray, no need for additional info)
 
-    def to_dfs(self, filename: str | Path, title: str = "", **kwargs: Any) -> None:
+    def to_dfs(self, filename: str | Path, **kwargs: Any) -> None:
         """Write data to a new dfs file.
 
         Parameters
         ----------
         filename: str
             full path to the new dfs file
-        title: str, optional
-            title for the dfs file
         **kwargs: Any
             additional arguments passed to the writing function, e.g. dtype for dfs0
 
         """
-        self._to_dataset().to_dfs(filename, title=title, **kwargs)
+        self._to_dataset().to_dfs(filename, **kwargs)
 
     def to_dataframe(
         self, *, unit_in_name: bool = False, round_time: str | bool = "ms"

--- a/src/mikeio/dataset/_dataarray.py
+++ b/src/mikeio/dataset/_dataarray.py
@@ -1837,18 +1837,20 @@ class DataArray:
             {self.name: self}
         )  # Single-item Dataset (All info is contained in the DataArray, no need for additional info)
 
-    def to_dfs(self, filename: str | Path, **kwargs: Any) -> None:
+    def to_dfs(self, filename: str | Path, title: str = "", **kwargs: Any) -> None:
         """Write data to a new dfs file.
 
         Parameters
         ----------
         filename: str
             full path to the new dfs file
+        title: str, optional
+            title for the dfs file
         **kwargs: Any
             additional arguments passed to the writing function, e.g. dtype for dfs0
 
         """
-        self._to_dataset().to_dfs(filename, **kwargs)
+        self._to_dataset().to_dfs(filename, title=title, **kwargs)
 
     def to_dataframe(
         self, *, unit_in_name: bool = False, round_time: str | bool = "ms"

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -109,7 +109,7 @@ class Dataset:
             self._set_name_attr(key, value)
         self.plot = DatasetPlotter(self)
 
-        self._title = title
+        self.title = title
 
     @staticmethod
     def from_numpy(
@@ -226,15 +226,6 @@ class Dataset:
     # ============ end of init =============
 
     # ============= Basic properties/methods ===========
-    @property
-    def title(self) -> str:
-        """Title of the dataset, typically read from the file."""
-        return self._title
-
-    @title.setter
-    def title(self, value: str) -> None:
-        """Set the title of the dataset."""
-        self._title = value
 
     @property
     def _dt(self) -> float:
@@ -365,7 +356,7 @@ class Dataset:
         """
         res = {name: da.fillna(value=value) for name, da in self._data_vars.items()}
 
-        return Dataset(data=res, validate=False)
+        return Dataset(data=res, validate=False, title=self.title)
 
     def dropna(self) -> Dataset:
         """Remove time steps where all items are NaN."""
@@ -412,7 +403,7 @@ class Dataset:
         )
         res = {name: da.squeeze() for name, da in self._data_vars.items()}
 
-        return Dataset(data=res, validate=False)
+        return Dataset(data=res, validate=False, title=self.title)
 
     def create_data_array(
         self,
@@ -577,14 +568,14 @@ class Dataset:
                     for k, da in self._data_vars.items()
                     if fnmatch.fnmatch(k, key)
                 }
-                return Dataset(data=data_vars, validate=False)
+                return Dataset(data=data_vars, validate=False, title=self.title)
             else:
                 item_names = ",".join(self._data_vars.keys())
                 raise KeyError(f"No item named: {key}. Valid items: {item_names}")
 
         if isinstance(key, Iterable):
             data_vars = {v: self._data_vars[v] for v in key}
-            return Dataset(data=data_vars, validate=False)
+            return Dataset(data=data_vars, validate=False, title=self.title)
 
         raise TypeError(f"indexing with a {type(key)} is not (yet) supported")
 
@@ -692,7 +683,7 @@ class Dataset:
             )
             for da in self
         ]
-        return Dataset(data=res, validate=False)
+        return Dataset(data=res, validate=False, title=self.title)
 
     def sel(
         self,
@@ -773,7 +764,7 @@ class Dataset:
             da.sel(time=time, x=x, y=y, z=z, coords=coords, area=area, layers=layers)
             for da in self
         ]
-        return Dataset(data=res, validate=False)
+        return Dataset(data=res, validate=False, title=self.title)
 
     def interp(
         self,
@@ -853,9 +844,9 @@ class Dataset:
                 das = [da.interp(x=x, y=y, interpolant=interpolant) for da in self]
             else:
                 das = [da.interp(x=x, y=y) for da in self]
-            ds = Dataset(das, validate=False)
+            ds = Dataset(das, validate=False, title=self.title)
         else:
-            ds = Dataset([da for da in self], validate=False)
+            ds = Dataset([da for da in self], validate=False, title=self.title)
 
         # interp in time
         if isinstance(time, (pd.DatetimeIndex, DataArray)):
@@ -982,7 +973,7 @@ class Dataset:
             for da in self
         ]
 
-        return Dataset(das)
+        return Dataset(das, title=self.title)
 
     def interp_na(self, axis: str = "time", **kwargs: Any) -> Dataset:
         ds = self.copy()
@@ -1183,7 +1174,12 @@ class Dataset:
                 zn[idx1, :] = self._zn
 
         return Dataset.from_numpy(
-            newdata, time=newtime, items=ds.items, geometry=ds.geometry, zn=zn
+            newdata,
+            time=newtime,
+            items=ds.items,
+            geometry=ds.geometry,
+            zn=zn,
+            title=ds.title,
         )
 
     def _check_n_items(self, other: Dataset) -> None:
@@ -1237,13 +1233,13 @@ class Dataset:
                 zn=self._zn,
             )
 
-            return Dataset([da], validate=False)
+            return Dataset([da], validate=False, title=self.title)
         else:
             res = {
                 name: da.aggregate(axis=axis, func=func, **kwargs)
                 for name, da in self._data_vars.items()
             }
-            return Dataset(data=res, validate=False)
+            return Dataset(data=res, validate=False, title=self.title)
 
     @staticmethod
     def _agg_item_from_items(items: Sequence[ItemInfo], name: str) -> ItemInfo:
@@ -1339,14 +1335,14 @@ class Dataset:
                     geometry=self.geometry,
                     zn=self._zn,
                 )
-                return Dataset([da], validate=False)
+                return Dataset([da], validate=False, title=self.title)
             else:
                 res: list[DataArray] = []
                 for quantile in q:
                     qd = self._quantile(q=quantile, axis=axis, func=func, **kwargs)[0]
                     assert isinstance(qd, DataArray)
                     res.append(qd)
-                return Dataset(data=res, validate=False)
+                return Dataset(data=res, validate=False, title=self.title)
         else:
             if np.isscalar(q):
                 res = [da._quantile(q=q, axis=axis, func=func) for da in self]
@@ -1361,7 +1357,7 @@ class Dataset:
                         qd.name = newname
                         res.append(qd)
 
-            return Dataset(data=res, validate=False)
+            return Dataset(data=res, validate=False, title=self.title)
 
     def max(self, axis: int | str = 0, **kwargs: Any) -> Dataset:
         """Max value along an axis.
@@ -1637,7 +1633,7 @@ class Dataset:
                 data = [x / y for x, y in zip(self, other)]
             case _:
                 raise ValueError(f"Unsupported operator: {operator}")
-        return Dataset(data)
+        return Dataset(data, title=self.title)
 
     def _scalar_op(self, value: float, operator: str) -> Dataset:
         match operator:
@@ -1651,7 +1647,7 @@ class Dataset:
                 data = [x / value for x in self]
             case _:
                 raise ValueError(f"Unsupported operator: {operator}")
-        return Dataset(data)
+        return Dataset(data, title=self.title)
 
     # ===============================================
 
@@ -1722,7 +1718,7 @@ class Dataset:
 
         filename = str(filename)
         # Use provided title or fall back to dataset's title
-        file_title = title if title is not None else self._title
+        file_title = title if title is not None else self.title
 
         match self.geometry:
             case (
@@ -1778,7 +1774,10 @@ class Dataset:
         if len(self) == 0:
             return "Empty <mikeio.Dataset>"
         da = self[0]
-        out = ["<mikeio.Dataset>", da._dims_txt(), da._time_txt(), da._geometry_txt()]  # type: ignore
+        out = ["<mikeio.Dataset>"]
+        if self.title:
+            out.append(f"title: {self.title}")
+        out.extend([da._dims_txt(), da._time_txt(), da._geometry_txt()])  # type: ignore
         out = [x for x in out if x is not None]
 
         if self.n_items > 10:

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -1693,19 +1693,13 @@ class Dataset:
 
         return df
 
-    def to_dfs(
-        self, filename: str | Path, title: str | None = None, **kwargs: Any
-    ) -> None:
+    def to_dfs(self, filename: str | Path, **kwargs: Any) -> None:
         """Write dataset to a new dfs file.
 
         Parameters
         ----------
         filename: str
             full path to the new dfs file
-        title: str, optional
-            title for the dfs file. When provided, this overrides the Dataset's
-            own `title` attribute for the current write operation only.
-            If omitted, the value stored in `Dataset.title` is used.
         **kwargs: Any
             additional arguments passed to the writing function, e.g. dtype for dfs0
 
@@ -1717,8 +1711,6 @@ class Dataset:
         from ..dfsu import write_dfsu
 
         filename = str(filename)
-        # Use provided title or fall back to dataset's title
-        file_title = title if title is not None else self.title
 
         match self.geometry:
             case (
@@ -1729,25 +1721,25 @@ class Dataset:
             ):
                 if self.ndim == 0 or (self.ndim == 1 and self[0]._has_time_axis):
                     self._validate_extension(filename, ".dfs0")
-                    write_dfs0(filename, self, title=file_title, **kwargs)
+                    write_dfs0(filename, self, title=self.title, **kwargs)
                 else:
                     raise ValueError("Cannot write Dataset with no geometry to file!")
 
             case Grid2D():
                 self._validate_extension(filename, ".dfs2")
-                write_dfs2(filename, self, title=file_title, **kwargs)
+                write_dfs2(filename, self, title=self.title, **kwargs)
 
             case Grid3D():
                 self._validate_extension(filename, ".dfs3")
-                write_dfs3(filename, self, title=file_title, **kwargs)
+                write_dfs3(filename, self, title=self.title, **kwargs)
 
             case Grid1D():
                 self._validate_extension(filename, ".dfs1")
-                write_dfs1(filename, self, title=file_title, **kwargs)
+                write_dfs1(filename, self, title=self.title, **kwargs)
 
             case _GeometryFM():
                 self._validate_extension(filename, ".dfsu")
-                write_dfsu(filename, self, title=file_title, **kwargs)
+                write_dfsu(filename, self, title=self.title, **kwargs)
 
             case _:
                 raise NotImplementedError(
@@ -1766,7 +1758,10 @@ class Dataset:
         import xarray
 
         data = {da.name: da.to_xarray() for da in self}
-        return xarray.Dataset(data)
+        attrs = {}
+        if self.title:
+            attrs["title"] = self.title
+        return xarray.Dataset(data, attrs=attrs)
 
     # ===============================================
 

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -94,6 +94,7 @@ class Dataset:
         self,
         data: Mapping[str, DataArray] | Sequence[DataArray],
         validate: bool = True,
+        title: str = "",
     ):
         data_vars = self._dataarrays_as_mapping(data)
 
@@ -108,6 +109,8 @@ class Dataset:
             self._set_name_attr(key, value)
         self.plot = DatasetPlotter(self)
 
+        self._title = title
+
     @staticmethod
     def from_numpy(
         data: Sequence[NDArray[np.floating]],
@@ -117,6 +120,7 @@ class Dataset:
         geometry: Any | None = None,
         zn: NDArray[np.floating] | None = None,
         validate: bool = True,
+        title: str = "",
         dt: float = 1.0,
     ) -> Dataset:
         """Create a Dataset from numpy arrays.
@@ -135,6 +139,8 @@ class Dataset:
             Z-coordinates of the DataArrays, by default None
         validate: bool, optional
             Validate the DataArrays, by default True
+        title: str, optional
+            Title of the dataset, by default ""
         dt: float, optional
             Dummy time step in seconds, by default 1.0
 
@@ -148,7 +154,7 @@ class Dataset:
             for dd, it in zip(data, item_infos)
         }
 
-        return Dataset(data_vars, validate=validate)
+        return Dataset(data_vars, validate=validate, title=title)
 
     @property
     def values(self) -> None:
@@ -220,6 +226,15 @@ class Dataset:
     # ============ end of init =============
 
     # ============= Basic properties/methods ===========
+    @property
+    def title(self) -> str:
+        """Title of the dataset, typically read from the file."""
+        return self._title
+
+    @title.setter
+    def title(self, value: str) -> None:
+        """Set the title of the dataset."""
+        self._title = value
 
     @property
     def _dt(self) -> float:
@@ -1682,13 +1697,19 @@ class Dataset:
 
         return df
 
-    def to_dfs(self, filename: str | Path, **kwargs: Any) -> None:
+    def to_dfs(
+        self, filename: str | Path, title: str | None = None, **kwargs: Any
+    ) -> None:
         """Write dataset to a new dfs file.
 
         Parameters
         ----------
         filename: str
             full path to the new dfs file
+        title: str, optional
+            title for the dfs file. When provided, this overrides the Dataset's
+            own `title` attribute for the current write operation only.
+            If omitted, the value stored in `Dataset.title` is used.
         **kwargs: Any
             additional arguments passed to the writing function, e.g. dtype for dfs0
 
@@ -1700,6 +1721,8 @@ class Dataset:
         from ..dfsu import write_dfsu
 
         filename = str(filename)
+        # Use provided title or fall back to dataset's title
+        file_title = title if title is not None else self._title
 
         match self.geometry:
             case (
@@ -1710,25 +1733,25 @@ class Dataset:
             ):
                 if self.ndim == 0 or (self.ndim == 1 and self[0]._has_time_axis):
                     self._validate_extension(filename, ".dfs0")
-                    write_dfs0(filename, self, **kwargs)
+                    write_dfs0(filename, self, title=file_title, **kwargs)
                 else:
                     raise ValueError("Cannot write Dataset with no geometry to file!")
 
             case Grid2D():
                 self._validate_extension(filename, ".dfs2")
-                write_dfs2(filename, self, **kwargs)
+                write_dfs2(filename, self, title=file_title, **kwargs)
 
             case Grid3D():
                 self._validate_extension(filename, ".dfs3")
-                write_dfs3(filename, self, **kwargs)
+                write_dfs3(filename, self, title=file_title, **kwargs)
 
             case Grid1D():
                 self._validate_extension(filename, ".dfs1")
-                write_dfs1(filename, self, **kwargs)
+                write_dfs1(filename, self, title=file_title, **kwargs)
 
             case _GeometryFM():
                 self._validate_extension(filename, ".dfsu")
-                write_dfsu(filename, self, **kwargs)
+                write_dfsu(filename, self, title=file_title, **kwargs)
 
             case _:
                 raise NotImplementedError(

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -1716,19 +1716,19 @@ class Dataset:
 
             case Grid2D():
                 self._validate_extension(filename, ".dfs2")
-                write_dfs2(filename, self)
+                write_dfs2(filename, self, **kwargs)
 
             case Grid3D():
                 self._validate_extension(filename, ".dfs3")
-                write_dfs3(filename, self)
+                write_dfs3(filename, self, **kwargs)
 
             case Grid1D():
                 self._validate_extension(filename, ".dfs1")
-                write_dfs1(filename, self)
+                write_dfs1(filename, self, **kwargs)
 
             case _GeometryFM():
                 self._validate_extension(filename, ".dfsu")
-                write_dfsu(filename, self)
+                write_dfsu(filename, self, **kwargs)
 
             case _:
                 raise NotImplementedError(

--- a/src/mikeio/dfs/_dfs0.py
+++ b/src/mikeio/dfs/_dfs0.py
@@ -191,7 +191,9 @@ class Dfs0:
             item_infos = [self.items[it] for it in item_numbers]
         else:
             item_infos = self.items
-        ds = Dataset.from_numpy(data, time=ftime, items=item_infos, validate=False)
+        ds = Dataset.from_numpy(
+            data, time=ftime, items=item_infos, title=self.title, validate=False
+        )
 
         # select time steps
         if self._timeaxistype == TimeAxisType.CalendarNonEquidistant and isinstance(

--- a/src/mikeio/dfs/_dfs0.py
+++ b/src/mikeio/dfs/_dfs0.py
@@ -103,6 +103,7 @@ class Dfs0:
 
         dfs = DfsFileFactory.DfsGenericOpen(str(path))
         self._dfs = dfs
+        self._title = dfs.FileInfo.FileTitle
 
         # Read items
         self._items = _get_item_info(dfs.ItemInfo)
@@ -303,6 +304,11 @@ class Dfs0:
             return self.read().time
         else:
             raise ValueError("Time axis type not supported")
+
+    @property
+    def title(self) -> str:
+        """File title."""
+        return self._title
 
     # ======================
     # Deprecated in 2.5.0

--- a/src/mikeio/dfs/_dfs1.py
+++ b/src/mikeio/dfs/_dfs1.py
@@ -91,6 +91,7 @@ class Dfs1(_Dfs123):
         self._x0: float = self._dfs.SpatialAxis.X0
         self._dx: float = self._dfs.SpatialAxis.Dx
         self._nx: int = self._dfs.SpatialAxis.XCount
+        self._title: str = self._dfs.FileInfo.FileTitle
 
         origin = self._longitude, self._latitude
         self._geometry = Grid1D(
@@ -200,3 +201,8 @@ class Dfs1(_Dfs123):
     def nx(self) -> int:
         """Number of node values."""
         return self._nx
+
+    @property
+    def title(self) -> str:
+        """Title of the dfs1 file."""
+        return self._title

--- a/src/mikeio/dfs/_dfs1.py
+++ b/src/mikeio/dfs/_dfs1.py
@@ -178,6 +178,7 @@ class Dfs1(_Dfs123):
             time=time,
             items=items,
             geometry=self.geometry,
+            title=self.title,
             validate=False,
             dt=self._timestep,
         )

--- a/src/mikeio/dfs/_dfs2.py
+++ b/src/mikeio/dfs/_dfs2.py
@@ -244,6 +244,7 @@ class Dfs2(_Dfs123):
             time=time,
             items=items,
             geometry=geometry,
+            title=self.title,
             validate=False,
         )
 

--- a/src/mikeio/dfs/_dfs2.py
+++ b/src/mikeio/dfs/_dfs2.py
@@ -151,6 +151,9 @@ class Dfs2(_Dfs123):
             is_spectral=is_spectral,
             is_vertical=is_vertical,
         )
+
+        self._title = dfs.FileInfo.FileTitle
+
         dfs.Close()
         self._validate_no_orientation_in_geo()
 
@@ -319,3 +322,8 @@ class Dfs2(_Dfs123):
     def ny(self) -> int:
         """Number of values in the y-direction."""
         return self.geometry.ny
+
+    @property
+    def title(self) -> str:
+        """Title of the dfs2 file."""
+        return self._title

--- a/src/mikeio/dfs/_dfs3.py
+++ b/src/mikeio/dfs/_dfs3.py
@@ -269,6 +269,7 @@ class Dfs3(_Dfs123):
             time=time,
             items=items,
             geometry=geometry,
+            title=self.title,
             validate=False,
         )
 

--- a/src/mikeio/dfs/_dfs3.py
+++ b/src/mikeio/dfs/_dfs3.py
@@ -153,6 +153,7 @@ class Dfs3(_Dfs123):
         self._nx = self._dfs.SpatialAxis.XCount
         self._ny = self._dfs.SpatialAxis.YCount
         self._nz = self._dfs.SpatialAxis.ZCount
+        self._title = self._dfs.FileInfo.FileTitle
 
     def read(
         self,
@@ -334,3 +335,8 @@ class Dfs3(_Dfs123):
     @property
     def shape(self) -> tuple[int, int, int, int]:
         return (self._n_timesteps, self._nz, self._ny, self._nx)
+
+    @property
+    def title(self) -> str:
+        """Title of the dfs3 file."""
+        return self._title

--- a/src/mikeio/dfsu/_dfsu.py
+++ b/src/mikeio/dfsu/_dfsu.py
@@ -498,6 +498,7 @@ class Dfsu2DH:
             time=time,
             items=item_infos,
             geometry=geometry,
+            title=self.title,
             validate=False,
             dt=self.timestep,
         )

--- a/src/mikeio/dfsu/_layered.py
+++ b/src/mikeio/dfsu/_layered.py
@@ -52,6 +52,7 @@ class DfsuLayered:
         self._start_time = info.start_time
         self._timestep = info.timestep
         self._n_timesteps = info.n_timesteps
+        self._title = info.title
         self._geometry = self._read_geometry(self._filename)
         # 3d files have a zn item
         self._items = self._read_items(self._filename)
@@ -137,6 +138,11 @@ class DfsuLayered:
             raise NotImplementedError(
                 "Non-equidistant time axis. Read the data to get time."
             )
+
+    @property
+    def title(self) -> str:
+        """File title."""
+        return self._title
 
     @property
     def geometry(self) -> GeometryFM3D | GeometryFMVerticalProfile:

--- a/src/mikeio/dfsu/_layered.py
+++ b/src/mikeio/dfsu/_layered.py
@@ -448,6 +448,7 @@ class DfsuLayered:
                 items=items,
                 geometry=geometry,
                 zn=data_list[0],
+                title=self.title,
                 validate=False,
                 dt=self.timestep,
             )
@@ -457,6 +458,7 @@ class DfsuLayered:
                 time=time,
                 items=items,
                 geometry=geometry,
+                title=self.title,
                 validate=False,
                 dt=self.timestep,
             )

--- a/src/mikeio/dfsu/_spectral.py
+++ b/src/mikeio/dfsu/_spectral.py
@@ -46,6 +46,7 @@ class DfsuSpectral:
         self._start_time = info.start_time
         self._timestep = info.timestep
         self._n_timesteps = info.n_timesteps
+        self._title = info.title
         self._items = info.items
         self._geometry = self._read_geometry(self._filename)
 
@@ -136,6 +137,11 @@ class DfsuSpectral:
             raise NotImplementedError(
                 "Non-equidistant time axis. Read the data to get time."
             )
+
+    @property
+    def title(self) -> str:
+        """File title."""
+        return self._title
 
     @staticmethod
     def _read_geometry(

--- a/src/mikeio/dfsu/_spectral.py
+++ b/src/mikeio/dfsu/_spectral.py
@@ -398,6 +398,7 @@ class DfsuSpectral:
             time=time,
             items=items,
             geometry=geometry,
+            title=self.title,
             validate=False,
         )
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1427,3 +1427,114 @@ def test_safe_name() -> None:
     bad_name = "MSLP., 1:st level\n 2nd chain"
     safe_name = "MSLP_1_st_level_2nd_chain"
     assert _to_safe_name(bad_name) == safe_name
+
+
+# === Title propagation tests ===
+
+
+@pytest.fixture
+def titled_ds() -> Dataset:
+    nt = 10
+    ne = 7
+    d1 = np.zeros([nt, ne]) + 0.1
+    d2 = np.zeros([nt, ne]) + 0.2
+    data = [d1, d2]
+    time = pd.date_range(start=datetime(2000, 1, 1), freq="s", periods=nt)
+    items = [ItemInfo("Foo"), ItemInfo("Bar")]
+    return Dataset.from_numpy(
+        data=data,
+        time=time,
+        items=items,
+        geometry=mikeio.Grid1D(nx=7, dx=1),
+        title="Test Title",
+    )
+
+
+def test_title_default_empty() -> None:
+    ds = Dataset.from_numpy(
+        data=[np.zeros(5)],
+        time=pd.date_range("2000", periods=5, freq="s"),
+        items=[ItemInfo("X")],
+    )
+    assert ds.title == ""
+
+
+def test_title_property(titled_ds: Dataset) -> None:
+    assert titled_ds.title == "Test Title"
+    titled_ds.title = "New Title"
+    assert titled_ds.title == "New Title"
+
+
+def test_title_preserved_isel(titled_ds: Dataset) -> None:
+    assert titled_ds.isel(time=0).title == "Test Title"
+    assert titled_ds.isel(time=slice(0, 3)).title == "Test Title"
+    assert titled_ds.isel(x=0).title == "Test Title"
+
+
+def test_title_preserved_sel(titled_ds: Dataset) -> None:
+    assert titled_ds.sel(time=titled_ds.time[0]).title == "Test Title"
+
+
+def test_title_preserved_squeeze(titled_ds: Dataset) -> None:
+    ds = titled_ds.isel(x=0)
+    assert ds.squeeze().title == "Test Title"
+
+
+def test_title_preserved_fillna(titled_ds: Dataset) -> None:
+    assert titled_ds.fillna(0.0).title == "Test Title"
+
+
+def test_title_preserved_dropna(titled_ds: Dataset) -> None:
+    assert titled_ds.dropna().title == "Test Title"
+
+
+def test_title_preserved_interp_time(titled_ds: Dataset) -> None:
+    assert titled_ds.interp_time(dt=2).title == "Test Title"
+
+
+def test_title_preserved_aggregate(titled_ds: Dataset) -> None:
+    assert titled_ds.aggregate(axis="time").title == "Test Title"
+    assert titled_ds.aggregate(axis="items").title == "Test Title"
+
+
+def test_title_preserved_concat(titled_ds: Dataset) -> None:
+    ds2 = titled_ds.copy()
+    ds2.time = pd.date_range(start=datetime(2000, 1, 2), freq="s", periods=10)
+    result = Dataset.concat([titled_ds, ds2])
+    assert result.title == "Test Title"
+
+
+def test_title_preserved_merge(titled_ds: Dataset) -> None:
+    ds_a = titled_ds[["Foo"]]
+    ds_b = titled_ds[["Bar"]]
+    result = Dataset.merge([ds_a, ds_b])
+    assert result.title == "Test Title"
+
+
+def test_title_preserved_arithmetic(titled_ds: Dataset) -> None:
+    assert (titled_ds + 1).title == "Test Title"
+    assert (titled_ds * 2).title == "Test Title"
+    assert (titled_ds - titled_ds).title == "Test Title"
+
+
+def test_title_preserved_getitem(titled_ds: Dataset) -> None:
+    assert titled_ds[["Foo"]].title == "Test Title"
+    assert titled_ds[["Foo", "Bar"]].title == "Test Title"
+
+
+def test_title_preserved_copy(titled_ds: Dataset) -> None:
+    assert titled_ds.copy().title == "Test Title"
+
+
+def test_title_in_repr(titled_ds: Dataset) -> None:
+    r = repr(titled_ds)
+    assert "title: Test Title" in r
+
+
+def test_title_not_in_repr_when_empty() -> None:
+    ds = Dataset.from_numpy(
+        data=[np.zeros(5)],
+        time=pd.date_range("2000", periods=5, freq="s"),
+        items=[ItemInfo("X")],
+    )
+    assert "title:" not in repr(ds)

--- a/tests/test_dfs0.py
+++ b/tests/test_dfs0.py
@@ -121,6 +121,15 @@ def test_read_with_title() -> None:
     assert dfs.title == "Diagnostic"
 
 
+def test_write_read_with_title(tmp_path: Path) -> None:
+    tmpfile = tmp_path / "tmp_title.dfs0"
+    dfs = Dfs0("tests/testdata/da_diagnostic.dfs0")
+    ds = dfs.read()
+    ds.to_dfs(tmpfile)
+    dfs2 = mikeio.Dfs0(tmpfile)
+    assert dfs.title == dfs2.title
+
+
 def test_items_dataframe() -> None:
     dfs = mikeio.Dfs0("tests/testdata/random.dfs0")
     df = dfs.items.to_dataframe()

--- a/tests/test_dfs0.py
+++ b/tests/test_dfs0.py
@@ -130,6 +130,16 @@ def test_write_read_with_title(tmp_path: Path) -> None:
     assert dfs.title == dfs2.title
 
 
+def test_write_read_with_empty_title(tmp_path: Path) -> None:
+    tmpfile = tmp_path / "tmp_empty_title.dfs0"
+    dfs = Dfs0("tests/testdata/da_diagnostic.dfs0")
+    ds = dfs.read()
+    # test that empty string overwrites title
+    ds.to_dfs(tmpfile, title="")
+    dfs3 = mikeio.Dfs0(tmpfile)
+    assert dfs3.title == ""
+
+
 def test_items_dataframe() -> None:
     dfs = mikeio.Dfs0("tests/testdata/random.dfs0")
     df = dfs.items.to_dataframe()

--- a/tests/test_dfs0.py
+++ b/tests/test_dfs0.py
@@ -72,6 +72,22 @@ def test_write_int_not_possible(tmp_path: Path) -> None:
         da.to_dfs(fp, dtype=np.int32)
 
 
+def test_write_with_title(tmp_path: Path) -> None:
+    fp = tmp_path / "simple_with_title.dfs0"
+
+    nt = 100
+
+    da = mikeio.DataArray(
+        data=np.random.random([nt]).astype(np.float32),
+        time=pd.date_range("2000", periods=nt, freq="h"),
+    )
+
+    da.to_dfs(fp, title="My DFS0 file")
+
+    dfs = mikeio.Dfs0(fp)
+    assert dfs.title == "My DFS0 file"
+
+
 def test_read_units_write_new(tmp_path: Path) -> None:
     fp = tmp_path / "random.dfs0"
 
@@ -98,6 +114,11 @@ def test_read_all_time_steps_without_reading_data() -> None:
     dfs = mikeio.Dfs0("tests/testdata/random.dfs0")
     assert isinstance(dfs.time, pd.DatetimeIndex)
     assert len(dfs.time) == 1000
+
+
+def test_read_with_title() -> None:
+    dfs = mikeio.Dfs0("tests/testdata/da_diagnostic.dfs0")
+    assert dfs.title == "Diagnostic"
 
 
 def test_items_dataframe() -> None:

--- a/tests/test_dfs0.py
+++ b/tests/test_dfs0.py
@@ -82,7 +82,9 @@ def test_write_with_title(tmp_path: Path) -> None:
         time=pd.date_range("2000", periods=nt, freq="h"),
     )
 
-    da.to_dfs(fp, title="My DFS0 file")
+    ds = da._to_dataset()
+    ds.title = "My DFS0 file"
+    ds.to_dfs(fp)
 
     dfs = mikeio.Dfs0(fp)
     assert dfs.title == "My DFS0 file"
@@ -135,7 +137,8 @@ def test_write_read_with_empty_title(tmp_path: Path) -> None:
     dfs = Dfs0("tests/testdata/da_diagnostic.dfs0")
     ds = dfs.read()
     # test that empty string overwrites title
-    ds.to_dfs(tmpfile, title="")
+    ds.title = ""
+    ds.to_dfs(tmpfile)
     dfs3 = mikeio.Dfs0(tmpfile)
     assert dfs3.title == ""
 

--- a/tests/test_dfs1.py
+++ b/tests/test_dfs1.py
@@ -52,6 +52,11 @@ def test_read_write_properties(tmp_path: Path) -> None:
     assert ds1.geometry == ds2.geometry
 
 
+def test_read_with_title() -> None:
+    dfs = mikeio.Dfs1("tests/testdata/tide1.dfs1")
+    assert dfs.title == "Predicted tide level"
+
+
 def test_read() -> None:
     dfs = mikeio.Dfs1("tests/testdata/random.dfs1")
 
@@ -90,6 +95,24 @@ def test_write_some_time_steps_new_file(tmp_path: Path) -> None:
     dsnew = dfsnew.read()
 
     assert dsnew["testing water level"].shape == (6, 3)
+
+
+def test_write_with_title(tmp_path: Path) -> None:
+    """Test writing a dfsu file with a custom title and reading it back."""
+    sourcefilename = "tests/testdata/tide1.dfs1"
+    fp = tmp_path / "with_title.dfs1"
+
+    # Read source file
+    dfs = mikeio.Dfs1(sourcefilename)
+    ds = dfs.read(items=[0])
+
+    # Write with custom title
+    custom_title = "Test DFS1 with Custom Title"
+    ds.to_dfs(fp, title=custom_title)
+
+    # Read back and verify title
+    newdfs = mikeio.Dfs1(fp)
+    assert newdfs.title == custom_title
 
 
 def test_read_item_names_not_in_dataset_fails() -> None:

--- a/tests/test_dfs1.py
+++ b/tests/test_dfs1.py
@@ -57,6 +57,15 @@ def test_read_with_title() -> None:
     assert dfs.title == "Predicted tide level"
 
 
+def test_write_read_with_title(tmp_path: Path) -> None:
+    tmpfile = tmp_path / "tmp_title.dfs1"
+    dfs = mikeio.Dfs1("tests/testdata/tide1.dfs1")
+    ds = dfs.read()
+    ds.to_dfs(tmpfile)
+    dfs_tmp = mikeio.Dfs1(tmpfile)
+    assert dfs.title == dfs_tmp.title
+
+
 def test_read() -> None:
     dfs = mikeio.Dfs1("tests/testdata/random.dfs1")
 

--- a/tests/test_dfs1.py
+++ b/tests/test_dfs1.py
@@ -117,7 +117,8 @@ def test_write_with_title(tmp_path: Path) -> None:
 
     # Write with custom title
     custom_title = "Test DFS1 with Custom Title"
-    ds.to_dfs(fp, title=custom_title)
+    ds.title = custom_title
+    ds.to_dfs(fp)
 
     # Read back and verify title
     newdfs = mikeio.Dfs1(fp)

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -164,6 +164,24 @@ def test_write_without_time(tmp_path: Path) -> None:
     assert ds.shape == (ny, nx)
 
 
+def test_write_with_title(tmp_path: Path) -> None:
+    """Test writing a dfsu file with a custom title and reading it back."""
+    sourcefilename = "tests/testdata/random.dfs2"
+    fp = tmp_path / "with_title.dfs2"
+
+    # Read source file
+    dfs = mikeio.Dfs2(sourcefilename)
+    ds = dfs.read(items=[0])
+
+    # Write with custom title
+    custom_title = "Test DFS2 with Custom Title"
+    ds.to_dfs(fp, title=custom_title)
+
+    # Read back and verify title
+    newdfs = mikeio.Dfs2(fp)
+    assert newdfs.title == custom_title
+
+
 def test_read(dfs2_random: Dfs2) -> None:
     dfs = dfs2_random
     assert isinstance(dfs.geometry, Grid2D)
@@ -172,6 +190,13 @@ def test_read(dfs2_random: Dfs2) -> None:
     assert data[0, 88, 0] == 0
     assert np.isnan(data[0, 89, 0])
     assert data.shape == (3, 100, 2)  # time, y, x
+
+
+def test_read_with_title() -> None:
+    sourcefilename = "tests/testdata/random.dfs2"
+    dfs = mikeio.Dfs2(sourcefilename)
+    assert hasattr(dfs, "title")
+    assert isinstance(dfs.title, str)
 
 
 def test_read_bad_item(dfs2_random: Dfs2) -> None:

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -175,7 +175,8 @@ def test_write_with_title(tmp_path: Path) -> None:
 
     # Write with custom title
     custom_title = "Test DFS2 with Custom Title"
-    ds.to_dfs(fp, title=custom_title)
+    ds.title = custom_title
+    ds.to_dfs(fp)
 
     # Read back and verify title
     newdfs = mikeio.Dfs2(fp)

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -199,6 +199,15 @@ def test_read_with_title() -> None:
     assert isinstance(dfs.title, str)
 
 
+def test_write_read_with_title(tmp_path: Path) -> None:
+    tmpfile = tmp_path / "tmp_title.dfs2"
+    dfs = mikeio.Dfs2("tests/testdata/random.dfs2")
+    ds = dfs.read()
+    ds.to_dfs(tmpfile)
+    dfs_tmp = mikeio.Dfs2(tmpfile)
+    assert dfs.title == dfs_tmp.title
+
+
 def test_read_bad_item(dfs2_random: Dfs2) -> None:
     dfs = dfs2_random
     with pytest.raises(ItemsError) as ex:

--- a/tests/test_dfs3.py
+++ b/tests/test_dfs3.py
@@ -65,6 +65,15 @@ def test_dfs3_read_time() -> None:
     assert isinstance(ds.geometry, Grid3D)
 
 
+def test_write_read_with_title(tmp_path: Path) -> None:
+    tmpfile = tmp_path / "tmp_title.dfs3"
+    dfs = mikeio.Dfs3("tests/testdata/test_dfs3.dfs3")
+    ds = dfs.read()
+    ds.to_dfs(tmpfile)
+    dfs_tmp = mikeio.Dfs3(tmpfile)
+    assert dfs.title == dfs_tmp.title
+
+
 def test_dfs3_read_1_layer() -> None:
     fn = "tests/testdata/test_dfs3.dfs3"
     ds = mikeio.read(fn, layers=-1)

--- a/tests/test_dfs3.py
+++ b/tests/test_dfs3.py
@@ -304,7 +304,8 @@ def test_write_with_title(tmp_path: Path) -> None:
 
     # Write with custom title
     custom_title = "Test DFS3 with Custom Title"
-    ds.to_dfs(fp, title=custom_title)
+    ds.title = custom_title
+    ds.to_dfs(fp)
 
     # Read back and verify title
     newdfs = mikeio.Dfs3(fp)

--- a/tests/test_dfs3.py
+++ b/tests/test_dfs3.py
@@ -276,3 +276,27 @@ def test_append_dfs3(tmp_path: Path) -> None:
     dfs = mikeio.Dfs3(new_fp)
 
     dfs.append(ds2)
+
+
+def test_read_with_title() -> None:
+    sourcefilename = "tests/testdata/single_layer.dfs3"
+    dfs = mikeio.Dfs3(sourcefilename)
+    assert hasattr(dfs, "title")
+    assert isinstance(dfs.title, str)
+
+
+def test_write_with_title(tmp_path: Path) -> None:
+    sourcefilename = "tests/testdata/single_layer.dfs3"
+    fp = tmp_path / "with_title.dfs3"
+
+    # Read source file
+    dfs = mikeio.Dfs3(sourcefilename)
+    ds = dfs.read(items=[0], keepdims=True)
+
+    # Write with custom title
+    custom_title = "Test DFS3 with Custom Title"
+    ds.to_dfs(fp, title=custom_title)
+
+    # Read back and verify title
+    newdfs = mikeio.Dfs3(fp)
+    assert newdfs.title == custom_title

--- a/tests/test_dfsu2dh.py
+++ b/tests/test_dfsu2dh.py
@@ -1042,15 +1042,13 @@ def test_write_dfsu_with_title(tmp_path: Path) -> None:
     sourcefilename = "tests/testdata/HD2D.dfsu"
     fp = tmp_path / "with_title.dfsu"
 
-    # Read source file
     dfs = mikeio.Dfsu2DH(sourcefilename)
     ds = dfs.read(items=[0])
 
-    # Write with custom title
     custom_title = "Test DFSU with Custom Title"
-    ds.to_dfs(fp, title=custom_title)
+    ds.title = custom_title
+    ds.to_dfs(fp)
 
-    # Read back and verify title
     newdfs = mikeio.Dfsu2DH(fp)
     assert newdfs.title == custom_title
 

--- a/tests/test_dfsu2dh.py
+++ b/tests/test_dfsu2dh.py
@@ -1035,3 +1035,31 @@ def test_dfsu_to_xarray_has_element_coordinates() -> None:
     assert xr_da.x.values[example_quad_element] == approx(example_quad_coordinates[0])
     assert xr_da.y.values[example_quad_element] == approx(example_quad_coordinates[1])
     assert xr_da.z.values[example_quad_element] == approx(example_quad_coordinates[2])
+
+
+def test_write_dfsu_with_title(tmp_path: Path) -> None:
+    """Test writing a dfsu file with a custom title and reading it back."""
+    sourcefilename = "tests/testdata/HD2D.dfsu"
+    fp = tmp_path / "with_title.dfsu"
+
+    # Read source file
+    dfs = mikeio.Dfsu2DH(sourcefilename)
+    ds = dfs.read(items=[0])
+
+    # Write with custom title
+    custom_title = "Test DFSU with Custom Title"
+    ds.to_dfs(fp, title=custom_title)
+
+    # Read back and verify title
+    newdfs = mikeio.Dfsu2DH(fp)
+    assert newdfs.title == custom_title
+
+
+def test_read_dfsu_title(tmp_path: Path) -> None:
+    """Test reading the title from an existing dfsu file."""
+    sourcefilename = "tests/testdata/HD2D.dfsu"
+    dfs = mikeio.Dfsu2DH(sourcefilename)
+
+    # Dfsu files should have a title property
+    assert hasattr(dfs, "title")
+    assert isinstance(dfs.title, str)

--- a/tests/test_dfsu3d.py
+++ b/tests/test_dfsu3d.py
@@ -45,6 +45,15 @@ def test_read_simple_2dv() -> None:
     assert ds.items[2].name == "W velocity"
 
 
+def test_write_read_with_title(tmp_path: Path) -> None:
+    tmpfile = tmp_path / "tmp_title.dfsu"
+    dfs = mikeio.Dfsu3D("tests/testdata/oresund_sigma_z.dfsu")
+    ds = dfs.read()
+    ds.to_dfs(tmpfile)
+    dfs_tmp = mikeio.Dfsu3D(tmpfile)
+    assert dfs.title == dfs_tmp.title
+
+
 def test_read_returns_correct_items_sigma_z() -> None:
     filename = "tests/testdata/oresund_sigma_z.dfsu"
     dfs = mikeio.Dfsu3D(filename)


### PR DESCRIPTION
DFS files have a title metadata field displayed in [MIKE Zero](https://www.dhigroup.com/technologies/mikepoweredbydhi/mike-zero). Previously this was ignored on read and lost on write. Resolves user request for title preservation through processing pipelines.

- `Dataset.title` attribute, preserved through all operations (sel, isel, aggregation, arithmetic, concat, merge, etc.)
- `title` property on all file readers (Dfs0–Dfs3, Dfsu2DH, DfsuLayered, DfsuSpectral)
- `to_dfs()` writes `Dataset.title` to the file
- `to_xarray()` propagates title as an `attrs["title"]`

```python
ds = mikeio.read("file.dfs0")
ds.title  # read from file
ds.title = "My Title"
ds.to_dfs("output.dfs0")  # written to file
```