### PR TITLE
Inline Cartography creation in Grid2D

### DIFF
--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -1320,7 +1320,10 @@ class Grid3D(_Geometry):
             if self._is_rotated:
                 # rotated => most be projected
                 cart = Cartography.CreateProjOrigin(
-                    self.projection, *self.origin, self.orientation
+                    projectionString=self.projection,
+                    east=self.origin[0],
+                    north=self.origin[1],
+                    orientationProj=self.orientation,
                 )
                 origin = cart.Xy2Proj(ii[0], jj[0])
             else:


### PR DESCRIPTION
- Inline `Cartography` creation in `_index_to_Grid2D` and remove the `_cart` property
- Remove stale TODO comments in unreachable code path

Following Ousterhout's "A Philosophy of Software Design" - the `_cart` property was a shallow abstraction used in only one place. Inlining removes unnecessary indirection without losing clarity.