### PR TITLE
Add product roadmap

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -18,14 +18,19 @@ For questions or feature requests, please open a [GitHub Discussion](https://git
 ## Under Consideration
 
 
+- **[EUM to CF Standard Name Mapping](features/cf-standard-name-mapping.md)** — Map DHI EUM types and units to CF convention standard names and UDUNITS, enabling standards-compliant metadata in NetCDF, Zarr, and xarray exports.
 - **[Time-Dependent Scaling](features/climate-change-factor.md)** — Apply time-dependent adjustment factors (additive or multiplicative) to DFS file data, e.g. for climate change scenarios or tidal corrections.
 - **[Consistent dfs2 and dfsu Plotting](features/consistent-plots.md)** — Unified plotting interface across grid and mesh geometries with consistent styling and options.
 - **[Spatial Resampling of dfs2](features/dfs2-resampling.md)** — Resample dfs2 grids to different resolutions or extents using interpolation.
 - **[Element Volume in 3D dfsu](features/element-volume-3d.md)** — Compute element volumes for 3D layered meshes, enabling volume-weighted analysis.
 - **[Exceedance Statistics](features/exceedance-statistics.md)** — Compute exceedance probabilities, return periods, and threshold-based statistics directly on DataArrays.
-- **[Lossless dfsu to NetCDF/Zarr Conversion](features/netcdf-zarr-conversion.md)** — Export dfsu files to NetCDF or Zarr while preserving mesh topology and all metadata.
+- **[GeoParquet Export](features/geoparquet-export.md)** — Export mesh element results as GeoParquet files for cloud-friendly columnar storage, fast spatial queries, and interoperability with modern data tools.
 - **[Horizontal Aggregation in Polygons](features/polygon-aggregation.md)** — Compute area-weighted zonal statistics (mean, sum, min, max) for elements within polygons.
 - **[Out-of-Core Temporal Statistics](features/rolling-average-large-files.md)** — Compute time-aggregated and rolling statistics on DFS files too large to fit in memory.
+- **[GeoDataFrame Export](features/to-geodataframe.md)** — Export DataArray and Dataset contents as GeoDataFrames with polygon or point geometries and CRS metadata, enabling direct use with GIS tools.
+- **[UGRID-Compliant NetCDF Export](features/ugrid-netcdf-export.md)** — Export dfsu mesh topology and data as UGRID-compliant NetCDF, readable by QGIS, ParaView, xugrid, and other standards-aware tools.
+- **[xarray Backend Entry Point](features/xarray-backend.md)** — Register MIKE IO as an xarray backend engine, enabling lazy loading of DFS files via xr.open_dataset(engine='mikeio').
+- **[Zarr Export](features/zarr-export.md)** — Export DFS data to Zarr stores for cloud-native access, parallel reads, and integration with cloud-hosted analysis workflows.
 
 ## Not Planned
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -1,0 +1,32 @@
+# MIKE IO Product Roadmap
+
+This roadmap outlines the current and future direction of MIKE IO — a Python package for reading, writing, and manipulating MIKE files (dfs0, dfs1, dfs2, dfs3, dfsu, mesh).
+
+For questions or feature requests, please open a [GitHub Discussion](https://github.com/DHI/mikeio/discussions).
+
+---
+
+
+## Delivered
+
+
+- **[Cross-Platform Support](features/cross-platform.md)** — Native Python DFS I/O via mikecore, replacing the Windows-only pythonnet dependency.
+- **[Flexible Mesh (dfsu) Support](features/flexible-mesh.md)** — Full read/write support for 2D and 3D unstructured mesh files, including spectral data.
+- **[PFS File Support](features/pfs-support.md)** — Read, modify, and write MIKE parameter files (.pfs) as structured Python objects.
+- **[Plotting](features/plotting.md)** — Geometry-aware matplotlib plotting for time series, grids, and flexible meshes.
+
+## Under Consideration
+
+
+- **[Time-Dependent Scaling](features/climate-change-factor.md)** — Apply time-dependent adjustment factors (additive or multiplicative) to DFS file data, e.g. for climate change scenarios or tidal corrections.
+- **[Consistent dfs2 and dfsu Plotting](features/consistent-plots.md)** — Unified plotting interface across grid and mesh geometries with consistent styling and options.
+- **[Spatial Resampling of dfs2](features/dfs2-resampling.md)** — Resample dfs2 grids to different resolutions or extents using interpolation.
+- **[Element Volume in 3D dfsu](features/element-volume-3d.md)** — Compute element volumes for 3D layered meshes, enabling volume-weighted analysis.
+- **[Exceedance Statistics](features/exceedance-statistics.md)** — Compute exceedance probabilities, return periods, and threshold-based statistics directly on DataArrays.
+- **[Lossless dfsu to NetCDF/Zarr Conversion](features/netcdf-zarr-conversion.md)** — Export dfsu files to NetCDF or Zarr while preserving mesh topology and all metadata.
+- **[Horizontal Aggregation in Polygons](features/polygon-aggregation.md)** — Compute area-weighted zonal statistics (mean, sum, min, max) for elements within polygons.
+- **[Out-of-Core Temporal Statistics](features/rolling-average-large-files.md)** — Compute time-aggregated and rolling statistics on DFS files too large to fit in memory.
+
+## Not Planned
+
+See [features considered out of scope](features/not-planned.md).

--- a/roadmap/features/cf-standard-name-mapping.md
+++ b/roadmap/features/cf-standard-name-mapping.md
@@ -1,0 +1,28 @@
+---
+title: "EUM to CF Standard Name Mapping"
+status: "Under Consideration"
+category: "Interoperability"
+summary: "Map DHI EUM types and units to CF convention standard names and UDUNITS, enabling standards-compliant metadata in NetCDF, Zarr, and xarray exports."
+---
+
+## Value Proposition
+
+The CF (Climate and Forecast) conventions are the lingua franca of earth science data. Tools like xarray, QGIS, ParaView, CDO, NCO, and cf-xarray all rely on `standard_name` and `units` attributes to interpret variables correctly. MIKE IO's EUM type system is rich (hundreds of physical quantities with associated units), but it is proprietary — no external tool understands `eumType=100006`. A mapping table would make every export from MIKE IO immediately meaningful to the broader ecosystem.
+
+## What This Enables
+
+- **Standards-compliant xarray export**: `to_xarray()` populates `standard_name`, `long_name`, and `units` attributes automatically
+- **Foundation for UGRID and NetCDF export**: CF metadata is a prerequisite for valid UGRID-compliant NetCDF files
+- **Tool interoperability**: cf-xarray, Iris, CDO, NCO, and CMIP tooling can discover and operate on variables by standard name
+- **Unit consistency**: Map EUM units to UDUNITS-compatible strings (e.g., `meter_per_second` rather than `m/s per sqrt(Hz)`)
+
+## Current State
+
+`to_xarray()` sets `name`, `units`, `eumType`, and `eumUnit` attributes from `ItemInfo`. The `units` string comes from the EUM system and is human-readable but not UDUNITS-compliant. No `standard_name` or `long_name` is set.
+
+## Design Considerations
+
+- The mapping should cover the most common EUM types used in MIKE 21/3 output (water level, velocity, salinity, temperature, wave parameters, etc.) rather than attempting to map all ~1000 EUM types
+- Some EUM types have no CF equivalent (e.g., MIKE-specific calibration parameters) — these should fall back to `long_name` only
+- The mapping table should be maintainable as a simple data structure (dict or CSV), not scattered across code
+- Unit strings must be UDUNITS-2 compatible (e.g., `m s-1` not `m/s`)

--- a/roadmap/features/climate-change-factor.md
+++ b/roadmap/features/climate-change-factor.md
@@ -1,0 +1,22 @@
+---
+title: "Time-Dependent Scaling"
+status: "Under Consideration"
+category: "Analysis"
+summary: "Apply time-dependent adjustment factors (additive or multiplicative) to DFS file data, e.g. for climate change scenarios or tidal corrections."
+---
+
+## Value Proposition
+
+Many workflows require adjusting time series or spatial fields by factors that vary over time — climate change impact assessments, tidal corrections, seasonal bias adjustment, or scenario scaling. A high-level API for applying time-dependent factors would eliminate repetitive boilerplate.
+
+## What This Enables
+
+- **Additive adjustments**: Add a time-varying delta to water levels, temperatures, or other variables
+- **Multiplicative adjustments**: Scale rainfall or wind speed by time-dependent factors
+- **Spatially varying factors**: Apply different factors to different regions or grid cells
+- **Seasonal factors**: Apply month- or season-dependent adjustment factors
+- **Scenario generation**: Produce multiple adjusted versions of a base dataset
+
+## Current State
+
+`scale()` and `transform()` in `generic.py` provide building blocks for applying mathematical operations to DFS file data. However, there is no high-level API for applying factors that vary by time step, season, or month.

--- a/roadmap/features/consistent-plots.md
+++ b/roadmap/features/consistent-plots.md
@@ -1,0 +1,21 @@
+---
+title: "Consistent dfs2 and dfsu Plotting"
+status: "Under Consideration"
+category: "Visualization"
+summary: "Unified plotting interface across grid and mesh geometries with consistent styling and options."
+---
+
+## Value Proposition
+
+Currently, dfs2 and dfsu data use separate plotting code paths with different styling defaults and option names. A unified interface would make it easier to compare results across grid and mesh models, and reduce the learning curve for users working with both formats.
+
+## What This Enables
+
+- **Consistent API**: Same method signatures and options for grid and mesh plots
+- **Easy comparison**: Plot dfs2 and dfsu results side by side with matching colour scales and styling
+- **Reduced learning curve**: Learn one plotting interface instead of two
+- **Shared defaults**: Consistent colormaps, label formatting, and layout across geometry types
+
+## Current State
+
+Plotting works well for both dfs2 and dfsu individually, but the implementations are separate (`_data_plot.py` for grids, `_FM_plot.py` for meshes) with different default styles and option handling.

--- a/roadmap/features/cross-platform.md
+++ b/roadmap/features/cross-platform.md
@@ -1,0 +1,23 @@
+---
+title: "Cross-Platform Support"
+status: "Delivered"
+category: "Infrastructure"
+summary: "Native Python DFS I/O via mikecore, replacing the Windows-only pythonnet dependency."
+---
+
+## Value Proposition
+
+MIKE IO was originally built on pythonnet, which required a .NET runtime and only worked on Windows. This blocked adoption by the many scientists and engineers who work on Linux or macOS, and made CI/CD pipelines fragile.
+
+Migrating to mikecore — a Python module with bindings to DHI's C libraries — removed the .NET dependency entirely, enabling MIKE IO to run on any platform where Python runs.
+
+## What This Enables
+
+- **Linux and macOS support**: Use MIKE IO in any environment, including cloud compute and HPC clusters
+- **Simpler installation**: No .NET runtime required — `pip install mikeio` just works
+- **Reliable CI/CD**: Tests run on all platforms without special configuration
+- **Docker-friendly**: Containerised workflows work out of the box
+
+## Current Status
+
+Delivered. All DFS file I/O uses mikecore. See ADR-002 for the decision record.

--- a/roadmap/features/dfs2-resampling.md
+++ b/roadmap/features/dfs2-resampling.md
@@ -1,0 +1,21 @@
+---
+title: "Spatial Resampling of dfs2"
+status: "Under Consideration"
+category: "Grid Operations"
+summary: "Resample dfs2 grids to different resolutions or extents using interpolation."
+---
+
+## Value Proposition
+
+Modellers frequently need to change the spatial resolution of gridded data — coarsening high-resolution bathymetry for a larger-domain model, or refining a coarse forcing field for a detailed local model. Spatial resampling of dfs2 files would support these workflows natively.
+
+## What This Enables
+
+- **Upsampling**: Increase grid resolution using interpolation (bilinear, nearest-neighbour)
+- **Downsampling**: Reduce grid resolution using aggregation (mean, max, min)
+- **Regridding**: Resample to a different grid extent or origin
+- **Resolution matching**: Align grids from different sources to a common resolution
+
+## Current State
+
+No spatial resampling support exists. Grid2D geometry is defined in `_grid_geometry.py` and dfs2 I/O in `_dfs2.py`, but there are no interpolation or aggregation operations on grids.

--- a/roadmap/features/element-volume-3d.md
+++ b/roadmap/features/element-volume-3d.md
@@ -1,0 +1,21 @@
+---
+title: "Element Volume in 3D dfsu"
+status: "Under Consideration"
+category: "3D Mesh"
+summary: "Compute element volumes for 3D layered meshes, enabling volume-weighted analysis."
+---
+
+## Value Proposition
+
+Volume is the 3D equivalent of area — essential for computing total quantities (e.g., total pollutant mass in a water body), volume-weighted averages, and mass budgets. Currently only element areas are available, limiting 3D analysis capabilities.
+
+## What This Enables
+
+- **Volume-weighted averages**: Compute proper spatial averages in 3D domains
+- **Mass budgets**: Calculate total mass of dissolved substances (concentration x volume)
+- **Layer volumes**: Quantify the volume of individual layers or depth ranges
+- **Temporal volume changes**: Track how volumes change with varying water levels
+
+## Current State
+
+Element areas are available in `GeometryFM3D` (inherited from 2D geometry). Layer thicknesses can be derived from node z-coordinates, but there is no method to compute element volumes directly.

--- a/roadmap/features/exceedance-statistics.md
+++ b/roadmap/features/exceedance-statistics.md
@@ -1,0 +1,21 @@
+---
+title: "Exceedance Statistics"
+status: "Under Consideration"
+category: "Analysis"
+summary: "Compute exceedance probabilities, return periods, and threshold-based statistics directly on DataArrays."
+---
+
+## Value Proposition
+
+Exceedance statistics — how often a value exceeds a threshold, or what value is exceeded X% of the time — are fundamental to coastal and hydraulic engineering design. Providing these as first-class operations on DataArray would eliminate boilerplate and reduce errors in common workflows.
+
+## What This Enables
+
+- **Exceedance curves**: Compute and plot percentage-of-time-exceeded for any variable
+- **Return periods**: Estimate N-year return values from time series
+- **Threshold statistics**: Count exceedances, compute durations above/below thresholds
+- **Spatial maps**: Produce maps of exceedance values across a domain (e.g., "100-year water level")
+
+## Current State
+
+`quantile()` is available on DataArray for computing percentiles, which is a building block for exceedance statistics. However, there is no dedicated exceedance API with return-period estimation or threshold-duration analysis.

--- a/roadmap/features/flexible-mesh.md
+++ b/roadmap/features/flexible-mesh.md
@@ -1,0 +1,23 @@
+---
+title: "Flexible Mesh (dfsu) Support"
+status: "Delivered"
+category: "File Formats"
+summary: "Full read/write support for 2D and 3D unstructured mesh files, including spectral data."
+---
+
+## Value Proposition
+
+Flexible mesh (dfsu) files are the primary output format for MIKE 21/3 FM simulations. Supporting these files — including their complex 3D layered structure and spectral variants — is essential for post-processing simulation results in Python.
+
+## What This Enables
+
+- **Read and write** 2D and 3D dfsu files with element-centred or node-centred data
+- **Spatial subsetting**: Extract data by element index, coordinate, or bounding box
+- **Geometry access**: Node coordinates, element tables, boundary codes, projection info
+- **3D layered meshes**: Navigate vertical structure with layer-aware operations
+- **Spectral data**: Read directional and frequency spectra from spectral dfsu files
+- **Mesh manipulation**: Create, modify, and write mesh files
+
+## Current Status
+
+Delivered. Full factory-based architecture supports all dfsu data types (2001, 2002, 2003, 2004) with geometry-aware operations.

--- a/roadmap/features/geoparquet-export.md
+++ b/roadmap/features/geoparquet-export.md
@@ -1,0 +1,32 @@
+---
+title: "GeoParquet Export"
+status: "Under Consideration"
+category: "Interoperability"
+summary: "Export mesh element results as GeoParquet files for cloud-friendly columnar storage, fast spatial queries, and interoperability with modern data tools."
+---
+
+## Value Proposition
+
+GeoParquet is an emerging standard for geospatial vector data in columnar format. It combines Parquet's strengths (compression, predicate pushdown, columnar access) with embedded geometry and CRS metadata. For MIKE IO users, this means simulation results can be stored, shared, and queried using tools like DuckDB, Polars, pandas, and cloud data platforms — without any GIS software.
+
+## What This Enables
+
+- **SQL queries on results**: `SELECT * FROM 'results.parquet' WHERE ST_Within(geometry, ?)` via DuckDB spatial
+- **Cloud-native sharing**: GeoParquet files on S3 are directly queryable with row-group filtering — no full download needed
+- **Dashboard backends**: Parquet files are fast data sources for dashboards and web applications
+- **Cross-tool compatibility**: Readable by QGIS, GeoPandas, Polars, DuckDB, BigQuery, Snowflake, and others
+- **Time series at elements**: Store all timesteps for selected elements as a tall table with element geometry, time, and values
+
+## Current State
+
+No Parquet or GeoParquet export exists. Building on `to_geodataframe()` (see GeoDataFrame Export feature), GeoParquet export would be a thin wrapper: `gdf.to_parquet("results.parquet")`.
+
+## Design Considerations
+
+- Depends on the `to_geodataframe()` feature for geometry construction
+- Default to one row per element per timestep (tall/tidy format) for time-varying data
+- For single-timestep snapshots, one row per element with all variables as columns (wide format)
+- Include CRS metadata in the Parquet file per the GeoParquet spec (PROJJSON in column metadata)
+- Element area could be included as a column to support area-weighted aggregation downstream
+- Consider a `to_parquet()` convenience method directly on DataArray/Dataset that handles the GeoDataFrame conversion internally
+- pyarrow and geopandas should remain optional dependencies

--- a/roadmap/features/netcdf-zarr-conversion.md
+++ b/roadmap/features/netcdf-zarr-conversion.md
@@ -1,21 +1,12 @@
 ---
 title: "Lossless dfsu to NetCDF/Zarr Conversion"
-status: "Under Consideration"
+status: "Superseded"
 category: "Interoperability"
 summary: "Export dfsu files to NetCDF or Zarr while preserving mesh topology and all metadata."
 ---
 
-## Value Proposition
+This feature has been superseded by more specific features:
 
-NetCDF and Zarr are widely supported by the scientific Python ecosystem (xarray, Dask, cloud storage). Converting dfsu files to these formats would unlock lazy loading, parallel computation, and cloud-native workflows — without losing the mesh structure or metadata that makes the data meaningful.
-
-## What This Enables
-
-- **Cloud-native workflows**: Store simulation results in Zarr for efficient cloud access
-- **Lazy loading with xarray**: Process datasets larger than memory using Dask-backed arrays
-- **Interoperability**: Share results with collaborators who don't have MIKE IO installed
-- **Round-trip fidelity**: Convert to NetCDF/Zarr and back without losing mesh topology, projection, or EUM metadata
-
-## Current State
-
-`to_xarray()` exists on Dataset and DataArray, enabling conversion to xarray objects. However, there is no direct export path that preserves mesh topology in a standardised format (e.g., UGRID conventions for NetCDF).
+- [UGRID-Compliant NetCDF Export](ugrid-netcdf-export.md)
+- [Zarr Export](zarr-export.md)
+- [EUM to CF Standard Name Mapping](cf-standard-name-mapping.md)

--- a/roadmap/features/netcdf-zarr-conversion.md
+++ b/roadmap/features/netcdf-zarr-conversion.md
@@ -1,0 +1,21 @@
+---
+title: "Lossless dfsu to NetCDF/Zarr Conversion"
+status: "Under Consideration"
+category: "Interoperability"
+summary: "Export dfsu files to NetCDF or Zarr while preserving mesh topology and all metadata."
+---
+
+## Value Proposition
+
+NetCDF and Zarr are widely supported by the scientific Python ecosystem (xarray, Dask, cloud storage). Converting dfsu files to these formats would unlock lazy loading, parallel computation, and cloud-native workflows — without losing the mesh structure or metadata that makes the data meaningful.
+
+## What This Enables
+
+- **Cloud-native workflows**: Store simulation results in Zarr for efficient cloud access
+- **Lazy loading with xarray**: Process datasets larger than memory using Dask-backed arrays
+- **Interoperability**: Share results with collaborators who don't have MIKE IO installed
+- **Round-trip fidelity**: Convert to NetCDF/Zarr and back without losing mesh topology, projection, or EUM metadata
+
+## Current State
+
+`to_xarray()` exists on Dataset and DataArray, enabling conversion to xarray objects. However, there is no direct export path that preserves mesh topology in a standardised format (e.g., UGRID conventions for NetCDF).

--- a/roadmap/features/not-planned.md
+++ b/roadmap/features/not-planned.md
@@ -1,0 +1,38 @@
+---
+title: "Not Planned"
+status: "Not Planned"
+category: "Out of Scope"
+summary: "Features that have been considered and determined to be outside MIKE IO's scope."
+---
+
+## Horizontal Slicing of 3D dfsu at Specified Depth
+
+Extracting a horizontal slice at an arbitrary depth from a 3D layered mesh requires interpolation between layers — a non-trivial geometric operation that depends on the vertical discretisation scheme. This is available in MIKE's proprietary tooling which handles the interpolation correctly for all mesh configurations.
+
+## Vertical Slicing of 3D dfsu Along Waypoints
+
+Creating a vertical cross-section along a polyline path through a 3D mesh requires intersecting the path with element boundaries, interpolating values, and constructing a new 2D representation. This is a complex geometric operation available in MIKE's proprietary tools.
+
+## Vertical Aggregation of 3D dfsu Over a Depth Range
+
+Aggregating values over a specific depth range (e.g., averaging salinity from 0–10m) requires identifying which layers intersect the range, computing partial volumes for boundary layers, and performing volume-weighted aggregation. This is available in MIKE's proprietary tooling.
+
+## Creation of 3D dfsu Transect from External Data
+
+Constructing a 3D transect file suitable for use as a boundary condition requires building a valid mesh section with correct layer structure and connectivity. This is specialised model setup functionality available in MIKE's proprietary tools.
+
+## Comparing Scenarios with Different Meshes
+
+Interpolating results from one unstructured mesh onto another — necessary for comparing model runs with different mesh resolutions — requires robust spatial interpolation in 2D or 3D. This is a complex geometric problem handled by MIKE's proprietary interpolation engine.
+
+## Discharge Calculations Across a Transect by Layer
+
+Computing discharge (flux) across a cross-section requires face-based velocity data, correct normal vector computation, and layer-aware integration. This specialised hydrodynamic analysis is available in MIKE's proprietary post-processing tools.
+
+## Brunt-Väisälä Frequency
+
+Computing the buoyancy frequency (N²) from temperature and salinity profiles is a domain-specific oceanographic analysis rather than a file I/O operation. This would be a great fit for a dedicated ocean/coastal science library that builds on MIKE IO's data structures. See the [feature page](brunt-vaisala.md) for details.
+
+## Ensemble Model Support
+
+DFS file formats store data on fixed spatial and temporal axes — they have no concept of an ensemble dimension. Supporting ensembles would require either a fundamentally different file format or a higher-level abstraction that manages collections of files. This is a format limitation rather than a MIKE IO limitation.

--- a/roadmap/features/pfs-support.md
+++ b/roadmap/features/pfs-support.md
@@ -1,0 +1,22 @@
+---
+title: "PFS File Support"
+status: "Delivered"
+category: "File Formats"
+summary: "Read, modify, and write MIKE parameter files (.pfs) as structured Python objects."
+---
+
+## Value Proposition
+
+MIKE parameter files (.pfs) control simulation setup — boundary conditions, output specifications, solver parameters. Being able to read and modify these files programmatically enables batch simulation workflows, parameter studies, and automated model setup.
+
+## What This Enables
+
+- **Read PFS files** into a structured PfsDocument with named sections and key-value pairs
+- **Modify parameters** using familiar Python dict-like access
+- **Write PFS files** back to disk with correct formatting
+- **Automate model setup**: Script parameter sweeps, boundary condition updates, and configuration changes
+- **Extract metadata**: Read output specifications, timestep settings, and other configuration from existing setups
+
+## Current Status
+
+Delivered. PfsDocument and PfsSection provide full read/write support for the PFS format.

--- a/roadmap/features/plotting.md
+++ b/roadmap/features/plotting.md
@@ -1,0 +1,23 @@
+---
+title: "Plotting"
+status: "Delivered"
+category: "Visualization"
+summary: "Geometry-aware matplotlib plotting for time series, grids, and flexible meshes."
+---
+
+## Value Proposition
+
+Visualising simulation results is a core part of any modelling workflow. MIKE IO's plotting dispatches automatically based on geometry type, so users get appropriate visualisations — time series plots for dfs0, pcolormesh for dfs2, triangulated plots for dfsu — without manual setup.
+
+## What This Enables
+
+- **DataArray.plot()**: Single entry point that dispatches to the right plot type based on geometry
+- **Grid plots**: 2D filled contour and pcolormesh plots for dfs2 data
+- **Mesh plots**: Triangulated plots for dfsu data with element boundaries
+- **Time series**: Line plots for dfs0 and point-extracted data
+- **Mesh geometry**: Plot mesh structure, bathymetry, and boundary codes
+- **Customisable**: All plots return matplotlib axes for further customisation
+
+## Current Status
+
+Delivered. Plotting is integrated into DataArray and geometry classes with automatic dispatch by geometry type.

--- a/roadmap/features/polygon-aggregation.md
+++ b/roadmap/features/polygon-aggregation.md
@@ -1,0 +1,20 @@
+---
+title: "Horizontal Aggregation in Polygons"
+status: "Under Consideration"
+category: "Analysis"
+summary: "Compute area-weighted zonal statistics (mean, sum, min, max) for elements within polygons."
+---
+
+## Value Proposition
+
+Engineers often need spatially aggregated values within specific zones — average salinity in a harbour basin, total discharge through an inlet, or maximum wave height in a protected area. Polygon-based aggregation provides these results directly without manual element selection and weighting.
+
+## What This Enables
+
+- **Zonal statistics**: Compute area-weighted mean, sum, min, max within arbitrary polygons
+- **Multi-zone analysis**: Aggregate across multiple polygons simultaneously (e.g., management zones)
+- **Time series extraction**: Produce a single time series per zone from a spatial field
+
+## Current State
+
+Polygon-based element selection exists in `GeometryFM2D` (find elements within a polygon), and element areas are available. The building blocks are in place, but there is no high-level API that combines selection with area-weighted aggregation.

--- a/roadmap/features/rolling-average-large-files.md
+++ b/roadmap/features/rolling-average-large-files.md
@@ -1,0 +1,21 @@
+---
+title: "Out-of-Core Temporal Statistics"
+status: "Under Consideration"
+category: "Analysis"
+summary: "Compute time-aggregated and rolling statistics on DFS files too large to fit in memory."
+---
+
+## Value Proposition
+
+Long-duration or high-resolution simulations produce files that exceed available memory. Users need both full time-axis aggregation (mean, max, min, quantile over all timesteps) and rolling window statistics — all without loading the entire file.
+
+## What This Enables
+
+- **Full time-axis aggregation**: Compute mean, max, min, percentiles over the entire time series out-of-core
+- **Rolling windows**: Rolling mean, min, max, and sum with configurable window sizes
+- **Streaming output**: Write results to a new file as chunks are processed
+- **Arbitrary file sizes**: Process multi-GB files with bounded memory usage
+
+## Current State
+
+`generic.py` already has chunked implementations of `avg_time` and `quantile` that process files in temporal chunks. These cover basic full-axis aggregation. Rolling window operations and a broader set of statistics (max, min, std) are not yet supported but could build on the same chunked infrastructure.

--- a/roadmap/features/to-geodataframe.md
+++ b/roadmap/features/to-geodataframe.md
@@ -1,0 +1,31 @@
+---
+title: "GeoDataFrame Export"
+status: "Under Consideration"
+category: "Interoperability"
+summary: "Export DataArray and Dataset contents as GeoDataFrames with polygon or point geometries and CRS metadata, enabling direct use with GIS tools."
+---
+
+## Value Proposition
+
+GeoDataFrame is the standard interchange format for vector geospatial data in Python. A `to_geodataframe()` method on DataArray would let users go from dfsu results to shapefile, GeoPackage, GeoJSON, or GeoParquet in one step — and access the full geopandas/shapely ecosystem for spatial analysis, joins, and visualization.
+
+## What This Enables
+
+- **GIS export**: Write dfsu results to GeoPackage, shapefile, or GeoJSON via `gdf.to_file()`
+- **Spatial joins**: Intersect MIKE results with other geospatial datasets (land use, catchments, monitoring stations)
+- **Interactive maps**: `gdf.explore()` renders results on an interactive Leaflet map in Jupyter/marimo
+- **GeoParquet output**: `gdf.to_parquet()` for cloud-friendly columnar storage (see GeoParquet feature)
+- **DuckDB/Polars spatial queries**: GeoParquet files are queryable by DuckDB's spatial extension
+
+## Current State
+
+`GeometryFM2D.to_shapely()` returns a `MultiPolygon` of mesh elements. CRS metadata is available via `spatial/crs.py`. The building blocks exist, but there is no method that combines geometry, data values, and CRS into a GeoDataFrame.
+
+## Design Considerations
+
+- For dfsu (unstructured mesh): each row is a mesh element with a polygon geometry and variable values at a single timestep
+- For dfs2 (structured grid): each row is a grid cell with a polygon geometry
+- For dfs0 (time series at a point): each row is a timestep with a point geometry
+- Multi-timestep data should default to a single timestep; a `timestep` parameter selects which one
+- CRS should be set from the file's projection metadata via `to_pyproj()`
+- geopandas should remain an optional dependency — import lazily and raise a helpful error if not installed

--- a/roadmap/features/ugrid-netcdf-export.md
+++ b/roadmap/features/ugrid-netcdf-export.md
@@ -1,0 +1,32 @@
+---
+title: "UGRID-Compliant NetCDF Export"
+status: "Under Consideration"
+category: "Interoperability"
+summary: "Export dfsu mesh topology and data as UGRID-compliant NetCDF, readable by QGIS, ParaView, xugrid, and other standards-aware tools."
+---
+
+## Value Proposition
+
+UGRID is the established convention for storing unstructured mesh data in NetCDF. It is supported by QGIS (mesh layer), ParaView, Deltares xugrid, MDAL, and many other tools. Currently, sharing dfsu results with collaborators requires them to install MIKE IO. A UGRID-compliant NetCDF export would make MIKE simulation output accessible to anyone with standard scientific software.
+
+## What This Enables
+
+- **QGIS visualization**: Open exported files directly as QGIS mesh layers — no plugins or converters needed
+- **xugrid interoperability**: Deltares xugrid can read UGRID NetCDF natively, unlocking regridding, spatial analysis, and GeoDataFrame conversion
+- **ParaView rendering**: 3D visualization of simulation results in ParaView via its UGRID reader
+- **Archival and sharing**: NetCDF is a widely accepted archival format with rich metadata support
+- **Cloud workflows**: NetCDF files can be served via THREDDS/OPeNDAP or converted to Zarr for cloud-native access
+
+## Current State
+
+`to_xarray()` converts data to xarray objects but does not encode mesh topology. The mesh structure (node coordinates, element-node connectivity, element types, boundary codes) is lost in the conversion. The existing `netcdf-zarr-conversion` roadmap item identifies this gap; this feature provides the specific approach.
+
+## Design Considerations
+
+- Target UGRID 1.0 conventions, which define `mesh_topology` variable with `cf_role`, `node_coordinates`, `face_node_connectivity`, and related attributes
+- Map element-based data (dfsu type 2001) to face-located variables, face-based data (type 2004) to edge-located variables
+- Include boundary codes as a node attribute (`boundary_node_connectivity` or via node `flag` variable)
+- Handle mixed meshes (triangles + quads) via padded connectivity arrays with fill values, per UGRID spec
+- Requires EUM-to-CF mapping for variable metadata (depends on the CF standard name mapping feature)
+- 3D layered meshes need careful consideration — UGRID has limited 3D support; a practical approach may be to export per-layer or use the UGRID layered extension
+- Projection information should be written as a CF grid mapping variable

--- a/roadmap/features/xarray-backend.md
+++ b/roadmap/features/xarray-backend.md
@@ -1,0 +1,32 @@
+---
+title: "xarray Backend Entry Point"
+status: "Under Consideration"
+category: "Interoperability"
+summary: "Register MIKE IO as an xarray backend engine, enabling lazy loading of DFS files via xr.open_dataset(engine='mikeio')."
+---
+
+## Value Proposition
+
+xarray's backend entry point system allows any file format to be opened with `xr.open_dataset()`. Registering MIKE IO as a backend would make DFS files first-class citizens in the xarray ecosystem — compatible with Dask for lazy/parallel computation, xarray's selection and aggregation API, and downstream tools like hvplot, cf-xarray, and flox.
+
+## What This Enables
+
+- **Lazy loading**: `xr.open_dataset("large.dfsu", engine="mikeio")` returns a Dataset without reading all data into memory
+- **Dask integration**: `xr.open_dataset(..., chunks={"time": 10})` enables out-of-core computation on large files
+- **Multi-file datasets**: `xr.open_mfdataset(["run1.dfsu", "run2.dfsu"], engine="mikeio")` for concatenating results
+- **Ecosystem compatibility**: Any tool that accepts xarray Datasets works with MIKE files immediately
+- **Notebook workflows**: Users familiar with xarray can work with MIKE files without learning a separate API
+
+## Current State
+
+`to_xarray()` on Dataset and DataArray performs an eager conversion — all data is read into memory first, then wrapped as xarray objects. There is no lazy path. The Rust DFS engine experiment (branch `experiment/thinking`) has a working `BackendEntrypoint` with `DfsBackendArray` for lazy timestep reads, demonstrating feasibility.
+
+## Design Considerations
+
+- Implement `xarray.backends.BackendEntrypoint` subclass with `open_dataset()` and `guess_can_open()` methods
+- Register via `[project.entry-points."xarray.backends"]` in `pyproject.toml`
+- Data variables should be backed by a lazy array wrapper that reads individual timesteps on demand
+- Coordinates should include time, and spatial coordinates appropriate to the geometry type (x/y for grids, element index for dfsu)
+- Mesh topology metadata should be included as attributes or coordinate variables (ideally UGRID-compliant)
+- CF standard names should be set when the EUM-to-CF mapping is available
+- For dfsu, the unstructured dimension does not map to xarray's regular grid model — consider compatibility with xugrid's `UgridDataset` for topology-aware operations

--- a/roadmap/features/zarr-export.md
+++ b/roadmap/features/zarr-export.md
@@ -1,0 +1,31 @@
+---
+title: "Zarr Export"
+status: "Under Consideration"
+category: "Interoperability"
+summary: "Export DFS data to Zarr stores for cloud-native access, parallel reads, and integration with cloud-hosted analysis workflows."
+---
+
+## Value Proposition
+
+Zarr is the cloud-native array storage format adopted by the Pangeo community and supported natively by xarray, Dask, and major cloud platforms. Converting MIKE simulation results to Zarr enables efficient access from anywhere — no file downloads, no proprietary readers, just standard HTTP range requests.
+
+## What This Enables
+
+- **Cloud storage**: Push simulation results to S3/GCS/Azure Blob as Zarr stores, accessible from any machine
+- **Parallel reads**: Multiple workers read different chunks concurrently without file locking
+- **Incremental writes**: Append new timesteps to an existing Zarr store as a simulation progresses
+- **Web visualization**: Zarr stores can back web-based dashboards (e.g., via xarray + hvplot/Panel)
+- **Large dataset handling**: Zarr's chunking eliminates the need to load entire files into memory
+
+## Current State
+
+No Zarr export exists in MIKE IO. The `netcdf-zarr-conversion` roadmap item identifies the need. With xarray's `to_zarr()`, the technical path is straightforward once UGRID-compliant xarray conversion is in place — the primary challenge is preserving mesh topology metadata.
+
+## Design Considerations
+
+- Build on top of UGRID-compliant xarray export — `ds.to_xarray().to_zarr()` should produce a valid, self-describing Zarr store
+- Target Zarr v3 with sharding codec to reduce object count for cloud storage (many small chunks → fewer sharded objects)
+- Chunking strategy matters: time-chunked (one chunk per timestep) suits temporal analysis; spatial chunking is harder for unstructured meshes but relevant for structured grids (dfs2, dfs3)
+- Include consolidated metadata for fast opening (single metadata fetch instead of one per variable)
+- Consider a direct `ds.to_zarr()` method on MIKE IO Dataset as a convenience wrapper
+- Mesh topology variables (node coordinates, connectivity) should be written as unchunked arrays

--- a/roadmap/scripts/generate_overview.py
+++ b/roadmap/scripts/generate_overview.py
@@ -1,0 +1,57 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["jinja2", "pyyaml"]
+# ///
+"""Generate roadmap/README.md from feature page YAML frontmatter."""
+
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+ROADMAP_DIR = Path(__file__).resolve().parent.parent
+FEATURES_DIR = ROADMAP_DIR / "features"
+TEMPLATE_DIR = ROADMAP_DIR / "templates"
+
+STATUSES = [
+    "Delivered",
+    "In Development",
+    "Planned",
+    "Under Consideration",
+    "Not Planned",
+]
+
+
+def parse_frontmatter(path: Path) -> dict:
+    """Extract YAML frontmatter from a markdown file."""
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        raise ValueError(f"No YAML frontmatter found in {path}")
+    _, frontmatter, _ = text.split("---", 2)
+    meta = yaml.safe_load(frontmatter)
+    meta["filename"] = path.name
+    return meta
+
+
+def main():
+    features = []
+    for path in sorted(FEATURES_DIR.glob("*.md")):
+        features.append(parse_frontmatter(path))
+
+    features_by_status: dict[str, list[dict]] = {s: [] for s in STATUSES}
+    for f in features:
+        status = f["status"]
+        if status in features_by_status:
+            features_by_status[status].append(f)
+
+    env = Environment(loader=FileSystemLoader(TEMPLATE_DIR), keep_trailing_newline=True)
+    template = env.get_template("overview.md.j2")
+    readme = template.render(statuses=STATUSES, features_by_status=features_by_status)
+
+    output_path = ROADMAP_DIR / "README.md"
+    output_path.write_text(readme, encoding="utf-8")
+    print(f"Generated {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/roadmap/templates/overview.md.j2
+++ b/roadmap/templates/overview.md.j2
@@ -1,0 +1,21 @@
+# MIKE IO Product Roadmap
+
+This roadmap outlines the current and future direction of MIKE IO — a Python package for reading, writing, and manipulating MIKE files (dfs0, dfs1, dfs2, dfs3, dfsu, mesh).
+
+For questions or feature requests, please open a [GitHub Discussion](https://github.com/DHI/mikeio/discussions).
+
+---
+{% for status in statuses %}
+{%- if features_by_status[status] %}
+
+## {{ status }}
+
+{% if status == "Not Planned" -%}
+See [features considered out of scope](features/{{ features_by_status[status][0].filename }}).
+{%- else -%}
+{% for f in features_by_status[status] %}
+- **[{{ f.title }}](features/{{ f.filename }})** — {{ f.summary }}
+{%- endfor %}
+{%- endif %}
+{%- endif %}
+{%- endfor %}


### PR DESCRIPTION
## Summary

Data-driven product roadmap with individual feature files (YAML frontmatter), a Jinja2 template, and a generation script — same structure as modelskill.

- 4 Delivered features (cross-platform, PFS, dfsu, plotting)
- 8 Under Consideration features
- Not Planned section with rationale for out-of-scope items

README.md is generated via `uv run python roadmap/scripts/generate_overview.py`.