### PR TITLE
Document track time hack, add interpolation tests

### DIFF
--- a/src/mikeio/_track.py
+++ b/src/mikeio/_track.py
@@ -101,7 +101,10 @@ def _extract_track(
     step = time_steps[dfsu_step]
     for i, item in enumerate(item_numbers):
         d, t2 = data_read_func(item, step)
-        t2 = t2 - 1e-10  # TODO what is this operation doing?
+        # Nudge t2 slightly back so that a track point at exactly
+        # this timestep triggers reading the next step.  The resulting
+        # interpolation weight ≈ 1.0 still gives the correct value.
+        t2 = t2 - 1e-10
         d[d == deletevalue] = np.nan
         d2[i, :] = d
 

--- a/tests/test_track_interpolation.py
+++ b/tests/test_track_interpolation.py
@@ -1,0 +1,47 @@
+"""Tests for track extraction time interpolation."""
+
+import pandas as pd
+import pytest
+
+import mikeio
+
+
+def test_track_at_exact_timestep() -> None:
+    """Track point at exact dfsu timestep should return exact values."""
+    dfs = mikeio.open("tests/testdata/HD2D.dfsu")
+    ds = mikeio.read("tests/testdata/HD2D.dfsu", items=[3])
+    da = ds[0]
+
+    # Use element 100 centroid as track coordinate
+    ec = dfs.geometry.element_coordinates
+    x, y = ec[100, 0], ec[100, 1]
+
+    # Track at exact first timestep
+    t0 = dfs.start_time
+    track_df = pd.DataFrame({"x": [x], "y": [y]}, index=pd.DatetimeIndex([t0]))
+    result = dfs.extract_track(track_df, items=[3])
+
+    expected = da.to_numpy()[0, 100]
+    assert result[2].to_numpy()[0] == pytest.approx(expected, abs=1e-5)
+
+
+def test_track_between_timesteps() -> None:
+    """Track point halfway between timesteps should get linear interpolation."""
+    dfs = mikeio.open("tests/testdata/HD2D.dfsu")
+    ds = mikeio.read("tests/testdata/HD2D.dfsu", items=[3])
+    da = ds[0]
+
+    ec = dfs.geometry.element_coordinates
+    x, y = ec[100, 0], ec[100, 1]
+
+    # Track halfway between first two timesteps
+    t0 = dfs.start_time
+    t_half = t0 + pd.Timedelta(seconds=dfs.timestep / 2)
+    track_df = pd.DataFrame({"x": [x], "y": [y]}, index=pd.DatetimeIndex([t_half]))
+    result = dfs.extract_track(track_df, items=[3])
+
+    v0 = da.to_numpy()[0, 100]
+    v1 = da.to_numpy()[1, 100]
+    expected = (v0 + v1) / 2.0
+
+    assert result[2].to_numpy()[0] == pytest.approx(expected, abs=1e-5)

--- a/tests/test_track_interpolation.py
+++ b/tests/test_track_interpolation.py
@@ -4,11 +4,12 @@ import pandas as pd
 import pytest
 
 import mikeio
+from mikeio.dfsu import Dfsu2DH
 
 
 def test_track_at_exact_timestep() -> None:
     """Track point at exact dfsu timestep should return exact values."""
-    dfs = mikeio.open("tests/testdata/HD2D.dfsu")
+    dfs = Dfsu2DH("tests/testdata/HD2D.dfsu")
     ds = mikeio.read("tests/testdata/HD2D.dfsu", items=[3])
     da = ds[0]
 
@@ -27,7 +28,7 @@ def test_track_at_exact_timestep() -> None:
 
 def test_track_between_timesteps() -> None:
     """Track point halfway between timesteps should get linear interpolation."""
-    dfs = mikeio.open("tests/testdata/HD2D.dfsu")
+    dfs = Dfsu2DH("tests/testdata/HD2D.dfsu")
     ds = mikeio.read("tests/testdata/HD2D.dfsu", items=[3])
     da = ds[0]
 


### PR DESCRIPTION
## Why

_track.py:104 has t2 = t2 - 1e-10 with a TODO asking what it does. Without documentation, a future contributor might remove it (breaking edge-case behavior) or waste time investigating. The nudge ensures that track points falling exactly on a dfsu timestep boundary trigger the correct interpolation path.

## What this adds

- Replaces the TODO with a clear explanation of the nudge's purpose
- 2 tests verifying track extraction at exact timestep boundaries and halfway between timesteps