### PR TITLE
Add DHI branding to documentation

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,3 @@
 /.quarto/
+
+**/*.quarto_ipynb

--- a/docs/_brand.yml
+++ b/docs/_brand.yml
@@ -1,0 +1,28 @@
+meta:
+  name: DHI
+
+color:
+  palette:
+    blue: "#2146A4"
+    dark-blue: "#1C3A86"
+    light-blue: "#456FD9"
+    coral: "#FD6341"
+    near-black: "#1B1B22"
+    off-white: "#F4F4F6"
+  foreground: near-black
+  background: "#FFFFFF"
+  primary: blue
+  secondary: coral
+  light: off-white
+  dark: near-black
+
+typography:
+  headings:
+    weight: 600
+    color: near-black
+
+defaults:
+  bootstrap:
+    defaults:
+      navbar-bg: "#2146A4"
+      navbar-fg: "#FFFFFF"

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -3,7 +3,7 @@ project:
 
 website:
   title: "MIKE IO"
-  page-footer: "© 2025 DHI Group"
+  page-footer: "© 2026 DHI Group"
   favicon: dhi.ico
   repo-url: https://github.com/DHI/mikeio
   repo-actions: [edit]
@@ -162,7 +162,8 @@ quartodoc:
 format:
   html:
     theme: cosmo
+    brand: _brand.yml
     toc: true
-  ipynb: 
+  ipynb:
     theme: cosmo
     toc: true


### PR DESCRIPTION
## Summary

- Add `_brand.yml` with DHI corporate colors (blue `#2146A4`, coral accent `#FD6341`) and navbar styling
- Configure Quarto to use brand file for consistent visual identity