### PR TITLE
Add scheduled test workflow

### DIFF
--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 5 */3 * *'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Runs every 3 days on Ubuntu (3.10, 3.14) and Windows (3.10, 3.13).