### PR TITLE
Improve temporal selection docs and fix typos

### DIFF
--- a/docs/user-guide/dataarray.qmd
+++ b/docs/user-guide/dataarray.qmd
@@ -8,7 +8,7 @@ The [DataArray](`mikeio.DataArray`) is the common MIKE IO data structure
 for *item* data from dfs files. 
 The [](`mikeio.read`) methods returns a Dataset as a container of DataArrays (Dfs items)
 
-Each DataArray have the following properties:
+Each DataArray has the following properties:
 
 * **item** - an  [](`mikeio.ItemInfo`) with name, type and unit
 * **time** - a [](`pandas.DatetimeIndex`) with the time instances of the data
@@ -29,24 +29,35 @@ da
 
 ## {{< fa calendar >}} Temporal selection
 
-A time slice of a DataArray can be selected in several different ways. 
+A time slice of a DataArray can be selected with `sel` (by label/value) or `isel` (by integer index), similar to [xarray](https://docs.xarray.dev/en/stable/user-guide/indexing.html).
+
+Select a single timestep by value:
 
 ```{python}
 da.sel(time="1985-08-06 12:00")
 ```
 
+Select a range of timesteps by value:
+
 ```{python}
 da.sel(time=slice("1985-08-06 12:00", "1985-08-06 17:00"))
 ```
+
+Select a single timestep by index:
 
 ```{python}
 da.isel(time=2)
 ```
 
+Select every other timestep using a slice:
+
 ```{python}
-da.isel(time=range(2, ds.n_timesteps, 2))
+da.isel(time=slice(None, None, 2))
 ```
 
+::: {.callout-tip}
+To extract every n'th timestep directly to a new file without loading all data into memory, use [`mikeio.generic.extract`](`mikeio.generic.extract`) with the `step` parameter.
+:::
 
 ## {{< fa map >}} Spatial selection
              
@@ -137,14 +148,14 @@ including different ways of *selecting* data:
 * [`quantile()`](`mikeio.DataArray.quantile`) - Quantiles along an axis
 
 ## {{< fa calculator >}} Mathematical operations
-* ds + value
-* ds - value
-* ds * value
+* da + value
+* da - value
+* da * value
 
 and + and - between two DataArrays (if number of items and shapes conform):
 
-* ds1 + ds2
-* ds1 - ds2
+* da1 + da2
+* da1 - da2
 
 ## Multiply or add scalar
 
@@ -169,7 +180,7 @@ da1_C.values.mean(), da1_D.values.mean()
 
 ## Difference between two DataArrays
 
-Assume that we have two calibration runs and we wan't to find the difference...
+Assume that we have two calibration runs and we want to find the difference...
 
 ```{python}
 da_diff = da1-da2
@@ -189,7 +200,7 @@ Multiplication and divison of two physical quantities would normally change the 
 
 Other methods that also return a DataArray:
 
-* [`interp_like`](`mikeio.DataArray.interp_like`) - Spatio (temporal) interpolation (see example [Dfsu interpolation](../examples/dfsu/spatial_interpolation.qmd)
+* [`interp_like`](`mikeio.DataArray.interp_like`) - Spatio (temporal) interpolation (see example [Dfsu interpolation](../examples/dfsu/spatial_interpolation.qmd))
 * [`interp_time()`](`mikeio.DataArray.interp_time`) - Temporal interpolation (see example [Time interpolation](../examples/Time-interpolation.qmd))
 * [`dropna()`](`mikeio.DataArray.dropna`) - Remove time steps where all items are NaN
 * [`fillna()`](`mikeio.DataArray.fillna`) - Fill missing values with a constant value

--- a/docs/user-guide/dataset.qmd
+++ b/docs/user-guide/dataset.qmd
@@ -51,25 +51,35 @@ Note that this behavior is similar to pandas and xarray.
 
 ## {{< fa calendar >}} Temporal selection
 
-A time slice of a Dataset can be selected in several different ways. 
+A time slice of a Dataset can be selected with `sel` (by label/value) or `isel` (by integer index), similar to [xarray](https://docs.xarray.dev/en/stable/user-guide/indexing.html).
+
+Select a single timestep by value:
 
 ```{python}
 ds.sel(time="1985-08-06 12:00")
 ```
 
+Select a range of timesteps by value:
+
 ```{python}
 ds.sel(time=slice("1985-08-06 12:00", "1985-08-06 17:00"))
 ```
+
+Select a single timestep by index:
 
 ```{python}
 ds.isel(time=2)
 ```
 
+Select every other timestep using a slice:
+
 ```{python}
-ds.isel(time=range(2, ds.n_timesteps, 2))
+ds.isel(time=slice(None, None, 2))
 ```
 
-
+::: {.callout-tip}
+To extract every n'th timestep directly to a new file without loading all data into memory, use [`mikeio.generic.extract`](`mikeio.generic.extract`) with the `step` parameter.
+:::
 
 
 ## {{< fa map >}} Spatial selection
@@ -83,7 +93,7 @@ ds.sel(x=607002, y=6906734)
 
 ## {{< fa chart-line >}} Plotting
 
-In most cases, you will *not* plot the Dataset, but rather it's DataArrays. But there are two exceptions: 
+In most cases, you will *not* plot the Dataset, but rather its DataArrays. But there are two exceptions: 
 
 * dfs0-Dataset : plot all items as timeseries with ds.plot()
 * scatter : compare two items using ds.plot.scatter(x="itemA", y="itemB")
@@ -186,7 +196,7 @@ and between two Datasets (if number of items and shapes conform):
 
 Other methods that also return a Dataset:
 
-* [`interp_like`](`mikeio.Dataset.interp_like`) - Spatio (temporal) interpolation (see [Dfsu interpolation notebook](../examples/dfsu/spatial_interpolation.qmd)
+* [`interp_like`](`mikeio.Dataset.interp_like`) - Spatio (temporal) interpolation (see [Dfsu interpolation notebook](../examples/dfsu/spatial_interpolation.qmd))
 * [`interp_time()`](`mikeio.Dataset.interp_time`) - Temporal interpolation (see [Time interpolation notebook](../examples/Time-interpolation.qmd))
 * [`dropna()`](`mikeio.Dataset.dropna`) - Remove time steps where all items are NaN
 * [`fillna()`](`mikeio.Dataset.fillna`) - Fill missing values with a constant value

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -246,6 +246,17 @@ def test_select_temporal_subset_by_idx() -> None:
     assert selds["Foo"].shape == (3, 100, 30)
 
 
+def test_isel_time_every_other_timestep() -> None:
+    nt = 10
+    time = pd.date_range(start=datetime(2000, 1, 1), freq="h", periods=nt)
+    ds = mikeio.Dataset.from_numpy(
+        data=[np.arange(nt, dtype=float)], time=time, items=[ItemInfo("Foo")]
+    )
+
+    assert ds.isel(time=range(0, nt, 2)).n_timesteps == 5
+    assert ds.isel(time=slice(None, None, 2)).n_timesteps == 5
+
+
 def test_temporal_subset_fancy() -> None:
     # TODO use .sel(time=...) instead, more explicit
     nt = (24 * 31) + 1


### PR DESCRIPTION
Replace `range(2, ds.n_timesteps, 2)` with `slice(None, None, 2)` in isel examples, add explanatory text for each temporal selection method, add callout linking to `mikeio.generic.extract` for file-level timestep extraction, and fix misc typos.

### For reviewer
The temporal selection examples use `sel`/`isel` with the same syntax as xarray. Are the examples clear enough for someone familiar with xarray, and does the link to xarray's indexing docs provide sufficient context for those who aren't?