### PR TITLE
Improve concat: test coverage, duplicate timestamp validation, match/case

### DIFF
--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -1079,6 +1079,14 @@ class Dataset:
         4
 
         """
+        for i, ds in enumerate(datasets):
+            if ds.time.has_duplicates:
+                raise ValueError(
+                    f"Dataset {i} has duplicate timestamps, "
+                    "e.g. from DA diagnostic output. "
+                    "Remove duplicates before concatenating."
+                )
+
         ds = datasets[0].copy()
         for dsj in datasets[1:]:
             ds = ds._concat_time(dsj, copy=False, keep=keep)
@@ -1125,19 +1133,12 @@ class Dataset:
         keep: Literal["last", "first"] = "last",
     ) -> Dataset:
         self._check_n_items(other)
-        # assuming time is always first dimension we can skip / keep it by bool
         start_dim = int("time" in self.dims)
         if not np.all(
             self.shape[start_dim:] == other.shape[int("time" in other.dims) :]
         ):
-            # if not np.all(self.shape[1:] == other.shape[1:]):
             raise ValueError("Shape of the datasets must match (except time dimension)")
-        if hasattr(self, "time"):  # using attribute instead of dim checking. Works
-            ds = self.copy() if copy else self
-        else:
-            raise ValueError(
-                "Datasets cannot be concatenated as they have no time attribute!"
-            )
+        ds = self.copy() if copy else self
 
         s1 = pd.Series(np.arange(len(ds.time)), index=ds.time, name="idx1")
         s2 = pd.Series(np.arange(len(other.time)), index=other.time, name="idx2")
@@ -1149,23 +1150,27 @@ class Dataset:
         idx1 = np.where(~df12["idx1"].isna())
         idx2 = np.where(~df12["idx2"].isna())
         for j in range(ds.n_items):
-            if keep == "last":
-                newdata[j][idx1] = ds[j].to_numpy()
-                newdata[j][idx2] = other[j].to_numpy()
-            else:
-                newdata[j][idx2] = other[j].to_numpy()
-                newdata[j][idx1] = ds[j].to_numpy()
+            match keep:
+                case "last":
+                    newdata[j][idx1] = ds[j].to_numpy()
+                    newdata[j][idx2] = other[j].to_numpy()
+                case "first":
+                    newdata[j][idx2] = other[j].to_numpy()
+                    newdata[j][idx1] = ds[j].to_numpy()
+                case _:
+                    raise ValueError(f"Invalid keep value: {keep!r}, expected 'first' or 'last'")
 
         zn = None
         if self._zn is not None and other._zn is not None:
             zshape = (len(newtime), self._zn.shape[start_dim])
             zn = np.zeros(shape=zshape, dtype=self._zn.dtype)
-            if keep == "last":
-                zn[idx1, :] = self._zn
-                zn[idx2, :] = other._zn
-            else:
-                zn[idx2, :] = other._zn
-                zn[idx1, :] = self._zn
+            match keep:
+                case "last":
+                    zn[idx1, :] = self._zn
+                    zn[idx2, :] = other._zn
+                case "first":
+                    zn[idx2, :] = other._zn
+                    zn[idx1, :] = self._zn
 
         return Dataset.from_numpy(
             newdata, time=newtime, items=ds.items, geometry=ds.geometry, zn=zn

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1018,6 +1018,22 @@ def test_concat_dataarray_keep_first() -> None:
     assert da3.to_numpy()[2] == 3.0
 
 
+def test_concat_duplicate_timestamps_raises() -> None:
+    # DA diagnostic output can have duplicate timestamps at correction times
+    time = pd.DatetimeIndex(["2000-01-01", "2000-01-01", "2000-01-02"])
+    ds1 = mikeio.Dataset.from_numpy(data=[np.zeros(3)], time=time)
+    ds2 = mikeio.Dataset.from_numpy(data=[np.ones(2)], time=pd.date_range("2000-01-03", periods=2))
+    with pytest.raises(ValueError, match="duplicate timestamps"):
+        mikeio.Dataset.concat([ds1, ds2])
+
+
+def test_concat_invalid_keep_raises() -> None:
+    ds1 = mikeio.read("tests/testdata/tide1.dfs1", time=[0, 1])
+    ds2 = mikeio.read("tests/testdata/tide1.dfs1", time=[2, 3])
+    with pytest.raises(ValueError, match="Invalid keep"):
+        mikeio.Dataset.concat([ds1, ds2], keep="lasst")  # type: ignore
+
+
 def test_concat_by_time() -> None:
     ds1 = mikeio.read("tests/testdata/tide1.dfs1")
     ds2 = mikeio.read("tests/testdata/tide2.dfs1") + 0.5  # add offset

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -349,6 +349,103 @@ def test_concat_keep(tmp_path: Path) -> None:
                     assert av_out, "overlap should be average of datasets"
 
 
+def test_concat_dfs0_keep_first_last(tmp_path: Path) -> None:
+    """Test keep='first' and keep='last' with overlapping dfs0 files."""
+    t1 = pd.date_range("2020-01-01", periods=4, freq="h")
+    t2 = pd.date_range("2020-01-01T02:00", periods=4, freq="h")
+
+    da1 = mikeio.DataArray(
+        data=np.array([10.0, 20.0, 30.0, 40.0]),
+        time=t1,
+        item=mikeio.ItemInfo("Test"),
+    )
+    da2 = mikeio.DataArray(
+        data=np.array([300.0, 400.0, 500.0, 600.0]),
+        time=t2,
+        item=mikeio.ItemInfo("Test"),
+    )
+
+    f1 = tmp_path / "a.dfs0"
+    f2 = tmp_path / "b.dfs0"
+    da1.to_dfs(f1)
+    da2.to_dfs(f2)
+
+    fp_first = tmp_path / "first.dfs0"
+    fp_last = tmp_path / "last.dfs0"
+
+    mikeio.generic.concat([f1, f2], fp_first, keep="first")
+    mikeio.generic.concat([f1, f2], fp_last, keep="last")
+
+    ds_first = mikeio.read(fp_first)
+    ds_last = mikeio.read(fp_last)
+
+    assert ds_first.n_timesteps == 6
+    assert ds_last.n_timesteps == 6
+
+    # Overlap at hours 2 and 3: da1=[30,40], da2=[300,400]
+    overlap_first = ds_first[0].to_numpy()[2:4]
+    overlap_last = ds_last[0].to_numpy()[2:4]
+
+    np.testing.assert_array_almost_equal(overlap_first, [30.0, 40.0])
+    np.testing.assert_array_almost_equal(overlap_last, [300.0, 400.0])
+
+
+def test_concat_dfs0_sorted_glob(tmp_path: Path) -> None:
+    """Test that sorted(glob(...)) gives correct results with keep='first'/'last'.
+
+    Simulates the workflow from GH issue #956: user collects dfs0 files with glob
+    and passes them to generic.concat. Files must be sorted chronologically.
+    """
+    from glob import glob
+
+    # Create 3 overlapping files (2 days overlap between consecutive files)
+    for i, year in enumerate([1979, 1980, 1981]):
+        t = pd.date_range(f"{year}-01-01", periods=6, freq="h")
+        da = mikeio.DataArray(
+            data=np.full(6, float(year)),
+            time=t,
+            item=mikeio.ItemInfo("WaterLevel"),
+        )
+        da.to_dfs(tmp_path / f"HD_Analysis_Loc_{year}.dfs0")
+
+    # Overwrite 1980 file to start at hour 4 of 1979 file (creating overlap)
+    t2 = pd.date_range("1979-01-01T04:00", periods=6, freq="h")
+    da2 = mikeio.DataArray(
+        data=np.full(6, 1980.0), time=t2, item=mikeio.ItemInfo("WaterLevel")
+    )
+    da2.to_dfs(tmp_path / "HD_Analysis_Loc_1980.dfs0")
+
+    t3 = pd.date_range("1979-01-01T08:00", periods=6, freq="h")
+    da3 = mikeio.DataArray(
+        data=np.full(6, 1981.0), time=t3, item=mikeio.ItemInfo("WaterLevel")
+    )
+    da3.to_dfs(tmp_path / "HD_Analysis_Loc_1981.dfs0")
+
+    files = sorted(glob(str(tmp_path / "HD_Analysis_Loc_*.dfs0")))
+    assert len(files) == 3
+
+    fp_first = tmp_path / "keep_first.dfs0"
+    fp_last = tmp_path / "keep_last.dfs0"
+
+    mikeio.generic.concat(files, fp_first, keep="first")
+    mikeio.generic.concat(files, fp_last, keep="last")
+
+    ds_first = mikeio.read(fp_first)
+    ds_last = mikeio.read(fp_last)
+
+    # Total timeline: hours 0-13 = 14 timesteps
+    assert ds_first.n_timesteps == 14
+    assert ds_last.n_timesteps == 14
+
+    # Overlap between file 1 and 2 at hours 4,5: values 1979 vs 1980
+    assert ds_first[0].to_numpy()[4] == pytest.approx(1979.0)  # keep first
+    assert ds_last[0].to_numpy()[4] == pytest.approx(1980.0)  # keep last
+
+    # Overlap between file 2 and 3 at hours 8,9: values 1980 vs 1981
+    assert ds_first[0].to_numpy()[8] == pytest.approx(1980.0)  # keep first
+    assert ds_last[0].to_numpy()[8] == pytest.approx(1981.0)  # keep last
+
+
 def test_concat_average(tmp_path: Path) -> None:
     # Test for multiple items?
     g = mikeio.Grid1D(x=range(5))


### PR DESCRIPTION
## Summary
- Adds unit tests verifying overlap values for `keep='first'` and `keep='last'` in `generic.concat` with dfs0 files
- Adds integration test using `sorted(glob(...))` to reproduce the [#956](https://github.com/DHI/mikeio/issues/956) workflow
- Rejects datasets with duplicate timestamps (e.g. DA diagnostic output) with a clear error instead of cryptic pandas `cannot reindex on an axis with duplicate labels`
- Uses `match/case` for the `keep` parameter to catch invalid values like typos
- Removes dead `hasattr(self, "time")` check and stale comments

The concat logic is correct — `glob()` returns files in arbitrary order, which is the likely root cause of #956. The workaround is `sorted(glob(...))`.

Closes #956