### PR TITLE
Fix quoted strings parsed as floats in PFS

### DIFF
--- a/src/mikeio/pfs/_pfssection.py
+++ b/src/mikeio/pfs/_pfssection.py
@@ -122,26 +122,10 @@ class PfsSection(SimpleNamespace, MutableMapping[str, Any]):
                             d = v.copy() if copy else v
                             sections.append(PfsSection(d))
                         case _:
-                            sections.append(self._parse_value(v))
+                            sections.append(v)
                 self.__setattr__(key, sections)
             case _:
-                self.__setattr__(key, self._parse_value(value))
-
-    def _parse_value(self, v: Any) -> Any:
-        if isinstance(v, str) and self._str_is_scientific_float(v):
-            return float(v)
-        return v
-
-    @staticmethod
-    def _str_is_scientific_float(s: str) -> bool:
-        """True: -1.0e2, 1E-4, -0.1E+0.5; False: E12, E-4."""
-        if len(s) < 3 or s.lower().startswith("e"):
-            return False
-        try:
-            float(s)
-            return "e" in s.lower()
-        except ValueError:
-            return False
+                self.__setattr__(key, value)
 
     def pop(self, key: Any, default: Any = None) -> Any:
         """If key is in the dictionary, remove it and return its

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -276,18 +276,6 @@ def test_pfssection_write(d1, tmp_path: Path) -> None:
     assert pfs2.root.key1 == sct.key1
 
 
-def test_str_is_scientific_float(d1) -> None:
-    sect = mikeio.PfsSection(d1)  # dummy
-    func = sect._str_is_scientific_float
-    assert func("-1.0e2")
-    assert func("1E-4")
-    assert func("-0.123213e-23")
-    assert not func("-0.1E+0.5")
-    assert not func("E12")
-    assert not func("E-4")
-    assert not func("-1.0e2e")
-    assert not func("e-1.0e2")
-
 
 def test_basic() -> None:
     pfs = mikeio.PfsDocument("tests/testdata/pfs/simple.pfs")
@@ -879,14 +867,14 @@ def test_floatlike_strings(tmp_path: Path) -> None:
     EndSect  // WELLNO_424
 """
     pfs = mikeio.PfsDocument.from_text(text)
-    # assert pfs.WELLNO_424.ID_A == "1E-3"  # not possible to distinguish
+    assert pfs.WELLNO_424.ID_A == "1E-3"
     assert pfs.WELLNO_424.ID_B == "1-E"
     assert pfs.WELLNO_424.ID_C == "1-E3"
 
     filename = tmp_path / "float_like_strings.pfs"
     pfs.write(filename)
     pfs = mikeio.read_pfs(filename)
-    # assert pfs.WELLNO_424.ID_A == "1E-3"  # not possible to distinguish
+    assert pfs.WELLNO_424.ID_A == "1E-3"
     assert pfs.WELLNO_424.ID_B == "1-E"
     assert pfs.WELLNO_424.ID_C == "1-E3"
 


### PR DESCRIPTION
- Quoted PFS values like `'1E-3'` were incorrectly converted to float `0.001`
- Root cause: `PfsSection._parse_value()` re-converted strings that the parser had intentionally kept as strings
- This method was originally needed for an older parser that didn't do type conversion, but became redundant (and harmful) when the parser was rewritten

Fixes #481