### PR TITLE
Add path filters to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,11 @@
 name: Documentation
 
-on: 
+on:
   push:
     branches: [ main]
+    paths:
+      - 'docs/**'
+      - 'src/mikeio/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Only trigger documentation builds when `docs/` or `src/mikeio/` files change, avoiding unnecessary builds for unrelated pushes to main.