### PR TITLE
Replace deprecated cKDTree with KDTree

### DIFF
--- a/src/mikeio/dfsu/_layered.py
+++ b/src/mikeio/dfsu/_layered.py
@@ -9,7 +9,7 @@ from matplotlib.axes import Axes
 from matplotlib.colors import Colormap
 from mikecore.DfsFileFactory import DfsFileFactory
 from mikecore.DfsuFile import DfsuFile, DfsuFileType
-from scipy.spatial import cKDTree
+from scipy.spatial import KDTree
 from tqdm import trange
 
 from .._interpolation import Interpolant
@@ -584,7 +584,7 @@ class Dfsu3D(DfsuLayered):
         geom = self.geometry.elements_to_geometry(top_el, node_layers="top")
         xye = geom.element_coordinates[:, 0:2]  # type: ignore
         xyn = geom.node_coordinates[:, 0:2]  # type: ignore
-        tree2d = cKDTree(xyn)
+        tree2d = KDTree(xyn)
         dist, node_ids = tree2d.query(xye, k=n_nearest)
         weights = Interpolant.from_distances(dist)
 

--- a/src/mikeio/spatial/_FM_geometry.py
+++ b/src/mikeio/spatial/_FM_geometry.py
@@ -16,7 +16,7 @@ from numpy.typing import NDArray
 from mikecore.DfsuFile import DfsuFileType
 from mikecore.eum import eumQuantity
 from mikecore.MeshBuilder import MeshBuilder
-from scipy.spatial import cKDTree
+from scipy.spatial import KDTree
 
 from ..eum import EUMType, EUMUnit
 from ..exceptions import OutsideModelDomainError
@@ -508,9 +508,9 @@ class GeometryFM2D(_GeometryFM):
         return self.max_nodes_per_element == 3 or self.max_nodes_per_element == 6
 
     @cached_property
-    def _tree2d(self) -> cKDTree:
+    def _tree2d(self) -> KDTree:
         xy = self.element_coordinates[:, :2]
-        return cKDTree(xy)
+        return KDTree(xy)
 
     def find_nearest_elements(
         self,
@@ -614,7 +614,7 @@ class GeometryFM2D(_GeometryFM):
     def _find_n_nearest_2d_elements(
         self, x: float | np.ndarray, y: float | np.ndarray | None = None, n: int = 1
     ) -> tuple[Any, Any]:
-        # TODO return arguments in the same order than cKDTree.query?
+        # TODO return arguments in the same order than KDTree.query?
 
         if n > self.n_elements:
             raise ValueError(


### PR DESCRIPTION
## Summary
- Replace `scipy.spatial.cKDTree` with `scipy.spatial.KDTree` (deprecated since SciPy 1.12, API identical)