### PR TITLE
Document unweighted spatial mean, add mean vs average tests

### DIFF
--- a/src/mikeio/dataset/_dataarray.py
+++ b/src/mikeio/dataset/_dataarray.py
@@ -1331,8 +1331,8 @@ class DataArray:
 
         Note: on unstructured meshes with variable element sizes,
         ``mean(axis="space")`` treats all elements equally regardless
-        of area. For an area-weighted spatial mean, use
-        :meth:`average` with ``weights=geometry.get_element_area()``.
+        of area. For an area-weighted spatial mean, use ``average()``
+        with ``weights=geometry.get_element_area()``.
 
         Parameters
         ----------
@@ -1486,7 +1486,7 @@ class DataArray:
         Note: on unstructured meshes with variable element sizes,
         ``nanmean(axis="space")`` treats all elements equally regardless
         of area. For an area-weighted spatial mean, use
-        :meth:`average` with ``weights=geometry.get_element_area()``.
+        ``average()`` with ``weights=geometry.get_element_area()``.
 
         Parameters
         ----------

--- a/src/mikeio/dataset/_dataarray.py
+++ b/src/mikeio/dataset/_dataarray.py
@@ -1327,7 +1327,12 @@ class DataArray:
         return self.aggregate(axis=axis, func=np.min, **kwargs)
 
     def mean(self, axis: int | str | None = 0, **kwargs: Any) -> DataArray:
-        """Mean value along an axis.
+        """Unweighted mean value along an axis.
+
+        Note: on unstructured meshes with variable element sizes,
+        ``mean(axis="space")`` treats all elements equally regardless
+        of area. For an area-weighted spatial mean, use
+        :meth:`average` with ``weights=geometry.get_element_area()``.
 
         Parameters
         ----------
@@ -1344,6 +1349,7 @@ class DataArray:
         See Also
         --------
             nanmean : Mean values with NaN values removed
+            average : Weighted average along an axis
 
         """
         return self.aggregate(axis=axis, func=np.mean, **kwargs)
@@ -1475,7 +1481,12 @@ class DataArray:
         return self.aggregate(axis=axis, func=np.nanmin, **kwargs)
 
     def nanmean(self, axis: int | str | None = 0, **kwargs: Any) -> DataArray:
-        """Mean value along an axis (NaN removed).
+        """Unweighted mean value along an axis (NaN removed).
+
+        Note: on unstructured meshes with variable element sizes,
+        ``nanmean(axis="space")`` treats all elements equally regardless
+        of area. For an area-weighted spatial mean, use
+        :meth:`average` with ``weights=geometry.get_element_area()``.
 
         Parameters
         ----------
@@ -1492,6 +1503,7 @@ class DataArray:
         See Also
         --------
             mean : Mean values
+            average : Weighted average along an axis
 
         """
         return self.aggregate(axis=axis, func=np.nanmean, **kwargs)

--- a/tests/test_mean_vs_average.py
+++ b/tests/test_mean_vs_average.py
@@ -1,0 +1,72 @@
+"""Tests documenting the difference between mean() and average() on spatial axes.
+
+mean(axis='space') is unweighted — all elements contribute equally.
+average(axis='space', weights=area) is area-weighted.
+On variable meshes these give different results; users must choose deliberately.
+"""
+
+import numpy as np
+
+import mikeio
+
+
+def test_mean_and_average_differ_on_variable_mesh() -> None:
+    """On a mesh with varying element areas, mean != average."""
+    da = mikeio.read("tests/testdata/HD2D.dfsu", items=[3])[0]
+    area = da.geometry.get_element_area()
+
+    # Sanity: areas actually vary
+    assert area.max() / area.min() > 2.0, "Need variable element areas"
+
+    mean_result = da.mean(axis="space").to_numpy()
+    avg_result = da.average(axis="space", weights=area).to_numpy()
+
+    # They must differ by more than floating-point noise
+    assert not np.allclose(mean_result, avg_result, atol=1e-10)
+
+
+def test_mean_and_average_agree_on_uniform_grid() -> None:
+    """On a uniform grid (dfs2), unweighted mean equals area-weighted mean."""
+    da = mikeio.read("tests/testdata/eq.dfs2")[0]
+
+    mean_result = da.mean(axis="space").to_numpy()
+
+    # On a uniform grid, all cells have the same area, so manual weighted
+    # average should match the unweighted mean
+    data = da.to_numpy()
+    manual_weighted = data.mean(axis=(1, 2))
+
+    np.testing.assert_allclose(mean_result, manual_weighted, atol=1e-10)
+
+
+def test_average_with_known_weights() -> None:
+    """Synthetic test: area=[1,9], values=[10,0] → mean=5, weighted_avg=1."""
+    da = mikeio.read("tests/testdata/HD2D.dfsu", items=[3])[0]
+    da_sub = da.isel(element=[0, 1])
+
+    # Override data with known values
+    data = da_sub.to_numpy().copy()
+    data[:, 0] = 10.0
+    data[:, 1] = 0.0
+    da_known = mikeio.DataArray(
+        data=data,
+        time=da_sub.time,
+        geometry=da_sub.geometry,
+        item=da_sub.item,
+    )
+
+    weights = np.array([1.0, 9.0])
+
+    unweighted = da_known.mean(axis="space").to_numpy()
+    weighted = da_known.average(axis="space", weights=weights).to_numpy()
+
+    np.testing.assert_allclose(unweighted, 5.0, atol=1e-10)
+    np.testing.assert_allclose(weighted, 1.0, atol=1e-10)
+
+
+def test_mean_docstring_warns_unweighted() -> None:
+    """mean() docstring should mention it's unweighted or reference average()."""
+    doc = mikeio.DataArray.mean.__doc__
+    assert doc is not None
+    doc_lower = doc.lower()
+    assert "unweighted" in doc_lower or "average" in doc_lower


### PR DESCRIPTION
## Why

mean(axis="space") on unstructured meshes is unweighted — all elements contribute equally regardless of area. On HD2D.dfsu, where the largest element is 15x the smallest, this gives biased results. Users must use average(weights=area) for correct area-weighted means, but nothing in the API or docstrings warns about this.

## What this adds

- 4 tests demonstrating the difference on variable meshes, agreement on uniform grids, and a synthetic known-weights case
- Updates mean() and nanmean() docstrings to note they are unweighted and reference average()