### PR TITLE
Fix broken llms.txt link in HTML head

### DIFF
--- a/docs/_llms-head.html
+++ b/docs/_llms-head.html
@@ -1,1 +1,1 @@
-<link rel="alternate" type="text/markdown" href="/mikeio/llms.txt" title="LLM-friendly documentation">
+<link rel="alternate" type="text/markdown" href="https://dhi.github.io/mikeio/llms.txt" title="LLM-friendly documentation">


### PR DESCRIPTION
The `<link rel="alternate">` tag in `_llms-head.html` used `href="/mikeio/llms.txt"`, which Quarto resolved against the site's base path (`/mikeio/`), producing a doubled `/mikeio/mikeio/llms.txt`.

Changed to the full URL to avoid path resolution issues.