### PR TITLE
Add GeometryFM3D.from_2d_geometry() for building 3D mesh from 2D

### DIFF
--- a/docs/examples/dfsu/create_3d_initial_conditions.qmd
+++ b/docs/examples/dfsu/create_3d_initial_conditions.qmd
@@ -1,0 +1,206 @@
+---
+title: Create 3D initial conditions from CTD profiles
+jupyter: python3
+description: Build a 3D mesh from a 2D mesh and vertical discretization, interpolate CTD profiles to create temperature and salinity initial conditions.
+---
+
+This example shows how to create initial condition fields for a MIKE 3 FM model from CTD profile observations. The workflow:
+
+1. Read a 2D mesh and define the vertical discretization
+2. Build a 3D geometry using `GeometryFM3D.from_2d_geometry()`
+3. Interpolate two fictive CTD profiles onto every 3D element
+4. Write the result as a dfsu file
+
+## Setup
+
+```{python}
+import numpy as np
+import matplotlib.pyplot as plt
+
+import mikeio
+from mikeio.spatial import GeometryFM3D
+```
+
+## Read vertical discretization from m3fm
+
+The vertical discretization of a MIKE 3 FM model is defined in the `.m3fm` setup file. We read it as a PFS document and extract the relevant parameters from the `[DOMAIN]` section.
+
+```{python}
+pfs = mikeio.PfsDocument("../../data/pfs/oresund.m3fm")
+domain = pfs.FemEngineHD.DOMAIN
+
+n_sigma = domain.number_of_layers
+layer_fractions = domain.layer_thickness
+```
+
+```{python}
+n_sigma
+```
+
+```{python}
+layer_fractions
+```
+
+## Read mesh and build 3D geometry
+
+Read the 2D mesh — the z-coordinates represent the bathymetry. Here we use `odense_rough.mesh` as a stand-in for the mesh referenced in the m3fm.
+
+```{python}
+mesh = mikeio.open("../../data/odense_rough.mesh")
+g2d = mesh.geometry
+g2d
+```
+
+Build the 3D geometry by extruding the 2D mesh with the vertical discretization from the m3fm.
+
+```{python}
+g3d = GeometryFM3D.from_2d_geometry(
+    g2d,
+    n_sigma=n_sigma,
+    layer_fractions=layer_fractions,
+)
+g3d
+```
+
+```{python}
+elem_coords = g3d.element_coordinates
+```
+
+## Define CTD profiles
+
+Two fictive CTD stations at different locations in the estuary — one near the inlet (saltier, cooler) and one upstream (fresher, warmer).
+
+```{python}
+# Station positions (UTM-33)
+ctd_x = np.array([213000, 222000])
+ctd_y = np.array([6155500, 6162000])
+
+# Depth levels (positive downward)
+ctd_depth = np.array([0, 2, 4, 6, 8, 10])
+
+# Temperature profiles (°C) — warmer upstream, cooler near inlet
+ctd_temp = np.array([
+    [14.0, 13.5, 12.0, 10.5, 9.0, 8.0],   # station 0 (inlet)
+    [18.0, 17.5, 16.0, 14.0, 12.0, 11.0],  # station 1 (upstream)
+])
+
+# Salinity profiles (PSU) — saltier near inlet, fresher upstream
+ctd_sal = np.array([
+    [25.0, 26.0, 28.0, 30.0, 31.0, 31.5],  # station 0 (inlet)
+    [ 5.0,  6.0,  8.0, 12.0, 15.0, 16.0],  # station 1 (upstream)
+])
+```
+
+```{python}
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4), sharey=True)
+for i, label in enumerate(["Inlet", "Upstream"]):
+    ax1.plot(ctd_temp[i], -ctd_depth, "o-", label=label)
+    ax2.plot(ctd_sal[i], -ctd_depth, "o-", label=label)
+ax1.set(xlabel="Temperature (°C)", ylabel="Depth (m)", title="Temperature")
+ax2.set(xlabel="Salinity (PSU)", title="Salinity")
+ax1.legend()
+fig.tight_layout();
+```
+
+## Interpolate onto 3D mesh
+
+For each element, interpolate the CTD profiles vertically to the element depth, then blend horizontally using inverse distance weighting.
+
+```{python}
+def interpolate_ctd(
+    elem_coords: np.ndarray,
+    ctd_x: np.ndarray,
+    ctd_y: np.ndarray,
+    ctd_depth: np.ndarray,
+    ctd_values: np.ndarray,
+) -> np.ndarray:
+    """Interpolate CTD profiles to 3D element centers.
+
+    Parameters
+    ----------
+    elem_coords : (n_elements, 3) array of x, y, z
+    ctd_x, ctd_y : (n_stations,) station positions
+    ctd_depth : (n_depths,) depth levels (positive down)
+    ctd_values : (n_stations, n_depths) profile values
+
+    Returns
+    -------
+    (n_elements,) interpolated values
+    """
+    n_stations = len(ctd_x)
+    elem_depth = -elem_coords[:, 2]  # positive downward
+
+    # Vertical interpolation: one profile per station → value at each element depth
+    vert_interp = np.column_stack([
+        np.interp(elem_depth, ctd_depth, ctd_values[i])
+        for i in range(n_stations)
+    ])  # shape: (n_elements, n_stations)
+
+    # Horizontal: inverse distance weighting
+    dist = np.column_stack([
+        np.sqrt((elem_coords[:, 0] - ctd_x[i])**2 +
+                (elem_coords[:, 1] - ctd_y[i])**2)
+        for i in range(n_stations)
+    ])  # shape: (n_elements, n_stations)
+
+    weights = 1.0 / dist**2
+    weights /= weights.sum(axis=1, keepdims=True)
+
+    return (vert_interp * weights).sum(axis=1)
+```
+
+```{python}
+temp = interpolate_ctd(elem_coords, ctd_x, ctd_y, ctd_depth, ctd_temp)
+sal = interpolate_ctd(elem_coords, ctd_x, ctd_y, ctd_depth, ctd_sal)
+```
+
+## Create dataset and write
+
+```{python}
+import pandas as pd
+
+time = pd.Timestamp("2020-01-01")
+
+ds = mikeio.Dataset(
+    [
+        mikeio.DataArray(
+            data=temp[np.newaxis, :].astype(np.float32),
+            time=[time],
+            geometry=g3d,
+            item=mikeio.ItemInfo("Temperature", mikeio.EUMType.Temperature),
+        ),
+        mikeio.DataArray(
+            data=sal[np.newaxis, :].astype(np.float32),
+            time=[time],
+            geometry=g3d,
+            item=mikeio.ItemInfo("Salinity", mikeio.EUMType.Salinity),
+        ),
+    ]
+)
+ds
+```
+
+```{python}
+ds.to_dfs("initial_conditions_3d.dfsu")
+```
+
+## Verify
+
+Read back and inspect the result.
+
+```{python}
+ds_back = mikeio.read("initial_conditions_3d.dfsu")
+ds_back
+```
+
+```{python}
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
+ds_back["Temperature"].isel(time=0).sel(layers="top").plot(ax=ax1, title="Surface temperature")
+ds_back["Salinity"].isel(time=0).sel(layers="top").plot(ax=ax2, title="Surface salinity");
+```
+
+```{python}
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
+ds_back["Temperature"].isel(time=0).sel(layers="bottom").plot(ax=ax1, title="Bottom temperature")
+ds_back["Salinity"].isel(time=0).sel(layers="bottom").plot(ax=ax2, title="Bottom salinity");
+```

--- a/src/mikeio/dfsu/_dfsu.py
+++ b/src/mikeio/dfsu/_dfsu.py
@@ -118,11 +118,10 @@ def write_dfsu_data(dfs: DfsuFile, ds: Dataset, is_layered: bool) -> None:
 
     for i in range(n_time_steps):
         if is_layered:
-            if "time" in data.dims:
-                assert data._zn is not None
-                zn = data._zn[i]
+            if data._zn is not None:
+                zn = data._zn[i] if "time" in data.dims else data._zn
             else:
-                zn = data._zn
+                zn = data.geometry.node_coordinates[:, 2]
             dfs.WriteItemTimeStepNext(t_rel[i], zn.astype(np.float32))
         for da in data:
             if "time" in data.dims:

--- a/src/mikeio/spatial/_FM_geometry_layered.py
+++ b/src/mikeio/spatial/_FM_geometry_layered.py
@@ -530,6 +530,76 @@ class _GeometryFMLayered(_GeometryFM):
 class GeometryFM3D(_GeometryFMLayered):
     """Flexible 3d mesh geometry."""
 
+    @classmethod
+    def from_2d_geometry(
+        cls,
+        geometry2d: GeometryFM2D,
+        n_sigma: int,
+        *,
+        layer_fractions: Sequence[float] | None = None,
+        sigma_depth: float | None = None,
+        z_layer_thickness: float | Sequence[float] | None = None,
+    ) -> GeometryFM3D:
+        """Create a 3D geometry by extruding a 2D mesh vertically.
+
+        Parameters
+        ----------
+        geometry2d : GeometryFM2D
+            2D mesh where z-coordinates represent bathymetry (bottom).
+            Surface is at z=0.
+        n_sigma : int
+            Number of sigma layers.
+        layer_fractions : Sequence[float] | None
+            Relative sigma layer thicknesses (bottom to top), must sum
+            to 1.0 and have length == n_sigma. If None, equidistant.
+        sigma_depth : float | None
+            Z-coordinate where sigma domain ends and z-layers begin.
+            Required (and only used) together with z_layer_thickness.
+        z_layer_thickness : float | Sequence[float] | None
+            Thickness of z-layers below sigma_depth. If a float,
+            equidistant layers of that thickness are created as deep
+            as the bathymetry requires. If a sequence, specifies
+            individual layer thicknesses from bottom to top.
+            Required together with sigma_depth.
+
+        Returns
+        -------
+        GeometryFM3D
+
+        """
+        if n_sigma < 1:
+            raise ValueError("n_sigma must be >= 1")
+        if layer_fractions is not None:
+            if len(layer_fractions) != n_sigma:
+                raise ValueError(
+                    f"layer_fractions length ({len(layer_fractions)}) "
+                    f"must equal n_sigma ({n_sigma})"
+                )
+            if abs(sum(layer_fractions) - 1.0) > 1e-6:
+                raise ValueError("layer_fractions must sum to 1.0")
+        if (sigma_depth is None) != (z_layer_thickness is None):
+            raise ValueError(
+                "sigma_depth and z_layer_thickness must be specified together"
+            )
+
+        # Compute cumulative sigma fractions
+        if layer_fractions is not None:
+            cum_sigma = np.zeros(n_sigma + 1)
+            cum_sigma[1:] = np.cumsum(layer_fractions)
+        else:
+            cum_sigma = np.linspace(0, 1, n_sigma + 1)
+
+        if sigma_depth is None:
+            return _build_sigma_geometry(geometry2d, n_sigma, cum_sigma, cls)
+        else:
+            assert z_layer_thickness is not None
+            z_levels = _z_levels_from_thickness(
+                sigma_depth, z_layer_thickness, geometry2d
+            )
+            return _build_sigma_z_geometry(
+                geometry2d, n_sigma, cum_sigma, z_levels, cls
+            )
+
     @property
     def plot(self) -> None:
         raise AttributeError(
@@ -780,3 +850,186 @@ class GeometryFMVerticalProfilePlotter:
             cmax=1.0,
             **kwargs,
         )
+
+
+# --- Builder functions for GeometryFM3D.from_2d_geometry ---
+
+
+def _z_levels_from_thickness(
+    sigma_depth: float,
+    z_layer_thickness: float | Sequence[float],
+    geometry2d: GeometryFM2D,
+) -> list[float]:
+    """Compute z-level interfaces from sigma depth and layer thicknesses.
+
+    Returns ascending list of z-coordinates. The last value is sigma_depth.
+    The number of z-levels equals the max number of z-layers. The bottom
+    z-layer extends from bathymetry down to z_levels[0].
+    """
+    if isinstance(z_layer_thickness, (int, float)):
+        # Equidistant: step down from sigma_depth, stop before going
+        # at or below the deepest bathymetry
+        dz = float(z_layer_thickness)
+        min_bathy = float(geometry2d.node_coordinates[:, 2].min())
+        levels: list[float] = []
+        z = sigma_depth
+        while True:
+            z -= dz
+            if z <= min_bathy:
+                break
+            levels.insert(0, z)
+        levels.append(sigma_depth)
+    else:
+        # Variable: thicknesses from bottom to top define interfaces
+        # below sigma_depth. Exclude the bottommost boundary (bathymetry
+        # provides it).
+        levels = [sigma_depth]
+        z = sigma_depth
+        for dz in reversed(z_layer_thickness):
+            z -= dz
+            levels.insert(0, z)
+        levels.pop(0)  # remove deepest boundary; bathymetry handles it
+    return levels
+
+
+def _build_sigma_geometry(
+    geometry2d: GeometryFM2D,
+    n_sigma: int,
+    cum_sigma: np.ndarray,
+    cls: type[GeometryFM3D],
+) -> GeometryFM3D:
+    """Build pure sigma 3D geometry from 2D mesh."""
+    n2d_elems = geometry2d.n_elements
+    npl = n_sigma + 1  # node levels per column
+
+    # --- Nodes ---
+    xy_2d = geometry2d.node_coordinates[:, :2]
+    z_bot = geometry2d.node_coordinates[:, 2]
+
+    # z_3d[i, k] = z_bot[i] + cum_sigma[k] * (0 - z_bot[i]) = z_bot[i] * (1 - cum_sigma[k])
+    z_3d = z_bot[:, np.newaxis] * (1.0 - cum_sigma[np.newaxis, :])
+    xy_rep = np.repeat(xy_2d, npl, axis=0)
+    node_coords = np.column_stack([xy_rep, z_3d.ravel()])
+
+    # --- Codes ---
+    codes = np.repeat(geometry2d.codes, npl)
+
+    # --- Elements ---
+    elem_table: list[np.ndarray] = []
+    for j in range(n2d_elems):
+        nodes_2d = geometry2d.element_table[j]
+        base = np.asarray(nodes_2d, dtype=np.int32) * npl
+        for k in range(n_sigma):
+            bot = base + k
+            top = base + (k + 1)
+            elem_table.append(np.concatenate([bot, top]))
+
+    return cls(
+        node_coordinates=node_coords,
+        element_table=elem_table,
+        codes=codes,
+        projection=geometry2d.projection_string,
+        dfsu_type=DfsuFileType.Dfsu3DSigma,
+        n_layers=n_sigma,
+        n_sigma=n_sigma,
+        validate=False,
+    )
+
+
+def _build_sigma_z_geometry(
+    geometry2d: GeometryFM2D,
+    n_sigma: int,
+    cum_sigma: np.ndarray,
+    z_levels: list[float],
+    cls: type[GeometryFM3D],
+) -> GeometryFM3D:
+    """Build sigma-z 3D geometry from 2D mesh."""
+    n2d_nodes = geometry2d.n_nodes
+    n2d_elems = geometry2d.n_elements
+    z_levels_arr = np.array(z_levels, dtype=np.float64)
+    sigma_depth = z_levels_arr[-1]
+    n_z_max = len(z_levels)
+    n_layers_max = n_sigma + n_z_max
+
+    xy_2d = geometry2d.node_coordinates[:, :2]
+    z_bot = geometry2d.node_coordinates[:, 2]
+
+    # --- Per-node: determine z-coordinates for each column ---
+    # For each node, find active z-levels (those strictly above z_bot)
+    node_z_lists: list[np.ndarray] = []
+    node_offset = np.zeros(n2d_nodes + 1, dtype=np.int32)
+
+    for i in range(n2d_nodes):
+        zb = z_bot[i]
+        # Active z-levels: those strictly above bathymetry
+        active_z = z_levels_arr[z_levels_arr > zb]
+
+        if len(active_z) == 0:
+            # All z-levels at or below bathymetry → pure sigma for this node
+            sigma_top = 0.0
+            sigma_bot = zb
+        else:
+            sigma_top = 0.0
+            sigma_bot = sigma_depth  # sigma domain: sigma_depth to 0
+
+        # Sigma node levels
+        sigma_z = sigma_bot + cum_sigma * (sigma_top - sigma_bot)
+
+        if len(active_z) == 0:
+            # No z-layers, just sigma
+            z_col = sigma_z
+        else:
+            # Z-layer levels: [z_bot, active_z_levels below sigma_depth...]
+            z_below_sigma = (
+                active_z[active_z < sigma_depth] if sigma_depth > zb else np.array([])
+            )
+            z_layer_nodes = np.concatenate([[zb], z_below_sigma])
+            # Combine z-layer nodes + sigma nodes (sigma starts at sigma_depth)
+            z_col = np.concatenate([z_layer_nodes, sigma_z])
+
+        node_z_lists.append(z_col)
+        node_offset[i + 1] = node_offset[i] + len(z_col)
+
+    # Build node coordinates
+    total_nodes = node_offset[-1]
+    node_coords = np.zeros((total_nodes, 3), dtype=np.float64)
+    codes = np.zeros(total_nodes, dtype=np.int32)
+
+    for i in range(n2d_nodes):
+        start = node_offset[i]
+        end = node_offset[i + 1]
+        node_coords[start:end, 0] = xy_2d[i, 0]
+        node_coords[start:end, 1] = xy_2d[i, 1]
+        node_coords[start:end, 2] = node_z_lists[i]
+        codes[start:end] = geometry2d.codes[i]
+
+    # --- Per-element: determine layers and build element table ---
+    elem_table: list[np.ndarray] = []
+
+    for j in range(n2d_elems):
+        nodes_2d = np.asarray(geometry2d.element_table[j], dtype=np.int32)
+
+        # Number of z-layers for this column = min active z-levels across nodes
+        min_active_z = min(int(np.sum(z_levels_arr > z_bot[ni])) for ni in nodes_2d)
+        n_z_col = min_active_z
+        n_layers_col = n_z_col + n_sigma
+
+        for k in range(n_layers_col):
+            bot_nodes = np.array(
+                [node_offset[ni] + k for ni in nodes_2d], dtype=np.int32
+            )
+            top_nodes = np.array(
+                [node_offset[ni] + k + 1 for ni in nodes_2d], dtype=np.int32
+            )
+            elem_table.append(np.concatenate([bot_nodes, top_nodes]))
+
+    return cls(
+        node_coordinates=node_coords,
+        element_table=elem_table,
+        codes=codes,
+        projection=geometry2d.projection_string,
+        dfsu_type=DfsuFileType.Dfsu3DSigmaZ,
+        n_layers=n_layers_max,
+        n_sigma=n_sigma,
+        validate=False,
+    )

--- a/src/mikeio/spatial/_FM_geometry_layered.py
+++ b/src/mikeio/spatial/_FM_geometry_layered.py
@@ -587,7 +587,7 @@ class GeometryFM3D(_GeometryFMLayered):
             cum_sigma = np.zeros(n_sigma + 1)
             cum_sigma[1:] = np.cumsum(layer_fractions)
         else:
-            cum_sigma = np.linspace(0, 1, n_sigma + 1)
+            cum_sigma = np.linspace(0.0, 1.0, n_sigma + 1)  # type: ignore[assignment]
 
         if sigma_depth is None:
             return _build_sigma_geometry(geometry2d, n_sigma, cum_sigma, cls)

--- a/tests/test_geometry_fm.py
+++ b/tests/test_geometry_fm.py
@@ -1,5 +1,7 @@
+import numpy as np
 import pytest
 
+import mikeio
 from mikeio.exceptions import OutsideModelDomainError
 from mikeio.spatial import GeometryFM2D, GeometryFM3D, GeometryPoint2D
 
@@ -277,3 +279,245 @@ def test_equality_shifted_coords() -> None:
 
     g2 = GeometryFM2D(node_coordinates=nc2, element_table=el, projection="LONG/LAT")
     assert g != g2
+
+
+# --- from_2d_geometry tests ---
+
+
+@pytest.fixture
+def triangle_2d() -> GeometryFM2D:
+    """Simple 1-triangle 2D mesh with bathymetry at z=-10."""
+    nc = [
+        (0.0, 0.0, -10.0),
+        (1.0, 0.0, -10.0),
+        (0.5, 1.0, -10.0),
+    ]
+    el = [(0, 1, 2)]
+    return GeometryFM2D(nc, el, projection="UTM-33")
+
+
+@pytest.fixture
+def two_triangles_2d() -> GeometryFM2D:
+    """2-triangle mesh with different bathymetry depths."""
+    nc = [
+        (0.0, 0.0, -10.0),
+        (1.0, 0.0, -8.0),
+        (1.0, 1.0, -6.0),
+        (0.0, 1.0, -12.0),
+    ]
+    el = [(0, 1, 2), (0, 2, 3)]
+    return GeometryFM2D(nc, el, projection="UTM-33")
+
+
+class TestFromTwoDGeometrySigma:
+    """Tests for GeometryFM3D.from_2d_geometry with pure sigma layers."""
+
+    def test_basic_counts(self, triangle_2d: GeometryFM2D) -> None:
+        g3d = GeometryFM3D.from_2d_geometry(triangle_2d, n_sigma=3)
+        assert g3d.n_nodes == 3 * (3 + 1)  # 12
+        assert g3d.n_elements == 1 * 3  # 3
+
+    def test_element_table_structure(self, triangle_2d: GeometryFM2D) -> None:
+        g3d = GeometryFM3D.from_2d_geometry(triangle_2d, n_sigma=3)
+        # 3 prism elements, bottom to top
+        # 2D nodes [0, 1, 2], npl = 4 (nodes per level)
+        # Layer 0 (bottom): [0*4+0, 1*4+0, 2*4+0, 0*4+1, 1*4+1, 2*4+1] = [0,4,8,1,5,9]
+        assert len(g3d.element_table) == 3
+        e0 = g3d.element_table[0]
+        assert len(e0) == 6  # prism = 6 nodes
+        np.testing.assert_array_equal(e0, [0, 4, 8, 1, 5, 9])
+
+    def test_z_coordinates_equidistant(self, triangle_2d: GeometryFM2D) -> None:
+        g3d = GeometryFM3D.from_2d_geometry(triangle_2d, n_sigma=4)
+        # Node 0 column: z = -10, -7.5, -5, -2.5, 0 (equidistant)
+        npl = 5  # 4 layers + 1
+        z_col0 = g3d.node_coordinates[0:npl, 2]
+        expected = [-10.0, -7.5, -5.0, -2.5, 0.0]
+        np.testing.assert_array_almost_equal(z_col0, expected)
+
+    def test_z_coordinates_nonequidistant(self, triangle_2d: GeometryFM2D) -> None:
+        fractions = [0.5, 0.3, 0.2]  # bottom to top
+        g3d = GeometryFM3D.from_2d_geometry(
+            triangle_2d, n_sigma=3, layer_fractions=fractions
+        )
+        # Node 0: z_bot=-10, surface=0, depth=10
+        # cumulative: [0, 0.5, 0.8, 1.0]
+        # z = -10 + c * 10 → [-10, -5, -2, 0]
+        npl = 4
+        z_col0 = g3d.node_coordinates[0:npl, 2]
+        np.testing.assert_array_almost_equal(z_col0, [-10.0, -5.0, -2.0, 0.0])
+
+    def test_properties(self, triangle_2d: GeometryFM2D) -> None:
+        g3d = GeometryFM3D.from_2d_geometry(triangle_2d, n_sigma=3)
+        assert g3d.n_layers == 3
+        assert g3d.n_sigma_layers == 3
+        assert g3d.n_z_layers == 0
+        assert g3d.is_layered
+
+    def test_top_and_bottom_elements(self, triangle_2d: GeometryFM2D) -> None:
+        g3d = GeometryFM3D.from_2d_geometry(triangle_2d, n_sigma=3)
+        np.testing.assert_array_equal(g3d.top_elements, [2])
+        np.testing.assert_array_equal(g3d.bottom_elements, [0])
+
+    def test_multi_element(self, two_triangles_2d: GeometryFM2D) -> None:
+        g3d = GeometryFM3D.from_2d_geometry(two_triangles_2d, n_sigma=3)
+        assert g3d.n_nodes == 4 * (3 + 1)  # 16
+        assert g3d.n_elements == 2 * 3  # 6
+        assert len(g3d.top_elements) == 2
+        assert len(g3d.bottom_elements) == 2
+
+    def test_projection_preserved(self, triangle_2d: GeometryFM2D) -> None:
+        g3d = GeometryFM3D.from_2d_geometry(triangle_2d, n_sigma=3)
+        assert g3d.projection_string == "UTM-33"
+
+    def test_xy_preserved(self, triangle_2d: GeometryFM2D) -> None:
+        g3d = GeometryFM3D.from_2d_geometry(triangle_2d, n_sigma=2)
+        # Each 2D node appears at 3 levels (n_sigma+1)
+        npl = 3
+        # Node 0 column: all should have x=0, y=0
+        np.testing.assert_array_equal(g3d.node_coordinates[0:npl, 0], [0.0, 0.0, 0.0])
+        np.testing.assert_array_equal(g3d.node_coordinates[0:npl, 1], [0.0, 0.0, 0.0])
+
+    def test_codes_replicated(self, triangle_2d: GeometryFM2D) -> None:
+        g3d = GeometryFM3D.from_2d_geometry(triangle_2d, n_sigma=3)
+        # Default codes are 0 for all nodes; they should be replicated
+        assert len(g3d.codes) == g3d.n_nodes
+
+    def test_roundtrip_basin_3d(self) -> None:
+        ds = mikeio.read("tests/testdata/basin_3d.dfsu", time=0)
+        g_orig = ds.geometry
+        assert isinstance(g_orig, GeometryFM3D)
+        g2d = g_orig.to_2d_geometry()
+        g_new = GeometryFM3D.from_2d_geometry(g2d, n_sigma=g_orig.n_sigma_layers)
+        assert g_new.n_elements == g_orig.n_elements
+        assert g_new.n_nodes == g_orig.n_nodes
+        assert g_new.n_layers == g_orig.n_layers
+
+
+class TestFromTwoDGeometrySigmaZ:
+    """Tests for GeometryFM3D.from_2d_geometry with sigma-z layers."""
+
+    def test_oresund_structure(self) -> None:
+        """Verify sigma-z creation with oresund-like parameters."""
+        ds = mikeio.read("tests/testdata/oresund_sigma_z.dfsu", time=0)
+        g_orig = ds.geometry
+        assert isinstance(g_orig, GeometryFM3D)
+        g2d = g_orig.to_2d_geometry()
+        # oresund: sigma_depth=-8, equidistant 5m z-layers
+        g_new = GeometryFM3D.from_2d_geometry(
+            g2d, n_sigma=4, sigma_depth=-8.0, z_layer_thickness=5.0
+        )
+        assert g_new.n_layers == g_orig.n_layers
+        assert g_new.n_sigma_layers == g_orig.n_sigma_layers
+        assert g_new.n_z_layers == g_orig.n_z_layers
+        # Same number of 2D columns
+        assert len(g_new.n_layers_per_column) == len(g_orig.n_layers_per_column)
+        # Layer counts per column are in valid range
+        assert all(4 <= n <= 9 for n in g_new.n_layers_per_column)
+
+    def test_sigma_z_exact_reconstruction(self) -> None:
+        """Verify exact reconstruction with a controlled 2-triangle mesh."""
+        # sigma_depth=-8, z_layer_thickness=5 → z-levels at -13, -8
+        # Node at -15: below -13 → 1 z-layer + partial bottom
+        # Node at -5: above sigma depth -8 → 0 z-layers
+        # Node at -3: above sigma depth → 0 z-layers
+        # Node at -20: below -13 → 2 z-layers + partial bottom
+        nc = [
+            (0.0, 0.0, -15.0),
+            (1.0, 0.0, -5.0),
+            (1.0, 1.0, -3.0),
+            (0.0, 1.0, -20.0),
+        ]
+        el = [(0, 1, 2), (0, 2, 3)]
+        g2d = GeometryFM2D(nc, el, projection="UTM-33")
+
+        g3d = GeometryFM3D.from_2d_geometry(
+            g2d, n_sigma=2, sigma_depth=-8.0, z_layer_thickness=5.0
+        )
+        assert g3d.n_sigma_layers == 2
+        nlpc = g3d.n_layers_per_column
+        # Element 0 (nodes at -15, -5, -3): shallowest=-3, above -8 → 0 z-layers → 2 layers
+        assert nlpc[0] == 2
+        # Element 1 (nodes at -15, -3, -20): shallowest=-3, above -8 → 0 z-layers → 2 layers
+        assert nlpc[1] == 2
+
+    def test_sigma_z_variable_thickness(self) -> None:
+        """Sigma-z with variable z-layer thicknesses (bottom to top)."""
+        nc = [
+            (0.0, 0.0, -20.0),
+            (1.0, 0.0, -20.0),
+            (0.5, 1.0, -20.0),
+        ]
+        el = [(0, 1, 2)]
+        g2d = GeometryFM2D(nc, el, projection="UTM-33")
+
+        # sigma_depth=-5, thicknesses [3, 5, 7] bottom to top
+        # z-levels from sigma_depth down: -5, -12, -17, -20
+        g3d = GeometryFM3D.from_2d_geometry(
+            g2d, n_sigma=2, sigma_depth=-5.0, z_layer_thickness=[3, 5, 7]
+        )
+        assert g3d.n_sigma_layers == 2
+        assert g3d.n_z_layers == 3
+        assert g3d.n_layers == 5  # 2 sigma + 3 z
+
+    def test_sigma_z_basic(self, two_triangles_2d: GeometryFM2D) -> None:
+        """Sigma-z where some columns lose z-layers due to shallow bathymetry."""
+        # Nodes at z=-10, -8, -6, -12
+        # sigma_depth=-7, z_layer_thickness=2 → z-levels at -9, -7
+        # Element 0 (nodes at -10,-8,-6): shallowest=-6, above sigma → 0 z-layers → 2 sigma
+        # Element 1 (nodes at -10,-6,-12): shallowest=-6, above sigma → 0 z-layers → 2 sigma
+        g3d = GeometryFM3D.from_2d_geometry(
+            two_triangles_2d, n_sigma=2, sigma_depth=-7.0, z_layer_thickness=2.0
+        )
+        assert g3d.n_sigma_layers == 2
+
+    def test_shallow_mesh_equals_pure_sigma(self) -> None:
+        """If all bathymetry is above sigma depth, result should be like pure sigma."""
+        nc = [
+            (0.0, 0.0, -3.0),
+            (1.0, 0.0, -2.0),
+            (0.5, 1.0, -4.0),
+        ]
+        el = [(0, 1, 2)]
+        g2d = GeometryFM2D(nc, el, projection="UTM-33")
+
+        # sigma_depth=-6, z_layer_thickness=2 → z-levels at -8, -6
+        # All nodes above -6 → no z-layers active → 3 layers only
+        g3d = GeometryFM3D.from_2d_geometry(
+            g2d, n_sigma=3, sigma_depth=-6.0, z_layer_thickness=2.0
+        )
+        assert all(n == 3 for n in g3d.n_layers_per_column)
+
+
+class TestFromTwoDGeometryValidation:
+    """Validation tests for from_2d_geometry."""
+
+    def test_n_sigma_zero_raises(self, triangle_2d: GeometryFM2D) -> None:
+        with pytest.raises(ValueError):
+            GeometryFM3D.from_2d_geometry(triangle_2d, n_sigma=0)
+
+    def test_wrong_fractions_length_raises(self, triangle_2d: GeometryFM2D) -> None:
+        with pytest.raises(ValueError):
+            GeometryFM3D.from_2d_geometry(
+                triangle_2d, n_sigma=3, layer_fractions=[0.5, 0.5]
+            )
+
+    def test_fractions_not_summing_to_one_raises(
+        self, triangle_2d: GeometryFM2D
+    ) -> None:
+        with pytest.raises(ValueError):
+            GeometryFM3D.from_2d_geometry(
+                triangle_2d, n_sigma=3, layer_fractions=[0.5, 0.3, 0.3]
+            )
+
+    def test_sigma_depth_without_thickness_raises(
+        self, triangle_2d: GeometryFM2D
+    ) -> None:
+        with pytest.raises(ValueError):
+            GeometryFM3D.from_2d_geometry(triangle_2d, n_sigma=3, sigma_depth=-5.0)
+
+    def test_thickness_without_sigma_depth_raises(
+        self, triangle_2d: GeometryFM2D
+    ) -> None:
+        with pytest.raises(ValueError):
+            GeometryFM3D.from_2d_geometry(triangle_2d, n_sigma=3, z_layer_thickness=2.0)

--- a/tests/testdata/pfs/oresund.m3fm
+++ b/tests/testdata/pfs/oresund.m3fm
@@ -1,0 +1,4437 @@
+// Created     : 2023-09-20 12:55:30
+// DLL         : C:\Program Files (x86)\DHI\MIKE Zero\2024\bin\x64\pfs2004.dll
+// Version     : 22.0.3.17261
+
+[FemEngineHD]
+   [DOMAIN]
+      Touched = 1
+      discretization = 2
+      number_of_dimensions = 3
+      number_of_meshes = 1
+      file_name = |..\..\Data\1997\Bathymetry\oresund.mesh|
+      type_of_reordering = 1
+      number_of_domains = 16
+      coordinate_type = 'UTM-33'
+      minimum_depth = -0.06142248369917411
+      datum_depth = 0.0
+      vertical_mesh_type_overall = 1
+      number_of_layers = 10
+      z_sigma = 0.0
+      vertical_mesh_type = 1
+      layer_thickness = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1
+      sigma_c = 0.0
+      theta = 2.0
+      b = 0.0
+      number_of_layers_zlevel = 10
+      vertical_mesh_type_zlevel = 1
+      constant_layer_thickness_zlevel = 0.0
+      variable_layer_thickness_zlevel = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+      type_of_bathymetry_adjustment = 1
+      minimum_layer_thickness_zlevel = 0.0
+      type_of_mesh = 0
+      type_of_gauss = 3
+      [BOUNDARY_NAMES]
+         Touched = 1
+         MzSEPfsListItemCount = 2
+         [CODE_3]
+            Touched = 0
+            name = 'South'
+         EndSect  // CODE_3
+
+         [CODE_2]
+            Touched = 0
+            name = 'North'
+         EndSect  // CODE_2
+
+      EndSect  // BOUNDARY_NAMES
+
+      [MATERIAL]
+         Touched = 0
+         include_material_zones = 0
+         [MATERIAL_ZONES]
+            Touched = 0
+            MzSEPfsListItemCount = 0
+            input_format = 1
+            format_code = 2
+            coordinate_type = 'UTM-33'
+            file_name = ||
+            item_number_for_code = 1
+            item_name_for_code = ''
+         EndSect  // MATERIAL_ZONES
+
+      EndSect  // MATERIAL
+
+      [INFRASTRUCTURE]
+         Touched = 0
+         include_building_zones = 0
+         include_road_zones = 0
+         [BUILDING_ZONES]
+            Touched = 0
+            MzSEPfsListItemCount = 0
+            input_format = 1
+            format_height = 1
+            type_height = 1
+            format_code = 2
+            coordinate_type = 'UTM-33'
+            file_name = ||
+            item_number_for_code = 1
+            item_number_for_height = 2
+            item_name_for_code = ''
+            item_name_for_height = ''
+         EndSect  // BUILDING_ZONES
+
+         [ROAD_ZONES]
+            Touched = 0
+            MzSEPfsListItemCount = 0
+            input_format = 1
+            format_offset = 1
+            format_code = 2
+            coordinate_type = 'UTM-33'
+            file_name = ||
+            item_number_for_code = 1
+            item_number_for_offset = 2
+            item_name_for_code = ''
+            item_name_for_offset = ''
+         EndSect  // ROAD_ZONES
+
+      EndSect  // INFRASTRUCTURE
+
+   EndSect  // DOMAIN
+
+   [TIME]
+      Touched = 1
+      start_time = 1997, 9, 9, 0, 0, 0
+      time_step_interval = 7.2
+      number_of_time_steps = 72000
+   EndSect  // TIME
+
+   [MODULE_SELECTION]
+      Touched = 1
+      mode_of_hydrodynamic_module = 2
+      hydrodynamic_features = 1
+      fluid_property = 1
+      mode_of_spectral_wave_module = 0
+      mode_of_transport_module = 0
+      mode_of_mud_transport_module = 0
+      mode_of_eco_lab_module = 0
+      mode_of_sand_transport_module = 0
+      mode_of_particle_tracking_module = 0
+      mode_of_oil_spill_module = 0
+      mode_of_shoreline_module = 0
+   EndSect  // MODULE_SELECTION
+
+   [HYDRODYNAMIC_MODULE]
+      mode = 2
+      [EQUATION]
+         formulation = 4
+      EndSect  // EQUATION
+
+      [TIME]
+         start_time_step = 0
+         time_step_factor = 1
+      EndSect  // TIME
+
+      [SOLUTION_TECHNIQUE]
+         Touched = 1
+         scheme_of_time_integration = 1
+         scheme_of_space_discretization_horizontal = 1
+         scheme_of_space_discretization_vertical = 1
+         method_of_space_discretization_horizontal = 0
+         type_of_filtering = 0
+         filtering_coefficient = 0.001
+         type_of_Riemann_solver = 3
+         Riemann_factor = 1.0
+         CFL_critical_HD = 0.8
+         dt_min_HD = 0.01
+         dt_max_HD = 7.2
+         CFL_critical_AD = 0.8
+         dt_min_AD = 0.01
+         dt_max_AD = 7.2
+         error_level = 0
+         maximum_number_of_errors = 200
+         [POISSON_EQUATION]
+            gradient_calculation = 3
+            gradient_limiter = 3
+            face_value_limiter = 0
+            order_vertical_discretization_q = 3
+            order_vertical_discretization_u = 2
+            order_vertical_discretization_w = 2
+            order_vertical_discretization_w_surface = 3
+            bottom_boundary_corretion = 0
+            open_boundary_correction = 2
+            [LINEAR_EQUATION_SYSTEM]
+               method = 2
+               type_of_print = 0
+            EndSect  // LINEAR_EQUATION_SYSTEM
+
+         EndSect  // POISSON_EQUATION
+
+         number_of_time_steps = 1
+         time_step_interval = 30
+         tolerance1 = 0.0001
+         tolerance2 = 0.001
+         maximum_number_of_iterations = 3000
+         minimum_number_of_iterations = 1
+         type_overall = 0
+         input_format = 1
+         file_name_overall = 'HD_convergence_overall.dfs0'
+         coordinate_type = ''
+         input_file_name = ||
+         number_of_points = 0
+         type_domain = 0
+         file_name_domain = 'HD_convergence_domain.dfsu'
+         output_frequency = 5
+      EndSect  // SOLUTION_TECHNIQUE
+
+      [DEPTH]
+         Touched = 1
+         type = 0
+         format = 2
+         file_name = ||
+         item_number = 1
+      EndSect  // DEPTH
+
+      [FLOOD_AND_DRY]
+         Touched = 1
+         type = 2
+         drying_depth = 0.01
+         mass_depth = 0.1
+      EndSect  // FLOOD_AND_DRY
+
+      [FLUID_PROPERTIES]
+         Touched = 1
+         type = 1
+         density = 1010.0
+         viscosity_Bingham = 0.0
+         yield_stress = 0.0
+         [BINGHAM_FLUID_VISCOSITY_DATA]
+            formulation = 1
+            c = 0.0
+            k = 0.0
+            cv_min = 0.05
+         EndSect  // BINGHAM_FLUID_VISCOSITY_DATA
+
+         [YIELD_STRESS_DATA]
+            formulation = 1
+            c = 0.0
+            k = 0.0
+            cv_min = 0.05
+         EndSect  // YIELD_STRESS_DATA
+
+      EndSect  // FLUID_PROPERTIES
+
+      [DENSITY]
+         Touched = 1
+         type = 1
+         temperature_reference = 15.0
+         salinity_reference = 22.0
+      EndSect  // DENSITY
+
+      [EDDY_VISCOSITY]
+         Touched = 1
+         [HORIZONTAL_EDDY_VISCOSITY]
+            Touched = 1
+            type = 3
+            [CONSTANT_EDDY_FORMULATION]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 0.002
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // CONSTANT_EDDY_FORMULATION
+
+            [SMAGORINSKY_FORMULATION]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 0.1
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+               minimum_eddy_viscosity = 0.0
+               maximum_eddy_viscosity = 10000000000
+            EndSect  // SMAGORINSKY_FORMULATION
+
+            [K_EPSILON_FORMULATION]
+               Touched = 0
+               minimum_eddy_viscosity = 1.8e-06
+               maximum_eddy_viscosity = 0.4
+            EndSect  // K_EPSILON_FORMULATION
+
+         EndSect  // HORIZONTAL_EDDY_VISCOSITY
+
+         [VERTICAL_EDDY_VISCOSITY]
+            Touched = 1
+            type = 5
+            [CONSTANT_EDDY_FORMULATION]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 0.002
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+               Ri_damping = 0
+               Ri_a = 10.0
+               Ri_b = 0.5
+               mixing_length_constants = 0.41, -0.41
+            EndSect  // CONSTANT_EDDY_FORMULATION
+
+            [LOG_LAW_FORMULATION]
+               Touched = 1
+               minimum_eddy_viscosity = 1.8e-06
+               maximum_eddy_viscosity = 10000000000
+               Ri_damping = 0
+               Ri_a = 10.0
+               Ri_b = 0.5
+               mixing_length_constants = 0.41, -0.41
+            EndSect  // LOG_LAW_FORMULATION
+
+            [K_EPSILON_FORMULATION]
+               Touched = 1
+               minimum_eddy_viscosity = 1.8e-06
+               maximum_eddy_viscosity = 180.0
+            EndSect  // K_EPSILON_FORMULATION
+
+         EndSect  // VERTICAL_EDDY_VISCOSITY
+
+      EndSect  // EDDY_VISCOSITY
+
+      [BED_RESISTANCE]
+         Touched = 1
+         type = 5
+         zone = 1
+         [DRAG_COEFFICIENT]
+            Touched = 1
+            type = 1
+            format = 0
+            constant_value = 0.01
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // DRAG_COEFFICIENT
+
+         [CHEZY_NUMBER]
+            Touched = 1
+            type = 1
+            format = 0
+            constant_value = 32.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // CHEZY_NUMBER
+
+         [MANNING_NUMBER]
+            Touched = 1
+            type = 1
+            format = 0
+            constant_value = 32.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // MANNING_NUMBER
+
+         [ROUGHNESS]
+            Touched = 1
+            type = 1
+            format = 0
+            constant_value = 0.1
+            file_name = |..\..\Oresund\Data\1997\rough.dfs2|
+            item_number = 1
+            item_name = 'temperature    (z=40)'
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // ROUGHNESS
+
+         [WAVE_INDUCED_ROUGHNESS]
+            Touched = 1
+            type = 7
+            format = 0
+            constant_value = 0.2
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+            type_of_wave_height_correction = 1
+            wave_height_over_depth_limit = 0.85
+            minimum_waterdepth_for_including_waves = 0.0
+         EndSect  // WAVE_INDUCED_ROUGHNESS
+
+      EndSect  // BED_RESISTANCE
+
+      [VEGETATION]
+         Touched = 1
+         type = 0
+         file_name = ||
+         item_number = 1
+         item_name = ''
+      EndSect  // VEGETATION
+
+      [CORIOLIS]
+         Touched = 1
+         type = 2
+         latitude = 55.0
+      EndSect  // CORIOLIS
+
+      [WIND_FORCING]
+         type = 1
+         format = 1
+         constant_speed = 0.0
+         constant_direction = 0.0
+         file_name = |..\..\Data\1997\Forcings\wind_ven.dfs0|
+         item_number_for_speed = 1
+         item_number_for_direction = 2
+         item_name_for_speed = 'Speed'
+         item_name_for_direction = 'Direction'
+         neutral_pressure = 1013.0
+         type_of_soft_start = 2
+         soft_time_interval = 7200.0
+         [WIND_FRICTION]
+            Touched = 1
+            type = 1
+            constant_friction = 0.001255
+            linear_friction_low = 0.001255
+            linear_friction_high = 0.002425
+            linear_speed_low = 7.0
+            linear_speed_high = 25.0
+         EndSect  // WIND_FRICTION
+
+      EndSect  // WIND_FORCING
+
+      [ICE]
+         Touched = 1
+         type = 0
+         format = 3
+         c_cut_off = 0.33
+         file_name = ||
+         item_number_concentration = -1
+         item_number_thickness = 2933710
+         item_name_concentration = ''
+         item_name_thickness = ''
+         [ROUGHNESS]
+            Touched = 1
+            type = 0
+            format = 0
+            constant_value = 0.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // ROUGHNESS
+
+      EndSect  // ICE
+
+      [TIDAL_POTENTIAL]
+         Touched = 1
+         MzSEPfsListItemCount = 11
+         type = 0
+         format = 0
+         constituent_file_name = ||
+         number_of_constituents = 11
+         [CONSTITUENT_1]
+            Touched = 1
+            name = 'M2'
+            species = 2
+            constituent = 1
+            amplitude = 0.242334
+            earthtide = 0.6929999999999999
+            period_scaling = 3600
+            period = 12.4206012
+            nodal_number_1 = 1.0
+            nodal_number_2 = -0.037
+            nodal_number_3 = -2.1
+            arguments = 0, 0, 0, 0, 0
+            phase = 0
+         EndSect  // CONSTITUENT_1
+
+         [CONSTITUENT_2]
+            Touched = 1
+            name = 'O1'
+            species = 1
+            constituent = 2
+            amplitude = 0.100514
+            earthtide = 0.695
+            period_scaling = 3600
+            period = 25.8193417
+            nodal_number_1 = 1.009
+            nodal_number_2 = 0.187
+            nodal_number_3 = 10.8
+            arguments = -1, 0, 0, 0, 0
+            phase = 0
+         EndSect  // CONSTITUENT_2
+
+         [CONSTITUENT_3]
+            Touched = 1
+            name = 'S2'
+            species = 2
+            constituent = 2
+            amplitude = 0.112841
+            earthtide = 0.6929999999999999
+            period_scaling = 3600
+            period = 12.0
+            nodal_number_1 = 1.0
+            nodal_number_2 = 0.0
+            nodal_number_3 = 0.0
+            arguments = 2, -2, 0, 0, 0
+            phase = 0
+         EndSect  // CONSTITUENT_3
+
+         [CONSTITUENT_4]
+            Touched = 1
+            name = 'K2'
+            species = 2
+            constituent = 4
+            amplitude = 0.030704
+            earthtide = 0.6929999999999999
+            period_scaling = 3600
+            period = 11.9672348
+            nodal_number_1 = 1.024
+            nodal_number_2 = 0.286
+            nodal_number_3 = -17.7
+            arguments = 2, 0, 0, 0, 0
+            phase = 0
+         EndSect  // CONSTITUENT_4
+
+         [CONSTITUENT_5]
+            Touched = 1
+            name = 'N2'
+            species = 2
+            constituent = 3
+            amplitude = 0.046398
+            earthtide = 0.6929999999999999
+            period_scaling = 3600
+            period = 12.6583482
+            nodal_number_1 = 1.0
+            nodal_number_2 = -0.037
+            nodal_number_3 = -2.1
+            arguments = -1, 0, 1, 0, 0
+            phase = 0
+         EndSect  // CONSTITUENT_5
+
+         [CONSTITUENT_6]
+            Touched = 1
+            name = 'K1'
+            species = 1
+            constituent = 1
+            amplitude = 0.141565
+            earthtide = 0.736
+            period_scaling = 3600
+            period = 23.9344696
+            nodal_number_1 = 1.006
+            nodal_number_2 = 0.115
+            nodal_number_3 = -8.9
+            arguments = 1, 0, 0, 0, 0
+            phase = 0
+         EndSect  // CONSTITUENT_6
+
+         [CONSTITUENT_7]
+            Touched = 1
+            name = 'P1'
+            species = 1
+            constituent = 3
+            amplitude = 0.046843
+            earthtide = 0.706
+            period_scaling = 3600
+            period = 24.0658902
+            nodal_number_1 = 1.0
+            nodal_number_2 = 0.0
+            nodal_number_3 = 0.0
+            arguments = 1, -2, 0, 0, 0
+            phase = 0
+         EndSect  // CONSTITUENT_7
+
+         [CONSTITUENT_8]
+            Touched = 1
+            name = 'Q1'
+            species = 1
+            constituent = 4
+            amplitude = 0.019256
+            earthtide = 0.695
+            period_scaling = 3600
+            period = 26.8683566
+            nodal_number_1 = 1.009
+            nodal_number_2 = 0.187
+            nodal_number_3 = 10.8
+            arguments = -2, 0, 1, 0, 0
+            phase = 0
+         EndSect  // CONSTITUENT_8
+
+         [CONSTITUENT_9]
+            Touched = 1
+            name = 'Mf'
+            species = 0
+            constituent = 1
+            amplitude = 0.041742
+            earthtide = 0.6929999999999999
+            period_scaling = 86400
+            period = 13.660791
+            nodal_number_1 = 1.043
+            nodal_number_2 = 0.414
+            nodal_number_3 = -23.7
+            arguments = 2, 0, 0, 0, 0
+            phase = 0
+         EndSect  // CONSTITUENT_9
+
+         [CONSTITUENT_10]
+            Touched = 1
+            name = 'Mm'
+            species = 0
+            constituent = 2
+            amplitude = 0.022026
+            earthtide = 0.6929999999999999
+            period_scaling = 86400
+            period = 27.554553
+            nodal_number_1 = 1.0
+            nodal_number_2 = -0.13
+            nodal_number_3 = 0.0
+            arguments = 1, 0, -1, 0, 0
+            phase = 0
+         EndSect  // CONSTITUENT_10
+
+         [CONSTITUENT_11]
+            Touched = 1
+            name = 'Ssa'
+            species = 0
+            constituent = 3
+            amplitude = 0.019446
+            earthtide = 0.6929999999999999
+            period_scaling = 86400
+            period = 182.6211
+            nodal_number_1 = 1.0
+            nodal_number_2 = 0.0
+            nodal_number_3 = 0.0
+            arguments = 0, 2, 0, 0, 0
+            phase = 0
+         EndSect  // CONSTITUENT_11
+
+      EndSect  // TIDAL_POTENTIAL
+
+      [PRECIPITATION_EVAPORATION]
+         Touched = 1
+         type_of_precipitation = 0
+         type_of_evaporation = 0
+         [PRECIPITATION]
+            Touched = 1
+            type = 1
+            format = 0
+            constant_value = 0.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // PRECIPITATION
+
+         [EVAPORATION]
+            Touched = 1
+            type = 1
+            format = 0
+            constant_value = 0.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // EVAPORATION
+
+      EndSect  // PRECIPITATION_EVAPORATION
+
+      [INFILTRATION]
+         Touched = 1
+         type = 0
+         zone = 1
+         formulation = 1
+         type_groundwater_depth = 1
+         type_initial_condition = 1
+      EndSect  // INFILTRATION
+
+      [RADIATION_STRESS]
+         Touched = 1
+         type = 0
+         format = 3
+         file_name = ||
+         soft_time_interval = 0.0
+      EndSect  // RADIATION_STRESS
+
+      [SOURCES]
+         Touched = 1
+         MzSEPfsListItemCount = 0
+         number_of_sources = 0
+         time_stepping_jet = 1
+         time_step_factor_jet = 1
+         output_type = 0
+         output_frequency = 1
+         output_file_name = 'Jet_data.dfs0'
+      EndSect  // SOURCES
+
+      [STRUCTURE_MODULE]
+         Structure_Version = 1, 1
+         [CROSSSECTIONS]
+            CrossSectionDataBridge = 'xns11'
+            CrossSectionFile = ||
+         EndSect  // CROSSSECTIONS
+
+         [WEIR]
+            output_frequency = 1
+            output_file_name = 'weir_data.dfs0'
+         EndSect  // WEIR
+
+         [CULVERTS]
+            output_frequency = 1
+            output_file_name = 'culvert_data.dfs0'
+         EndSect  // CULVERTS
+
+      EndSect  // STRUCTURE_MODULE
+
+      [STRUCTURES]
+         [RIVER_LINKS]
+            type_of_coupling = 2
+            line_information = 2
+            output_of_link_data = 0
+            file_name_curve = 'river_curve.xyz'
+            file_name_section = 'river_section.xyz'
+         EndSect  // RIVER_LINKS
+
+         [URBAN_LINKS]
+            output_of_link_data = 0
+            file_name_curve = 'urban_curve.xyz'
+            file_name_section = 'urban_section.xyz'
+         EndSect  // URBAN_LINKS
+
+         [GATES]
+            Touched = 1
+            MzSEPfsListItemCount = 0
+            number_of_gates = 0
+            output_frequency = 1
+            output_file_name = 'gate_data.dfs0'
+         EndSect  // GATES
+
+         [DIKES]
+            Touched = 1
+            MzSEPfsListItemCount = 0
+            output_of_link_data = 0
+            file_name_section = 'line_section.xyz'
+            number_of_dikes = 0
+         EndSect  // DIKES
+
+         [PIERS]
+            Touched = 1
+            MzSEPfsListItemCount = 0
+            format = 0
+            number_of_piers = 0
+         EndSect  // PIERS
+
+         [TURBINES]
+            Touched = 1
+            MzSEPfsListItemCount = 0
+            format = 0
+            number_of_turbines = 0
+            output_frequency = 1
+            output_file_name = 'turbine_data.dfs0'
+         EndSect  // TURBINES
+
+      EndSect  // STRUCTURES
+
+      [INFRASTRUCTURE]
+         Touched = 1
+         [BUILDING_DATA]
+            critical_level_difference = 0.01
+            coefficient = 1.838
+            exponent = 1.5
+         EndSect  // BUILDING_DATA
+
+         [ROAD_DATA]
+            critical_level_difference = 0.01
+            coefficient = 1.838
+            exponent = 1.5
+         EndSect  // ROAD_DATA
+
+      EndSect  // INFRASTRUCTURE
+
+      [WAVES]
+         Touched = 1
+         type = 1
+         [WAVE_FIELD]
+            Touched = 1
+            format = 0
+            type_of_wave_height = 2
+            type_of_wave_period = 1
+            wave_height = 1.0
+            wave_period = 3.0
+            wave_direction = 180.0
+            file_name = ||
+            item_number_for_wave_height = 1
+            item_number_for_wave_period = 2
+            item_number_for_wave_direction = 3
+            item_name_for_wave_height = ''
+            item_name_for_wave_period = ''
+            item_name_for_wave_direction = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+         EndSect  // WAVE_FIELD
+
+      EndSect  // WAVES
+
+      [INITIAL_CONDITIONS]
+         Touched = 1
+         type = 3
+         surface_elevation_constant = 0.0
+         u_velocity_constant = 0.0
+         v_velocity_constant = 0.0
+         w_velocity_constant = 0.0
+         file_name_2D = |..\..\Data\1997\Initial_Conditions\2D_sept_9_1997.dfsu|
+         total_water_depth_item_no = 1
+         item_name_for_total_water_depth = 'Total water depth'
+         file_name_3D = |..\..\Data\1997\Initial_Conditions\3D_sept_9_1997.dfsu|
+         u_velocity_item_no = 2
+         v_velocity_item_no = 3
+         w_velocity_item_no = 3
+         item_name_for_u = 'U velocity'
+         item_name_for_v = 'V velocity'
+         item_name_for_w = 'WS velocity'
+      EndSect  // INITIAL_CONDITIONS
+
+      [BOUNDARY_CONDITIONS]
+         Touched = 1
+         MzSEPfsListItemCount = 2
+         internal_land_boundary_Type = 1
+         [CODE_1]
+            type = 1
+            type_resistance = 0
+            resistance_coefficient = 0.05
+         EndSect  // CODE_1
+
+         [CODE_3]
+            identifier = ''
+            type = 6
+            type_interpolation_constrain = 0
+            type_secondary = 1
+            type_resistance = 0
+            resistance_coefficient = 0.05
+            type_of_vertical_profile = 1
+            format = 3
+            constant_value = 0.0
+            file_name = |..\..\Data\1997\Boundary_Conditions\waterlevel_south.dfs1|
+            item_number = 1
+            item_name = 'South'
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+            type_of_space_interpolation = 1
+            type_of_coriolis_correction = 0
+            type_of_wind_correction = 0
+            type_of_tilting = 1
+            type_of_tilting_point = 1
+            point_tilting = 1
+            type_of_pressure_correction = 1
+            type_of_radiation_stress_correction = 1
+         EndSect  // CODE_3
+
+         [CODE_2]
+            identifier = ''
+            type = 6
+            type_interpolation_constrain = 0
+            type_secondary = 1
+            type_resistance = 0
+            resistance_coefficient = 0.05
+            type_of_vertical_profile = 1
+            format = 3
+            constant_value = 0.0
+            file_name = |..\..\Data\1997\Boundary_Conditions\waterlevel_north.dfs1|
+            item_number = 1
+            item_name = 'North'
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+            type_of_space_interpolation = 1
+            type_of_coriolis_correction = 0
+            type_of_wind_correction = 0
+            type_of_tilting = 1
+            type_of_tilting_point = 1
+            point_tilting = 1
+            type_of_pressure_correction = 1
+            type_of_radiation_stress_correction = 1
+         EndSect  // CODE_2
+
+      EndSect  // BOUNDARY_CONDITIONS
+
+      [TEMPERATURE_SALINITY_MODULE]
+         temperature_mode = 2
+         salinity_mode = 2
+         [EQUATION]
+            Touched = 1
+            minimum_temperature = 0.0
+            maximum_temperature = 10000000000
+            minimum_salinity = 0.0
+            maximum_salinity = 10000000000
+         EndSect  // EQUATION
+
+         [SOLUTION_TECHNIQUE]
+            Touched = 1
+            scheme_of_time_integration = 1
+            scheme_of_space_discretization_horizontal = 1
+            scheme_of_space_discretization_vertical = 1
+            method_of_space_discretization_horizontal = 0
+         EndSect  // SOLUTION_TECHNIQUE
+
+         [DIFFUSION]
+            [HORIZONTAL_DIFFUSION]
+               Touched = 1
+               type = 1
+               [SCALED_EDDY_VISCOSITY]
+                  format = 0
+                  sigma = 1.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // SCALED_EDDY_VISCOSITY
+
+               [DIFFUSION_COEFFICIENT]
+                  format = 0
+                  constant_value = 0.01
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // DIFFUSION_COEFFICIENT
+
+            EndSect  // HORIZONTAL_DIFFUSION
+
+            [VERTICAL_DIFFUSION]
+               Touched = 1
+               type = 1
+               [SCALED_EDDY_VISCOSITY]
+                  format = 0
+                  sigma = 0.1
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // SCALED_EDDY_VISCOSITY
+
+               [DIFFUSION_COEFFICIENT]
+                  format = 0
+                  constant_value = 0.01
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // DIFFUSION_COEFFICIENT
+
+            EndSect  // VERTICAL_DIFFUSION
+
+         EndSect  // DIFFUSION
+
+         [HEAT_EXCHANGE]
+            Touched = 1
+            type = 1
+            type_of_latent_heat = 1
+            Daltons_law_A = 0.5
+            Daltons_law_B = 0.9
+            latent_heat_critical_wind_speed = 2.0
+            type_of_sensible_heat = 1
+            sensible_heat_transfer_coefficient_heating = 0.0011
+            sensible_heat_transfer_coefficient_cooling = 0.0011
+            sensible_heat_critical_wind_speed = 2.0
+            type_of_short_wave_radiation = 1
+            Angstroms_law_A = 0.295
+            Angstroms_law_B = 0.371
+            displacement_hours = 0.0
+            standard_meridian = 0.0
+            Beers_law_beta = 0.3
+            type_of_solar_radiation = 1
+            type_of_long_wave_radiation = 1
+            long_wave_radiation_A = 0.5600000000000001
+            long_wave_radiation_B = 0.077
+            long_wave_radiation_C = 0.1
+            long_wave_radiation_D = 0.9
+            type_of_ground_heat = 0
+            distance_below_ground = 1.0
+            storage = 0
+            [LIGHT_EXTINCTION]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 1.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // LIGHT_EXTINCTION
+
+            [SHORT_WAVE_RADIATION_DATA]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 0.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // SHORT_WAVE_RADIATION_DATA
+
+            [LONG_WAVE_RADIATION_DATA]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 0.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // LONG_WAVE_RADIATION_DATA
+
+            [air_temperature]
+               Touched = 1
+               type = 1
+               format = 1
+               constant_value = 15.0
+               file_name = |..\..\Data\1997\Forcings\temperature.dfs0|
+               item_number = 1
+               item_name = 'Air temperature'
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // air_temperature
+
+            [relative_humidity]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 88.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // relative_humidity
+
+            [clearness_coefficient]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 70.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // clearness_coefficient
+
+            [THERMAL_CONDUCTIVITY]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 1.65
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // THERMAL_CONDUCTIVITY
+
+            [GROUND_TEMPERATURE]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 15.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // GROUND_TEMPERATURE
+
+         EndSect  // HEAT_EXCHANGE
+
+         [PRECIPITATION_EVAPORATION]
+            Touched = 0
+            type_of_precipitation = 1
+            type_of_evaporation = 1
+            [PRECIPITATION]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 0.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // PRECIPITATION
+
+            [EVAPORATION]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 0.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // EVAPORATION
+
+         EndSect  // PRECIPITATION_EVAPORATION
+
+         [INFILTRATION]
+            Touched = 1
+            type_of_infiltration_temperature = 1
+            [INFILTRATION]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 0.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // INFILTRATION
+
+         EndSect  // INFILTRATION
+
+         [SOURCES]
+            Touched = 1
+            MzSEPfsListItemCount = 0
+         EndSect  // SOURCES
+
+         [INITIAL_CONDITIONS]
+            Touched = 1
+            [TEMPERATURE]
+               Touched = 1
+               type = 1
+               format = 2
+               constant_value = 15.0
+               file_name = |..\..\Data\1997\Initial_Conditions\3D_sept_9_1997.dfsu|
+               item_number = 4
+               item_name = 'Temperature'
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // TEMPERATURE
+
+            [SALINITY]
+               Touched = 1
+               type = 1
+               format = 2
+               constant_value = 22.0
+               file_name = |..\..\Data\1997\Initial_Conditions\3D_sept_9_1997.dfsu|
+               item_number = 5
+               item_name = 'Salinity'
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // SALINITY
+
+         EndSect  // INITIAL_CONDITIONS
+
+         [BOUNDARY_CONDITIONS]
+            Touched = 1
+            MzSEPfsListItemCount = 2
+            [CODE_1]
+               [TEMPERATURE]
+               EndSect  // TEMPERATURE
+
+               [SALINITY]
+               EndSect  // SALINITY
+
+            EndSect  // CODE_1
+
+            [CODE_3]
+               [TEMPERATURE]
+                  identifier = 'Temperature'
+                  type = 2
+                  type_interpolation_constrain = 0
+                  type_secondary = 1
+                  type_of_vertical_profile = 1
+                  format = 3
+                  constant_value = 10.0
+                  file_name = |..\..\Data\1997\Boundary_Conditions\temperature_south.dfs2|
+                  item_number = 1
+                  item_name = 'Temperature'
+                  type_of_soft_start = 2
+                  soft_time_interval = 7200.0
+                  reference_value = 15.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 1
+                  type_of_coriolis_correction = 0
+                  type_of_wind_correction = 0
+                  type_of_tilting = 1
+                  type_of_tilting_point = 1
+                  point_tilting = 1
+                  type_of_pressure_correction = 1
+                  type_of_radiation_stress_correction = 1
+               EndSect  // TEMPERATURE
+
+               [SALINITY]
+                  identifier = 'Salinity'
+                  type = 2
+                  type_interpolation_constrain = 0
+                  type_secondary = 1
+                  type_of_vertical_profile = 1
+                  format = 3
+                  constant_value = 32.0
+                  file_name = |..\..\Data\1997\Boundary_Conditions\salinity_south.dfs2|
+                  item_number = 1
+                  item_name = 'Salinity'
+                  type_of_soft_start = 2
+                  soft_time_interval = 7200.0
+                  reference_value = 22.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 1
+                  type_of_coriolis_correction = 0
+                  type_of_wind_correction = 0
+                  type_of_tilting = 1
+                  type_of_tilting_point = 1
+                  point_tilting = 1
+                  type_of_pressure_correction = 1
+                  type_of_radiation_stress_correction = 1
+               EndSect  // SALINITY
+
+            EndSect  // CODE_3
+
+            [CODE_2]
+               [TEMPERATURE]
+                  identifier = 'Temperature'
+                  type = 2
+                  type_interpolation_constrain = 0
+                  type_secondary = 1
+                  type_of_vertical_profile = 1
+                  format = 3
+                  constant_value = 10.0
+                  file_name = |..\..\Data\1997\Boundary_Conditions\temperature_north.dfs2|
+                  item_number = 1
+                  item_name = 'Temperature'
+                  type_of_soft_start = 2
+                  soft_time_interval = 7200.0
+                  reference_value = 15.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 2
+                  type_of_coriolis_correction = 0
+                  type_of_wind_correction = 0
+                  type_of_tilting = 1
+                  type_of_tilting_point = 1
+                  point_tilting = 1
+                  type_of_pressure_correction = 1
+                  type_of_radiation_stress_correction = 1
+               EndSect  // TEMPERATURE
+
+               [SALINITY]
+                  identifier = 'Salinity'
+                  type = 2
+                  type_interpolation_constrain = 0
+                  type_secondary = 1
+                  type_of_vertical_profile = 1
+                  format = 3
+                  constant_value = 32.0
+                  file_name = |..\..\Data\1997\Boundary_Conditions\salinity_north.dfs2|
+                  item_number = 1
+                  item_name = 'Salinity'
+                  type_of_soft_start = 2
+                  soft_time_interval = 7200.0
+                  reference_value = 22.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 2
+                  type_of_coriolis_correction = 0
+                  type_of_wind_correction = 0
+                  type_of_tilting = 1
+                  type_of_tilting_point = 1
+                  point_tilting = 1
+                  type_of_pressure_correction = 1
+                  type_of_radiation_stress_correction = 1
+               EndSect  // SALINITY
+
+            EndSect  // CODE_2
+
+         EndSect  // BOUNDARY_CONDITIONS
+
+      EndSect  // TEMPERATURE_SALINITY_MODULE
+
+      [TURBULENCE_MODULE]
+         mode = 2
+         [EQUATION]
+            Touched = 1
+            model = 1
+            c1e = 1.44
+            c2e = 1.92
+            c3e = 0.0
+            prandtl_number = 0.9
+            cmy = 0.09
+            beta_k = 0.09
+            prandtl_number_KO = 0.7
+            alpha = 0.52
+            beta_0 = 0.0708
+            sigma_do = 0.125
+            lambda1 = 0.875
+            lambda2 = 0.05
+            minimum_kinetic_energy = 1e-07
+            maximum_kinetic_energy = 10000000000
+            minimum_dissipation_of_kinetic_energy = 5e-10
+            maximum_dissipation_of_kinetic_energy = 10000000000
+            minimum_specific_dissipation_rate = 0.055
+            maximum_specific_dissipation_rate = 10000000000
+            vegetation_coefficient_k = 1.0
+            vegetation_coefficient_epsilon = 1.33
+            vegetation_coefficient_omega = 1.0
+            surface_dissipation_parameter = 0.07000000000000001
+            Ri_damping = 1
+         EndSect  // EQUATION
+
+         [SOLUTION_TECHNIQUE]
+            Touched = 1
+            scheme_of_time_integration = 1
+            scheme_of_space_discretization_horizontal = 1
+            scheme_of_space_discretization_vertical = 1
+            method_of_space_discretization_horizontal = 0
+         EndSect  // SOLUTION_TECHNIQUE
+
+         [DIFFUSION]
+            Touched = 1
+            sigma_k_h = 1.0
+            sigma_e_h = 1.3
+            sigma_k = 1.0
+            sigma_e = 1.3
+            sigma_turbulent_kinetic_energy_h = 1.666666666666667
+            sigma_specific_dissipation_rate_h = 2.0
+            sigma_turbulent_kinetic_energy_v = 1.666666666666667
+            sigma_specific_dissipation_rate_v = 2.0
+         EndSect  // DIFFUSION
+
+         [SOURCES]
+            Touched = 1
+            MzSEPfsListItemCount = 0
+         EndSect  // SOURCES
+
+         [INITIAL_CONDITIONS]
+            Touched = 1
+            [KINETIC_ENERGY]
+               Touched = 1
+               type = 1
+               format = 2
+               constant_value = 1e-07
+               file_name = |..\..\Data\1997\Initial_Conditions\3D_sept_9_1997.dfsu|
+               item_number = 6
+               item_name = 'Turbulent kinetic energy'
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // KINETIC_ENERGY
+
+            [DISSIPATION_OF_KINETIC_ENERGY]
+               Touched = 1
+               type = 1
+               format = 2
+               constant_value = 5e-10
+               file_name = |..\..\Data\1997\Initial_Conditions\3D_sept_9_1997.dfsu|
+               item_number = 7
+               item_name = 'Dissipation of TKE'
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // DISSIPATION_OF_KINETIC_ENERGY
+
+            [SPECIFIC_DISSIPATION_RATE]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 0.055
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // SPECIFIC_DISSIPATION_RATE
+
+         EndSect  // INITIAL_CONDITIONS
+
+         [BOUNDARY_CONDITIONS]
+            Touched = 1
+            MzSEPfsListItemCount = 2
+            [CODE_1]
+               [KINETIC_ENERGY]
+               EndSect  // KINETIC_ENERGY
+
+               [DISSIPATION_OF_KINETIC_ENERGY]
+               EndSect  // DISSIPATION_OF_KINETIC_ENERGY
+
+               [SPECIFIC_DISSIPATION_RATE]
+               EndSect  // SPECIFIC_DISSIPATION_RATE
+
+            EndSect  // CODE_1
+
+            [CODE_3]
+               [KINETIC_ENERGY]
+                  identifier = 'Turbulent kinetic energy'
+                  type = 2
+                  type_interpolation_constrain = 0
+                  type_secondary = 1
+                  type_of_vertical_profile = 1
+                  format = 0
+                  constant_value = 1e-07
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 1
+                  type_of_coriolis_correction = 0
+                  type_of_wind_correction = 0
+                  type_of_tilting = 1
+                  type_of_tilting_point = 1
+                  point_tilting = 1
+                  type_of_pressure_correction = 1
+                  type_of_radiation_stress_correction = 1
+               EndSect  // KINETIC_ENERGY
+
+               [DISSIPATION_OF_KINETIC_ENERGY]
+                  identifier = 'Dissipation of turbulent kinetic energy'
+                  type = 2
+                  type_interpolation_constrain = 0
+                  type_secondary = 1
+                  type_of_vertical_profile = 1
+                  format = 0
+                  constant_value = 5e-10
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 1
+                  type_of_coriolis_correction = 0
+                  type_of_wind_correction = 0
+                  type_of_tilting = 1
+                  type_of_tilting_point = 1
+                  point_tilting = 1
+                  type_of_pressure_correction = 1
+                  type_of_radiation_stress_correction = 1
+               EndSect  // DISSIPATION_OF_KINETIC_ENERGY
+
+               [SPECIFIC_DISSIPATION_RATE]
+                  identifier = 'Specific dissipation rate'
+                  type = 2
+                  type_interpolation_constrain = 0
+                  type_secondary = 1
+                  type_of_vertical_profile = 1
+                  format = 0
+                  constant_value = 0.055
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 1
+                  type_of_coriolis_correction = 0
+                  type_of_wind_correction = 0
+                  type_of_tilting = 1
+                  type_of_tilting_point = 1
+                  point_tilting = 1
+                  type_of_pressure_correction = 1
+                  type_of_radiation_stress_correction = 1
+               EndSect  // SPECIFIC_DISSIPATION_RATE
+
+            EndSect  // CODE_3
+
+            [CODE_2]
+               [KINETIC_ENERGY]
+                  identifier = 'Turbulent kinetic energy'
+                  type = 2
+                  type_interpolation_constrain = 0
+                  type_secondary = 1
+                  type_of_vertical_profile = 1
+                  format = 0
+                  constant_value = 1e-07
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 1
+                  type_of_coriolis_correction = 0
+                  type_of_wind_correction = 0
+                  type_of_tilting = 1
+                  type_of_tilting_point = 1
+                  point_tilting = 1
+                  type_of_pressure_correction = 1
+                  type_of_radiation_stress_correction = 1
+               EndSect  // KINETIC_ENERGY
+
+               [DISSIPATION_OF_KINETIC_ENERGY]
+                  identifier = 'Dissipation of turbulent kinetic energy'
+                  type = 2
+                  type_interpolation_constrain = 0
+                  type_secondary = 1
+                  type_of_vertical_profile = 1
+                  format = 0
+                  constant_value = 5e-10
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 1
+                  type_of_coriolis_correction = 0
+                  type_of_wind_correction = 0
+                  type_of_tilting = 1
+                  type_of_tilting_point = 1
+                  point_tilting = 1
+                  type_of_pressure_correction = 1
+                  type_of_radiation_stress_correction = 1
+               EndSect  // DISSIPATION_OF_KINETIC_ENERGY
+
+               [SPECIFIC_DISSIPATION_RATE]
+                  identifier = 'Specific dissipation rate'
+                  type = 2
+                  type_interpolation_constrain = 0
+                  type_secondary = 1
+                  type_of_vertical_profile = 1
+                  format = 0
+                  constant_value = 0.055
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 1
+                  type_of_coriolis_correction = 0
+                  type_of_wind_correction = 0
+                  type_of_tilting = 1
+                  type_of_tilting_point = 1
+                  point_tilting = 1
+                  type_of_pressure_correction = 1
+                  type_of_radiation_stress_correction = 1
+               EndSect  // SPECIFIC_DISSIPATION_RATE
+
+            EndSect  // CODE_2
+
+         EndSect  // BOUNDARY_CONDITIONS
+
+      EndSect  // TURBULENCE_MODULE
+
+      [DECOUPLING]
+         Touched = 1
+         type = 0
+         file_name_flux = ||
+         file_name_area = ||
+         file_name_volume = ||
+         specification_file = ||
+         first_time_step = 0
+         last_time_step = 72000
+         time_step_frequency = 1
+      EndSect  // DECOUPLING
+
+      [OUTPUTS]
+         Touched = 1
+         MzSEPfsListItemCount = 6
+         number_of_outputs = 6
+         [OUTPUT_1]
+            Touched = 1
+            include = 1
+            title = '3D volume series'
+            file_name = |.\Output\3D_flow.dfsu|
+            type = 2
+            format = 3
+            flood_and_dry = 2
+            coordinate_type = 'UTM-33'
+            zone = 0
+            input_file_name = ||
+            input_format = 1
+            interpolation_type = 1
+            use_end_time = 1
+            first_time_step = 0
+            last_time_step = 72000
+            time_step_frequency = 1500
+            number_of_points = 2
+            [POINT_1]
+               name = 'POINT_1'
+               x = 350359.194505691
+               y = 6176124.896267602
+               z = -20.58542104720917
+               layer = 22732386
+            EndSect  // POINT_1
+
+            [POINT_2]
+               name = 'POINT_2'
+               x = 350359.194505691
+               y = 6176124.896267602
+               z = -20.58542104720917
+               layer = 22732386
+            EndSect  // POINT_2
+
+            [LINE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+                  z = -41.1428377740823
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+                  z = -0.02800432033603826
+               EndSect  // POINT_2
+
+               npoints = 3
+            EndSect  // LINE
+
+            [PLANE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+               EndSect  // POINT_2
+
+               layer_min = 1
+               layer_max = 10
+               z_min = -37.38161279884851
+               z_max = 7.476322559769699
+               npoints_horizontal = 20
+               npoints_vertical = 10
+            EndSect  // PLANE
+
+            [AREA]
+               number_of_points = 4
+               [POINT_1]
+                  x = 322028.774312474
+                  y = 6127731.488865693
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 322028.774312474
+                  y = 6224518.303669511
+               EndSect  // POINT_2
+
+               [POINT_3]
+                  x = 378689.6146989079
+                  y = 6224518.303669511
+               EndSect  // POINT_3
+
+               [POINT_4]
+                  x = 378689.6146989079
+                  y = 6127731.488865693
+               EndSect  // POINT_4
+
+               layer_min = 1
+               layer_max = 10
+               orientation = 0.0
+               x_origo = 322584.2727476351
+               x_ds = 4994.159690599497
+               x_npoints = 13
+               y_origo = 6128680.379206907
+               y_ds = 4994.159690599497
+               y_npoints = 20
+               z_origo = -37.38161279884851
+               z_ds = 4.984215039846467
+               z_npoints = 10
+            EndSect  // AREA
+
+            [PARAMETERS_2D]
+               Touched = 1
+               SURFACE_ELEVATION = 1
+               STILL_WATER_DEPTH = 0
+               TOTAL_WATER_DEPTH = 0
+               U_VELOCITY = 1
+               V_VELOCITY = 1
+               P_FLUX = 0
+               Q_FLUX = 0
+               CURRENT_SPEED = 0
+               CURRENT_DIRECTION = 0
+               WIND_U_VELOCITY = 0
+               WIND_V_VELOCITY = 0
+               AIR_PRESSURE = 0
+               PRECIPITATION = 0
+               EVAPORATION = 0
+               BED_RESISTANCE_COEFFICIENT = 0
+               DRAG_COEFFICIENT = 0
+               BED_SHEARSTRESS = 0
+               BED_SHEARSTRESS_X_COMPONENT = 0
+               BED_SHEARSTRESS_Y_COMPONENT = 0
+               CONVERGENCE_ANGLE = 0
+               AREA = 0
+            EndSect  // PARAMETERS_2D
+
+            [PARAMETERS_3D]
+               Touched = 1
+               U_VELOCITY = 1
+               V_VELOCITY = 1
+               W_VELOCITY = 1
+               WS_VELOCITY = 0
+               DENSITY = 1
+               TEMPERATURE = 1
+               SALINITY = 1
+               TURBULENT_KINETIC_ENERGY = 0
+               DISSIPATION_OF_TKE = 0
+               CURRENT_SPEED = 1
+               CURRENT_DIRECTION_HORIZONTAL = 0
+               CURRENT_DIRECTION_VERTICAL = 0
+               HORIZONTAL_EDDY_VISCOSITY = 0
+               VERTICAL_EDDY_VISCOSITY = 0
+               CFL_NUMBER = 0
+               VOLUME = 0
+            EndSect  // PARAMETERS_3D
+
+            [DISCHARGE]
+               Touched = 0
+               Type = 1
+               domain = 1
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               DISCHARGE_POSITIVE = 0
+               ACCUMULATED_DISCHARGE_POSITIVE = 0
+               DISCHARGE_NEGATIVE = 0
+               ACCUMULATED_DISCHARGE_NEGATIVE = 0
+               FLOW = 0
+               TEMPERATURE = 0
+               SALINITY = 0
+            EndSect  // DISCHARGE
+
+            [MASSBUDGET]
+               Touched = 0
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               FLOW = 1
+               TEMPERATURE = 1
+               SALINITY = 1
+            EndSect  // MASSBUDGET
+
+            [INUNDATION]
+               Touched = 0
+               MAXIMUM_HEIGHT = 1
+               MAXIMUM_SURFACE_ELEVATION = 1
+               TIME_MAXIMUM_HEIGHT = 1
+               MAXIMUM_CURRENT_SPEED = 1
+               DIRECTION_AT_MAXIMUM_CURRENT_SPEED = 1
+               U_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               V_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               TIME_MAXIMUM_CURRENT_SPEED = 1
+               MAXIMUM_FLUX_MAGNITUDE = 0
+               DIRECTION_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               P_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               Q_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               TIME_MAXIMUM_FLUX_MAGNITUDE = 0
+               DURATION_ABOVE_THRESHOLD = 1
+               TIME_FIRST_ABOVE_THRESHOLD = 1
+               threshold_height = 0.0
+            EndSect  // INUNDATION
+
+         EndSect  // OUTPUT_1
+
+         [OUTPUT_2]
+            Touched = 1
+            include = 1
+            title = '2D area series'
+            file_name = |.\Output\2D_flow.dfsu|
+            type = 1
+            format = 2
+            flood_and_dry = 2
+            coordinate_type = 'UTM-33'
+            zone = 0
+            input_file_name = ||
+            input_format = 1
+            interpolation_type = 1
+            use_end_time = 1
+            first_time_step = 0
+            last_time_step = 72000
+            time_step_frequency = 1500
+            number_of_points = 2
+            [POINT_1]
+               name = 'POINT_1'
+               x = 350359.194505691
+               y = 6176124.896267602
+               z = -20.58542104720917
+               layer = 22732386
+            EndSect  // POINT_1
+
+            [POINT_2]
+               name = 'POINT_2'
+               x = 350359.194505691
+               y = 6176124.896267602
+               z = -20.58542104720917
+               layer = 22732386
+            EndSect  // POINT_2
+
+            [LINE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+                  z = -41.1428377740823
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+                  z = -0.02800432033603826
+               EndSect  // POINT_2
+
+               npoints = 3
+            EndSect  // LINE
+
+            [PLANE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+               EndSect  // POINT_2
+
+               layer_min = 1
+               layer_max = 10
+               z_min = -37.38161279884851
+               z_max = 7.476322559769699
+               npoints_horizontal = 20
+               npoints_vertical = 10
+            EndSect  // PLANE
+
+            [AREA]
+               number_of_points = 4
+               [POINT_1]
+                  x = 322028.774312474
+                  y = 6127731.488865693
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 322028.774312474
+                  y = 6224518.303669511
+               EndSect  // POINT_2
+
+               [POINT_3]
+                  x = 378689.6146989079
+                  y = 6224518.303669511
+               EndSect  // POINT_3
+
+               [POINT_4]
+                  x = 378689.6146989079
+                  y = 6127731.488865693
+               EndSect  // POINT_4
+
+               layer_min = 1
+               layer_max = 10
+               orientation = 0.0
+               x_origo = 322584.2727476351
+               x_ds = 4994.159690599497
+               x_npoints = 13
+               y_origo = 6128680.379206907
+               y_ds = 4994.159690599497
+               y_npoints = 20
+               z_origo = -37.38161279884851
+               z_ds = 4.984215039846467
+               z_npoints = 10
+            EndSect  // AREA
+
+            [PARAMETERS_2D]
+               Touched = 1
+               SURFACE_ELEVATION = 1
+               STILL_WATER_DEPTH = 0
+               TOTAL_WATER_DEPTH = 1
+               U_VELOCITY = 1
+               V_VELOCITY = 1
+               P_FLUX = 0
+               Q_FLUX = 0
+               CURRENT_SPEED = 1
+               CURRENT_DIRECTION = 1
+               WIND_U_VELOCITY = 0
+               WIND_V_VELOCITY = 0
+               AIR_PRESSURE = 0
+               PRECIPITATION = 0
+               EVAPORATION = 0
+               BED_RESISTANCE_COEFFICIENT = 0
+               DRAG_COEFFICIENT = 0
+               BED_SHEARSTRESS = 0
+               BED_SHEARSTRESS_X_COMPONENT = 0
+               BED_SHEARSTRESS_Y_COMPONENT = 0
+               CONVERGENCE_ANGLE = 0
+               AREA = 0
+            EndSect  // PARAMETERS_2D
+
+            [PARAMETERS_3D]
+               Touched = 1
+               U_VELOCITY = 1
+               V_VELOCITY = 1
+               W_VELOCITY = 1
+               WS_VELOCITY = 0
+               DENSITY = 0
+               TEMPERATURE = 0
+               SALINITY = 0
+               TURBULENT_KINETIC_ENERGY = 0
+               DISSIPATION_OF_TKE = 0
+               CURRENT_SPEED = 0
+               CURRENT_DIRECTION_HORIZONTAL = 0
+               CURRENT_DIRECTION_VERTICAL = 0
+               HORIZONTAL_EDDY_VISCOSITY = 0
+               VERTICAL_EDDY_VISCOSITY = 0
+               CFL_NUMBER = 0
+               VOLUME = 0
+            EndSect  // PARAMETERS_3D
+
+            [DISCHARGE]
+               Touched = 0
+               Type = 1
+               domain = 1
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               DISCHARGE_POSITIVE = 0
+               ACCUMULATED_DISCHARGE_POSITIVE = 0
+               DISCHARGE_NEGATIVE = 0
+               ACCUMULATED_DISCHARGE_NEGATIVE = 0
+               FLOW = 0
+               TEMPERATURE = 0
+               SALINITY = 0
+            EndSect  // DISCHARGE
+
+            [MASSBUDGET]
+               Touched = 0
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               FLOW = 1
+               TEMPERATURE = 1
+               SALINITY = 1
+            EndSect  // MASSBUDGET
+
+            [INUNDATION]
+               Touched = 0
+               MAXIMUM_HEIGHT = 1
+               MAXIMUM_SURFACE_ELEVATION = 1
+               TIME_MAXIMUM_HEIGHT = 1
+               MAXIMUM_CURRENT_SPEED = 1
+               DIRECTION_AT_MAXIMUM_CURRENT_SPEED = 1
+               U_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               V_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               TIME_MAXIMUM_CURRENT_SPEED = 1
+               MAXIMUM_FLUX_MAGNITUDE = 0
+               DIRECTION_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               P_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               Q_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               TIME_MAXIMUM_FLUX_MAGNITUDE = 0
+               DURATION_ABOVE_THRESHOLD = 1
+               TIME_FIRST_ABOVE_THRESHOLD = 1
+               threshold_height = 0.0
+            EndSect  // INUNDATION
+
+         EndSect  // OUTPUT_2
+
+         [OUTPUT_3]
+            Touched = 1
+            include = 1
+            title = 'Ndr. Roese point series'
+            file_name = |.\Output\3D_ndr_roese_flow.dfs0|
+            type = 2
+            format = 0
+            flood_and_dry = 2
+            coordinate_type = 'UTM-33'
+            zone = 0
+            input_file_name = ||
+            input_format = 1
+            interpolation_type = 2
+            use_end_time = 1
+            first_time_step = 0
+            last_time_step = 72000
+            time_step_frequency = 15
+            number_of_points = 6
+            [POINT_1]
+               name = '-2.9'
+               x = 354950.0
+               y = 6167973.0
+               z = -2.9
+               layer = 1
+            EndSect  // POINT_1
+
+            [POINT_2]
+               name = '-4.4'
+               x = 354950.0
+               y = 6167973.0
+               z = -4.4
+               layer = 10
+            EndSect  // POINT_2
+
+            [POINT_3]
+               name = '-5.9'
+               x = 354950.0
+               y = 6167973.0
+               z = -5.9
+               layer = 1
+            EndSect  // POINT_3
+
+            [POINT_4]
+               name = '-7.4'
+               x = 354950.0
+               y = 6167973.0
+               z = -7.4
+               layer = 1
+            EndSect  // POINT_4
+
+            [POINT_5]
+               name = '-9.0'
+               x = 354950.0
+               y = 6167973.0
+               z = -9.0
+               layer = 1
+            EndSect  // POINT_5
+
+            [POINT_6]
+               name = '-10.6'
+               x = 354950.0
+               y = 6167973.0
+               z = -10.6
+               layer = 1
+            EndSect  // POINT_6
+
+            [LINE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+                  z = -41.1428377740823
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+                  z = -0.02800432033603826
+               EndSect  // POINT_2
+
+               npoints = 3
+            EndSect  // LINE
+
+            [PLANE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+               EndSect  // POINT_2
+
+               layer_min = 1
+               layer_max = 10
+               z_min = -37.38161279884851
+               z_max = 7.476322559769699
+               npoints_horizontal = 20
+               npoints_vertical = 10
+            EndSect  // PLANE
+
+            [AREA]
+               number_of_points = 4
+               [POINT_1]
+                  x = 322028.774312474
+                  y = 6127731.488865693
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 322028.774312474
+                  y = 6224518.303669511
+               EndSect  // POINT_2
+
+               [POINT_3]
+                  x = 378689.6146989079
+                  y = 6224518.303669511
+               EndSect  // POINT_3
+
+               [POINT_4]
+                  x = 378689.6146989079
+                  y = 6127731.488865693
+               EndSect  // POINT_4
+
+               layer_min = 1
+               layer_max = 10
+               orientation = 0.0
+               x_origo = 322584.2727476351
+               x_ds = 4994.159690599497
+               x_npoints = 13
+               y_origo = 6128680.379206907
+               y_ds = 4994.159690599497
+               y_npoints = 20
+               z_origo = -37.38161279884851
+               z_ds = 4.984215039846467
+               z_npoints = 10
+            EndSect  // AREA
+
+            [PARAMETERS_2D]
+               Touched = 1
+               SURFACE_ELEVATION = 1
+               STILL_WATER_DEPTH = 0
+               TOTAL_WATER_DEPTH = 0
+               U_VELOCITY = 1
+               V_VELOCITY = 1
+               P_FLUX = 0
+               Q_FLUX = 0
+               CURRENT_SPEED = 0
+               CURRENT_DIRECTION = 0
+               WIND_U_VELOCITY = 0
+               WIND_V_VELOCITY = 0
+               AIR_PRESSURE = 0
+               PRECIPITATION = 0
+               EVAPORATION = 0
+               BED_RESISTANCE_COEFFICIENT = 0
+               DRAG_COEFFICIENT = 0
+               BED_SHEARSTRESS = 0
+               BED_SHEARSTRESS_X_COMPONENT = 0
+               BED_SHEARSTRESS_Y_COMPONENT = 0
+               CONVERGENCE_ANGLE = 0
+               AREA = 0
+            EndSect  // PARAMETERS_2D
+
+            [PARAMETERS_3D]
+               Touched = 1
+               U_VELOCITY = 1
+               V_VELOCITY = 1
+               W_VELOCITY = 1
+               WS_VELOCITY = 0
+               DENSITY = 1
+               TEMPERATURE = 1
+               SALINITY = 1
+               TURBULENT_KINETIC_ENERGY = 0
+               DISSIPATION_OF_TKE = 0
+               CURRENT_SPEED = 1
+               CURRENT_DIRECTION_HORIZONTAL = 0
+               CURRENT_DIRECTION_VERTICAL = 0
+               HORIZONTAL_EDDY_VISCOSITY = 0
+               VERTICAL_EDDY_VISCOSITY = 0
+               CFL_NUMBER = 0
+               VOLUME = 0
+            EndSect  // PARAMETERS_3D
+
+            [DISCHARGE]
+               Touched = 0
+               Type = 1
+               domain = 1
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               DISCHARGE_POSITIVE = 0
+               ACCUMULATED_DISCHARGE_POSITIVE = 0
+               DISCHARGE_NEGATIVE = 0
+               ACCUMULATED_DISCHARGE_NEGATIVE = 0
+               FLOW = 0
+               TEMPERATURE = 0
+               SALINITY = 0
+            EndSect  // DISCHARGE
+
+            [MASSBUDGET]
+               Touched = 0
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               FLOW = 1
+               TEMPERATURE = 1
+               SALINITY = 1
+            EndSect  // MASSBUDGET
+
+            [INUNDATION]
+               Touched = 0
+               MAXIMUM_HEIGHT = 1
+               MAXIMUM_SURFACE_ELEVATION = 1
+               TIME_MAXIMUM_HEIGHT = 1
+               MAXIMUM_CURRENT_SPEED = 1
+               DIRECTION_AT_MAXIMUM_CURRENT_SPEED = 1
+               U_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               V_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               TIME_MAXIMUM_CURRENT_SPEED = 1
+               MAXIMUM_FLUX_MAGNITUDE = 0
+               DIRECTION_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               P_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               Q_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               TIME_MAXIMUM_FLUX_MAGNITUDE = 0
+               DURATION_ABOVE_THRESHOLD = 1
+               TIME_FIRST_ABOVE_THRESHOLD = 1
+               threshold_height = 0.0
+            EndSect  // INUNDATION
+
+         EndSect  // OUTPUT_3
+
+         [OUTPUT_4]
+            Touched = 1
+            include = 1
+            title = 'Ndr. Roese point series'
+            file_name = |.\Output\2D_ndr_roese_flow.dfs0|
+            type = 1
+            format = 0
+            flood_and_dry = 2
+            coordinate_type = 'UTM-33'
+            zone = 0
+            input_file_name = ||
+            input_format = 1
+            interpolation_type = 1
+            use_end_time = 1
+            first_time_step = 0
+            last_time_step = 72000
+            time_step_frequency = 15
+            number_of_points = 1
+            [POINT_1]
+               name = 'Point 1'
+               x = 354950.0
+               y = 6167973.0
+               z = -18.72151764127384
+               layer = 1
+            EndSect  // POINT_1
+
+            [LINE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+                  z = -37.38161279884851
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+                  z = -0.06142248369917411
+               EndSect  // POINT_2
+
+               npoints = 3
+            EndSect  // LINE
+
+            [PLANE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+               EndSect  // POINT_2
+
+               layer_min = 1
+               layer_max = 10
+               z_min = -37.38161279884851
+               z_max = 7.476322559769699
+               npoints_horizontal = 20
+               npoints_vertical = 10
+            EndSect  // PLANE
+
+            [AREA]
+               number_of_points = 4
+               [POINT_1]
+                  x = 322028.774312474
+                  y = 6127731.488865693
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 322028.774312474
+                  y = 6224518.303669511
+               EndSect  // POINT_2
+
+               [POINT_3]
+                  x = 378689.6146989079
+                  y = 6224518.303669511
+               EndSect  // POINT_3
+
+               [POINT_4]
+                  x = 378689.6146989079
+                  y = 6127731.488865693
+               EndSect  // POINT_4
+
+               layer_min = 1
+               layer_max = 10
+               orientation = 0.0
+               x_origo = 322584.2727476351
+               x_ds = 4994.159690599497
+               x_npoints = 13
+               y_origo = 6128680.379206907
+               y_ds = 4994.159690599497
+               y_npoints = 20
+               z_origo = -37.38161279884851
+               z_ds = 4.984215039846467
+               z_npoints = 10
+            EndSect  // AREA
+
+            [PARAMETERS_2D]
+               Touched = 1
+               SURFACE_ELEVATION = 1
+               STILL_WATER_DEPTH = 0
+               TOTAL_WATER_DEPTH = 0
+               U_VELOCITY = 0
+               V_VELOCITY = 0
+               P_FLUX = 0
+               Q_FLUX = 0
+               CURRENT_SPEED = 1
+               CURRENT_DIRECTION = 1
+               WIND_U_VELOCITY = 0
+               WIND_V_VELOCITY = 0
+               AIR_PRESSURE = 0
+               PRECIPITATION = 0
+               EVAPORATION = 0
+               BED_RESISTANCE_COEFFICIENT = 0
+               DRAG_COEFFICIENT = 1
+               BED_SHEARSTRESS = 0
+               BED_SHEARSTRESS_X_COMPONENT = 0
+               BED_SHEARSTRESS_Y_COMPONENT = 0
+               CONVERGENCE_ANGLE = 0
+               AREA = 0
+            EndSect  // PARAMETERS_2D
+
+            [PARAMETERS_3D]
+               Touched = 1
+               U_VELOCITY = 1
+               V_VELOCITY = 1
+               W_VELOCITY = 1
+               WS_VELOCITY = 0
+               DENSITY = 1
+               TEMPERATURE = 1
+               SALINITY = 1
+               TURBULENT_KINETIC_ENERGY = 0
+               DISSIPATION_OF_TKE = 0
+               CURRENT_SPEED = 0
+               CURRENT_DIRECTION_HORIZONTAL = 0
+               CURRENT_DIRECTION_VERTICAL = 0
+               HORIZONTAL_EDDY_VISCOSITY = 0
+               VERTICAL_EDDY_VISCOSITY = 0
+               CFL_NUMBER = 0
+               VOLUME = 0
+            EndSect  // PARAMETERS_3D
+
+            [DISCHARGE]
+               Touched = 0
+               Type = 1
+               domain = 1
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               DISCHARGE_POSITIVE = 0
+               ACCUMULATED_DISCHARGE_POSITIVE = 0
+               DISCHARGE_NEGATIVE = 0
+               ACCUMULATED_DISCHARGE_NEGATIVE = 0
+               FLOW = 0
+               TEMPERATURE = 0
+               SALINITY = 0
+            EndSect  // DISCHARGE
+
+            [MASSBUDGET]
+               Touched = 0
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               FLOW = 1
+               TEMPERATURE = 1
+               SALINITY = 1
+            EndSect  // MASSBUDGET
+
+            [INUNDATION]
+               Touched = 0
+               MAXIMUM_HEIGHT = 1
+               MAXIMUM_SURFACE_ELEVATION = 1
+               TIME_MAXIMUM_HEIGHT = 1
+               MAXIMUM_CURRENT_SPEED = 1
+               DIRECTION_AT_MAXIMUM_CURRENT_SPEED = 1
+               U_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               V_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               TIME_MAXIMUM_CURRENT_SPEED = 1
+               MAXIMUM_FLUX_MAGNITUDE = 0
+               DIRECTION_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               P_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               Q_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               TIME_MAXIMUM_FLUX_MAGNITUDE = 0
+               DURATION_ABOVE_THRESHOLD = 1
+               TIME_FIRST_ABOVE_THRESHOLD = 1
+               threshold_height = 0.0
+            EndSect  // INUNDATION
+
+         EndSect  // OUTPUT_4
+
+         [OUTPUT_5]
+            Touched = 1
+            include = 1
+            title = 'hot 3D'
+            file_name = |..\..\Data\1997\Initial_Conditions\3D_sept_15_1997.dfsu|
+            type = 2
+            format = 3
+            flood_and_dry = 2
+            coordinate_type = 'UTM-33'
+            zone = 0
+            input_file_name = ||
+            input_format = 1
+            interpolation_type = 1
+            use_end_time = 1
+            first_time_step = 72000
+            last_time_step = 72000
+            time_step_frequency = 1
+            number_of_points = 1
+            [POINT_1]
+               name = 'Point 1'
+               x = 350359.194505691
+               y = 6176124.896267602
+               z = -18.72151764127384
+               layer = 1
+            EndSect  // POINT_1
+
+            [LINE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+                  z = -37.38161279884851
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+                  z = -0.06142248369917411
+               EndSect  // POINT_2
+
+               npoints = 3
+            EndSect  // LINE
+
+            [PLANE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+               EndSect  // POINT_2
+
+               layer_min = 1
+               layer_max = 10
+               z_min = -37.38161279884851
+               z_max = 7.476322559769699
+               npoints_horizontal = 20
+               npoints_vertical = 10
+            EndSect  // PLANE
+
+            [AREA]
+               number_of_points = 4
+               [POINT_1]
+                  x = 322028.774312474
+                  y = 6127731.488865693
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 322028.774312474
+                  y = 6224518.303669511
+               EndSect  // POINT_2
+
+               [POINT_3]
+                  x = 378689.6146989079
+                  y = 6224518.303669511
+               EndSect  // POINT_3
+
+               [POINT_4]
+                  x = 378689.6146989079
+                  y = 6127731.488865693
+               EndSect  // POINT_4
+
+               layer_min = 1
+               layer_max = 10
+               orientation = 0.0
+               x_origo = 322584.2727476351
+               x_ds = 4994.159690599497
+               x_npoints = 13
+               y_origo = 6128680.379206907
+               y_ds = 4994.159690599497
+               y_npoints = 20
+               z_origo = -37.38161279884851
+               z_ds = 4.984215039846467
+               z_npoints = 10
+            EndSect  // AREA
+
+            [PARAMETERS_2D]
+               Touched = 1
+               SURFACE_ELEVATION = 1
+               STILL_WATER_DEPTH = 0
+               TOTAL_WATER_DEPTH = 0
+               U_VELOCITY = 1
+               V_VELOCITY = 1
+               P_FLUX = 0
+               Q_FLUX = 0
+               CURRENT_SPEED = 0
+               CURRENT_DIRECTION = 0
+               WIND_U_VELOCITY = 0
+               WIND_V_VELOCITY = 0
+               AIR_PRESSURE = 0
+               PRECIPITATION = 0
+               EVAPORATION = 0
+               BED_RESISTANCE_COEFFICIENT = 0
+               DRAG_COEFFICIENT = 0
+               BED_SHEARSTRESS = 0
+               BED_SHEARSTRESS_X_COMPONENT = 0
+               BED_SHEARSTRESS_Y_COMPONENT = 0
+               CONVERGENCE_ANGLE = 0
+               AREA = 0
+            EndSect  // PARAMETERS_2D
+
+            [PARAMETERS_3D]
+               Touched = 1
+               U_VELOCITY = 1
+               V_VELOCITY = 1
+               W_VELOCITY = 0
+               WS_VELOCITY = 0
+               DENSITY = 0
+               TEMPERATURE = 1
+               SALINITY = 1
+               TURBULENT_KINETIC_ENERGY = 1
+               DISSIPATION_OF_TKE = 1
+               CURRENT_SPEED = 0
+               CURRENT_DIRECTION_HORIZONTAL = 0
+               CURRENT_DIRECTION_VERTICAL = 0
+               HORIZONTAL_EDDY_VISCOSITY = 0
+               VERTICAL_EDDY_VISCOSITY = 0
+               CFL_NUMBER = 0
+               VOLUME = 0
+            EndSect  // PARAMETERS_3D
+
+            [DISCHARGE]
+               Touched = 0
+               Type = 1
+               domain = 1
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               DISCHARGE_POSITIVE = 0
+               ACCUMULATED_DISCHARGE_POSITIVE = 0
+               DISCHARGE_NEGATIVE = 0
+               ACCUMULATED_DISCHARGE_NEGATIVE = 0
+               FLOW = 0
+               TEMPERATURE = 0
+               SALINITY = 0
+            EndSect  // DISCHARGE
+
+            [MASSBUDGET]
+               Touched = 0
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               FLOW = 1
+               TEMPERATURE = 1
+               SALINITY = 1
+            EndSect  // MASSBUDGET
+
+            [INUNDATION]
+               Touched = 0
+               MAXIMUM_HEIGHT = 1
+               MAXIMUM_SURFACE_ELEVATION = 1
+               TIME_MAXIMUM_HEIGHT = 1
+               MAXIMUM_CURRENT_SPEED = 1
+               DIRECTION_AT_MAXIMUM_CURRENT_SPEED = 1
+               U_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               V_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               TIME_MAXIMUM_CURRENT_SPEED = 1
+               MAXIMUM_FLUX_MAGNITUDE = 0
+               DIRECTION_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               P_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               Q_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               TIME_MAXIMUM_FLUX_MAGNITUDE = 0
+               DURATION_ABOVE_THRESHOLD = 1
+               TIME_FIRST_ABOVE_THRESHOLD = 1
+               threshold_height = 0.0
+            EndSect  // INUNDATION
+
+         EndSect  // OUTPUT_5
+
+         [OUTPUT_6]
+            Touched = 1
+            include = 1
+            title = 'hot 2D'
+            file_name = |..\..\Data\1997\Initial_Conditions\2D_sept_15_1997.dfsu|
+            type = 1
+            format = 2
+            flood_and_dry = 2
+            coordinate_type = 'UTM-33'
+            zone = 0
+            input_file_name = ||
+            input_format = 1
+            interpolation_type = 1
+            use_end_time = 1
+            first_time_step = 72000
+            last_time_step = 72000
+            time_step_frequency = 1
+            number_of_points = 1
+            [POINT_1]
+               name = 'Point 1'
+               x = 350359.194505691
+               y = 6176124.896267602
+               z = -18.72151764127384
+               layer = 1
+            EndSect  // POINT_1
+
+            [LINE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+                  z = -37.38161279884851
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+                  z = -0.06142248369917411
+               EndSect  // POINT_2
+
+               npoints = 3
+            EndSect  // LINE
+
+            [PLANE]
+               number_of_points = 2
+               [POINT_1]
+                  x = 322584.2727476351
+                  y = 6128680.379206907
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 378134.1162637468
+                  y = 6223569.413328297
+               EndSect  // POINT_2
+
+               layer_min = 1
+               layer_max = 10
+               z_min = -37.38161279884851
+               z_max = 7.476322559769699
+               npoints_horizontal = 20
+               npoints_vertical = 10
+            EndSect  // PLANE
+
+            [AREA]
+               number_of_points = 4
+               [POINT_1]
+                  x = 322028.774312474
+                  y = 6127731.488865693
+               EndSect  // POINT_1
+
+               [POINT_2]
+                  x = 322028.774312474
+                  y = 6224518.303669511
+               EndSect  // POINT_2
+
+               [POINT_3]
+                  x = 378689.6146989079
+                  y = 6224518.303669511
+               EndSect  // POINT_3
+
+               [POINT_4]
+                  x = 378689.6146989079
+                  y = 6127731.488865693
+               EndSect  // POINT_4
+
+               layer_min = 1
+               layer_max = 10
+               orientation = 0.0
+               x_origo = 322584.2727476351
+               x_ds = 4994.159690599497
+               x_npoints = 13
+               y_origo = 6128680.379206907
+               y_ds = 4994.159690599497
+               y_npoints = 20
+               z_origo = -37.38161279884851
+               z_ds = 4.984215039846467
+               z_npoints = 10
+            EndSect  // AREA
+
+            [PARAMETERS_2D]
+               Touched = 1
+               SURFACE_ELEVATION = 0
+               STILL_WATER_DEPTH = 0
+               TOTAL_WATER_DEPTH = 1
+               U_VELOCITY = 0
+               V_VELOCITY = 0
+               P_FLUX = 0
+               Q_FLUX = 0
+               CURRENT_SPEED = 0
+               CURRENT_DIRECTION = 0
+               WIND_U_VELOCITY = 0
+               WIND_V_VELOCITY = 0
+               AIR_PRESSURE = 0
+               PRECIPITATION = 0
+               EVAPORATION = 0
+               BED_RESISTANCE_COEFFICIENT = 0
+               DRAG_COEFFICIENT = 0
+               BED_SHEARSTRESS = 0
+               BED_SHEARSTRESS_X_COMPONENT = 0
+               BED_SHEARSTRESS_Y_COMPONENT = 0
+               CONVERGENCE_ANGLE = 0
+               AREA = 0
+            EndSect  // PARAMETERS_2D
+
+            [PARAMETERS_3D]
+               Touched = 1
+               U_VELOCITY = 1
+               V_VELOCITY = 1
+               W_VELOCITY = 1
+               WS_VELOCITY = 0
+               DENSITY = 1
+               TEMPERATURE = 1
+               SALINITY = 1
+               TURBULENT_KINETIC_ENERGY = 0
+               DISSIPATION_OF_TKE = 0
+               CURRENT_SPEED = 0
+               CURRENT_DIRECTION_HORIZONTAL = 0
+               CURRENT_DIRECTION_VERTICAL = 0
+               HORIZONTAL_EDDY_VISCOSITY = 0
+               VERTICAL_EDDY_VISCOSITY = 0
+               CFL_NUMBER = 0
+               VOLUME = 0
+            EndSect  // PARAMETERS_3D
+
+            [DISCHARGE]
+               Touched = 0
+               Type = 1
+               domain = 1
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               DISCHARGE_POSITIVE = 0
+               ACCUMULATED_DISCHARGE_POSITIVE = 0
+               DISCHARGE_NEGATIVE = 0
+               ACCUMULATED_DISCHARGE_NEGATIVE = 0
+               FLOW = 0
+               TEMPERATURE = 0
+               SALINITY = 0
+            EndSect  // DISCHARGE
+
+            [MASSBUDGET]
+               Touched = 0
+               DISCHARGE = 1
+               ACCUMULATED_DISCHARGE = 1
+               FLOW = 1
+               TEMPERATURE = 1
+               SALINITY = 1
+            EndSect  // MASSBUDGET
+
+            [INUNDATION]
+               Touched = 0
+               MAXIMUM_HEIGHT = 1
+               MAXIMUM_SURFACE_ELEVATION = 1
+               TIME_MAXIMUM_HEIGHT = 1
+               MAXIMUM_CURRENT_SPEED = 1
+               DIRECTION_AT_MAXIMUM_CURRENT_SPEED = 1
+               U_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               V_VELOCITY_AT_MAXIMUM_CURRENT_SPEED = 1
+               TIME_MAXIMUM_CURRENT_SPEED = 1
+               MAXIMUM_FLUX_MAGNITUDE = 0
+               DIRECTION_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               P_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               Q_FLUX_AT_MAXIMUM_FLUX_MAGNITUDE = 0
+               TIME_MAXIMUM_FLUX_MAGNITUDE = 0
+               DURATION_ABOVE_THRESHOLD = 1
+               TIME_FIRST_ABOVE_THRESHOLD = 1
+               threshold_height = 0.0
+            EndSect  // INUNDATION
+
+         EndSect  // OUTPUT_6
+
+      EndSect  // OUTPUTS
+
+   EndSect  // HYDRODYNAMIC_MODULE
+
+   [TRANSPORT_MODULE]
+      mode = 0
+      [TIME]
+         start_time_step = 0
+         time_step_factor = 1
+      EndSect  // TIME
+
+      [COMPONENTS]
+         Touched = 0
+         MzSEPfsListItemCount = 0
+         number_of_components = 0
+      EndSect  // COMPONENTS
+
+      [SOLUTION_TECHNIQUE]
+         Touched = 0
+         scheme_of_time_integration = 1
+         scheme_of_space_discretization_horizontal = 1
+         scheme_of_space_discretization_vertical = 1
+         method_of_space_discretization_horizontal = 0
+      EndSect  // SOLUTION_TECHNIQUE
+
+      [HYDRODYNAMIC_CONDITIONS]
+         Touched = 0
+         type = 0
+         format = 0
+         surface_elevation_constant = 0.0
+         u_velocity_constant = 0.0
+         v_velocity_constant = 0.0
+         w_velocity_constant = 0.0
+         file_name = ||
+      EndSect  // HYDRODYNAMIC_CONDITIONS
+
+      [DISPERSION]
+         [HORIZONTAL_DISPERSION]
+            Touched = 0
+            MzSEPfsListItemCount = 0
+         EndSect  // HORIZONTAL_DISPERSION
+
+         [VERTICAL_DISPERSION]
+            Touched = 0
+            MzSEPfsListItemCount = 0
+         EndSect  // VERTICAL_DISPERSION
+
+      EndSect  // DISPERSION
+
+      [DECAY]
+         Touched = 0
+         MzSEPfsListItemCount = 0
+      EndSect  // DECAY
+
+      [PRECIPITATION_EVAPORATION]
+         Touched = 0
+         MzSEPfsListItemCount = 0
+      EndSect  // PRECIPITATION_EVAPORATION
+
+      [INFILTRATION]
+         Touched = 1
+         MzSEPfsListItemCount = 0
+      EndSect  // INFILTRATION
+
+      [SOURCES]
+         Touched = 0
+         MzSEPfsListItemCount = 0
+      EndSect  // SOURCES
+
+      [INITIAL_CONDITIONS]
+         Touched = 0
+         MzSEPfsListItemCount = 0
+      EndSect  // INITIAL_CONDITIONS
+
+      [BOUNDARY_CONDITIONS]
+         Touched = 0
+         MzSEPfsListItemCount = 2
+         [CODE_1]
+         EndSect  // CODE_1
+
+         [CODE_3]
+            Touched = 0
+            MzSEPfsListItemCount = 0
+         EndSect  // CODE_3
+
+         [CODE_2]
+            Touched = 0
+            MzSEPfsListItemCount = 0
+         EndSect  // CODE_2
+
+      EndSect  // BOUNDARY_CONDITIONS
+
+      [OUTPUTS]
+         Touched = 0
+         MzSEPfsListItemCount = 0
+         number_of_outputs = 0
+      EndSect  // OUTPUTS
+
+   EndSect  // TRANSPORT_MODULE
+
+   [ECOLAB_MODULE]
+      mode = 0
+      [TIME]
+         start_time_step = 0
+         time_step_factor = 1
+      EndSect  // TIME
+
+      [MODEL_DEFINITION]
+         Touched = 0
+         model_definition_file = ||
+         template_datetime = ''
+         integration_method = 1
+         update_frequency = 1
+         type_of_processes = 1
+         optimisation_level = 0
+         compute_dry_elements = false
+         options = 0
+      EndSect  // MODEL_DEFINITION
+
+      [DISPERSION]
+         [HORIZONTAL_DISPERSION]
+            Touched = 0
+            MzSEPfsListItemCount = 0
+         EndSect  // HORIZONTAL_DISPERSION
+
+         [VERTICAL_DISPERSION]
+            Touched = 0
+            MzSEPfsListItemCount = 0
+         EndSect  // VERTICAL_DISPERSION
+
+      EndSect  // DISPERSION
+
+   EndSect  // ECOLAB_MODULE
+
+   [MUD_TRANSPORT_MODULE]
+      mode = 0
+      [MODEL_DEFINITION]
+         Touched = 0
+         number_of_fractions = 1
+         number_of_layers = 1
+      EndSect  // MODEL_DEFINITION
+
+      [TIME]
+         Touched = 1
+         start_time_step = 0
+      EndSect  // TIME
+
+      [SOLUTION_TECHNIQUE]
+         Touched = 0
+         scheme_of_time_integration = 1
+         scheme_of_space_discretization_horizontal = 1
+         scheme_of_space_discretization_vertical = 1
+         method_of_space_discretization_horizontal = 0
+      EndSect  // SOLUTION_TECHNIQUE
+
+      [WATER_COLUMN]
+         [SAND_FRACTIONS]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            sand_fraction_description = 0
+            data_file = ||
+            [FRACTION_1]
+               Touched = 0
+               include_sand = true
+               mean_settling_velocity = 0.001
+            EndSect  // FRACTION_1
+
+         EndSect  // SAND_FRACTIONS
+
+         [SETTLING_VELOCITY]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            hindered_settling_description = 0
+            rho_sediment = 2650.0
+            cfloc = 0.01
+            cgel = 50.0
+            chinder = 10.0
+            c1_salt = 0.5
+            c2_salt = -0.33
+            [FRACTION_1]
+               Touched = 0
+               type_flocculation = 1
+               gamma = 1.0
+               wsn = 1.0
+               [CONSTANT_SETTLING_VELOCITY]
+                  Touched = 0
+                  type = 1
+                  format = 0
+                  constant_value = 0.0005
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+               EndSect  // CONSTANT_SETTLING_VELOCITY
+
+               [SETTLING_VELOCITY_COEFFICIENT]
+                  Touched = 0
+                  type = 1
+                  format = 0
+                  constant_value = 5.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+               EndSect  // SETTLING_VELOCITY_COEFFICIENT
+
+            EndSect  // FRACTION_1
+
+         EndSect  // SETTLING_VELOCITY
+
+         [DEPOSITION]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            concentration_profile = 1
+            centroid_height = 0.3
+            [FRACTION_1]
+               Touched = 0
+               [CRITICAL_SHEARSTRESS_FOR_DEPOSITION]
+                  Touched = 0
+                  type = 1
+                  format = 0
+                  constant_value = 0.07000000000000001
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+               EndSect  // CRITICAL_SHEARSTRESS_FOR_DEPOSITION
+
+            EndSect  // FRACTION_1
+
+         EndSect  // DEPOSITION
+
+         [DENSITY_AND_VISCOSITY]
+            Touched = 0
+            include_density_feedback_on_HD = false
+            density_of_sediment = 2650.0
+            base_in_viscosity_formula = 1.0
+            concentration_in_viscosity_formula = 1.0
+         EndSect  // DENSITY_AND_VISCOSITY
+
+      EndSect  // WATER_COLUMN
+
+      [BED]
+         [EROSION]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            max_concentration_due_to_erosion = 50.0
+            type_of_critical_shearstress_for_erosion = 1
+            [LAYER_1]
+               Touched = 0
+               description = 1
+               [EROSION_COEFFICIENT]
+                  Touched = 0
+                  type = 1
+                  format = 0
+                  constant_value = 5e-05
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+               EndSect  // EROSION_COEFFICIENT
+
+               [CRITICAL_SHEARSTRESS_FOR_EROSION]
+                  Touched = 0
+                  type = 1
+                  format = 0
+                  constant_value = 0.1
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+                  constant_values = 0.1
+               EndSect  // CRITICAL_SHEARSTRESS_FOR_EROSION
+
+               [POWER_OF_EROSION]
+                  Touched = 0
+                  type = 1
+                  format = 0
+                  constant_value = 8.300000000000001
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+               EndSect  // POWER_OF_EROSION
+
+            EndSect  // LAYER_1
+
+         EndSect  // EROSION
+
+         [BED_DENSITY]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            [LAYER_1]
+               Touched = 0
+               type = 1
+               format = 0
+               constant_value = 180.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // LAYER_1
+
+         EndSect  // BED_DENSITY
+
+         [ROUGHNESS]
+            Touched = 0
+            type = 0
+            format = 0
+            constant_value = 0.1
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // ROUGHNESS
+
+         [TRANSITION]
+            Touched = 0
+            MzSEPfsListItemCount = 0
+            include_transition = false
+         EndSect  // TRANSITION
+
+      EndSect  // BED
+
+      [SEDIMENT_PROPERTIES]
+         Touched = 1
+         porosity_of_sand = 0.4
+         [SAND_DATA]
+            Touched = 1
+            format = 0
+            grain_diameter = 0.2
+            grading_coefficient = 1.1
+            file_name = ||
+            item_number_for_grain_diameter = 1
+            item_number_for_grading_coefficient = 2
+            item_name_for_grain_diameter = ''
+            item_name_for_grading_coefficient = ''
+            density_of_sand = 2650.0
+         EndSect  // SAND_DATA
+
+      EndSect  // SEDIMENT_PROPERTIES
+
+      [FORCINGS]
+         [WAVES]
+            Touched = 0
+            type_of_wave_height_correction = 1
+            minimum_waterdepth_for_including_waves = 0.0
+            wave_height_over_depth_limit = 0.8
+            include_liquefaction = false
+            liquefaction_factor = 1.0
+            shearstress_formulation = 0
+            type = 1
+            [WAVE_FIELD]
+               Touched = 0
+               type_of_wave_period = 2
+               format = 0
+               wave_height = 1.0
+               wave_period = 3.0
+               wave_direction = 180.0
+               file_name = ||
+               item_number_for_wave_height = 1
+               item_number_for_wave_period = 2
+               item_number_for_wave_direction = 3
+               item_name_for_wave_height = ''
+               item_name_for_wave_period = ''
+               item_name_for_wave_direction = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+            EndSect  // WAVE_FIELD
+
+            [WAVE_DATABASE]
+               Touched = 0
+               MzSEPfsListItemCount = 1
+               type_of_wave_period = 2
+               [Data_Base_Item_1_1_1]
+                  file_name = ||
+                  item_number_for_wave_height = 1
+                  item_number_for_wave_period = 2
+                  item_number_for_wave_direction = 3
+               EndSect  // Data_Base_Item_1_1_1
+
+               [WIND_SPEED]
+                  Touched = 0
+                  starting_value_of_wind_speed = 5
+                  increment_value_of_wind_speed = 5
+                  number_of_wind_speeds = 1
+               EndSect  // WIND_SPEED
+
+               [WIND_DIRECTION]
+                  Touched = 0
+                  starting_value_of_wind_direction = 90
+                  increment_value_of_wind_direction = 90
+                  number_of_wind_directions = 1
+               EndSect  // WIND_DIRECTION
+
+               [WATER_LEVEL]
+                  Touched = 0
+                  starting_value_of_water_level = 0
+                  increment_value_of_water_level = 1
+                  number_of_water_levels = 1
+               EndSect  // WATER_LEVEL
+
+            EndSect  // WAVE_DATABASE
+
+         EndSect  // WAVES
+
+      EndSect  // FORCINGS
+
+      [DREDGING]
+         Touched = 1
+         MzSEPfsListItemCount = 0
+         number_of_dredgers = 0
+         update_bed = true
+      EndSect  // DREDGING
+
+      [DISPOSAL]
+         Touched = 1
+         MzSEPfsListItemCount = 0
+         number_of_vessels = 0
+         stripping = 1
+         c_strip1 = 0.0033
+         c_strip2 = 0.0033
+      EndSect  // DISPOSAL
+
+      [DISPERSION]
+         [HORIZONTAL_DISPERSION]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            [SSC_FRACTION_1]
+               Touched = 0
+               type = 1
+               [SCALED_EDDY_VISCOSITY]
+                  format = 0
+                  sigma = 1.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // SCALED_EDDY_VISCOSITY
+
+               [DISPERSION_COEFFICIENT]
+                  format = 0
+                  constant_value = 0.01
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // DISPERSION_COEFFICIENT
+
+            EndSect  // SSC_FRACTION_1
+
+         EndSect  // HORIZONTAL_DISPERSION
+
+         [VERTICAL_DISPERSION]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            [SSC_FRACTION_1]
+               Touched = 0
+               type = 1
+               [SCALED_EDDY_VISCOSITY]
+                  format = 0
+                  sigma = 1.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // SCALED_EDDY_VISCOSITY
+
+               [DISPERSION_COEFFICIENT]
+                  format = 0
+                  constant_value = 0.01
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // DISPERSION_COEFFICIENT
+
+            EndSect  // SSC_FRACTION_1
+
+         EndSect  // VERTICAL_DISPERSION
+
+      EndSect  // DISPERSION
+
+      [SOURCES]
+         Touched = 0
+         MzSEPfsListItemCount = 0
+      EndSect  // SOURCES
+
+      [INITIAL_CONDITIONS]
+         [SSC_FRACTION_1]
+            Touched = 0
+            type = 1
+            format = 0
+            constant_value = 0.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // SSC_FRACTION_1
+
+         [BED_THICKNESS_LAYER_1]
+            format = 0
+            constant_value = 0.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+         EndSect  // BED_THICKNESS_LAYER_1
+
+         [BED_DISTRIBUTION_LAYER_1]
+            [BED_DISTRIBUTION_FRACTION_1]
+               format = 0
+               constant_value = 100.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+            EndSect  // BED_DISTRIBUTION_FRACTION_1
+
+         EndSect  // BED_DISTRIBUTION_LAYER_1
+
+      EndSect  // INITIAL_CONDITIONS
+
+      [BOUNDARY_CONDITIONS]
+         Touched = 0
+         MzSEPfsListItemCount = 2
+         [CODE_1]
+         EndSect  // CODE_1
+
+         [CODE_3]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            [SSC_FRACTION_1]
+               Touched = 0
+               type = 2
+               format = 0
+               constant_value = 0.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+               type_of_space_interpolation = 1
+            EndSect  // SSC_FRACTION_1
+
+         EndSect  // CODE_3
+
+         [CODE_2]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            [SSC_FRACTION_1]
+               Touched = 0
+               type = 2
+               format = 0
+               constant_value = 0.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+               type_of_space_interpolation = 1
+            EndSect  // SSC_FRACTION_1
+
+         EndSect  // CODE_2
+
+      EndSect  // BOUNDARY_CONDITIONS
+
+      [MORPHOLOGY]
+         [MODEL_DEFINITION]
+            Touched = 1
+            include_morphological_update = false
+            include_speedup = false
+            [SPEEDUP_FACTOR]
+               format = 0
+               constant_value = 1.0
+               file_name = ||
+               item_number = 1
+               soft_time_interval = 0.0
+            EndSect  // SPEEDUP_FACTOR
+
+         EndSect  // MODEL_DEFINITION
+
+         [BOUNDARY_CONDITIONS]
+            Touched = 1
+            MzSEPfsListItemCount = 2
+            [CODE_1]
+            EndSect  // CODE_1
+
+            [CODE_3]
+               Touched = 1
+               type = 2
+            EndSect  // CODE_3
+
+            [CODE_2]
+               Touched = 1
+               type = 2
+            EndSect  // CODE_2
+
+         EndSect  // BOUNDARY_CONDITIONS
+
+      EndSect  // MORPHOLOGY
+
+      [OUTPUTS]
+         Touched = 0
+         MzSEPfsListItemCount = 0
+         number_of_outputs = 0
+      EndSect  // OUTPUTS
+
+   EndSect  // MUD_TRANSPORT_MODULE
+
+   [SAND_TRANSPORT_MODULE]
+      mode = 0
+      [MODEL_DEFINITION]
+         Touched = 0
+         model = 1
+         multi_fraction_multi_layer = 0
+         transport_description = 1
+         helical_flow_description = 0
+         formulation_forcing = 1
+         number_of_fractions = 1
+         number_of_fractions_multi = 2
+         number_of_layers = 0
+         number_of_layers_multi = 2
+         total_load_factor = 1.0, 1.0
+         maximum_thickness_surface_layer = 0.1
+         maximum_thickness_sublayer = 0.5
+         equilibrium_layer_thickness = 0.0005
+         data_file = ||
+         [FRACTION_1]
+            bed_load_formula = 1
+            bed_load_factor = 1.0
+            bed_concentration_formula = 1
+            suspended_load_formula = 1
+            suspended_load_factor = 1.0
+            maximum_value = 10000.0
+            type_of_shear_stress = 2
+            static_friction_coefficient = 0.63
+            dynamic_friction_coefficient = 0.51
+            friction_velocity_factor = 10.0
+         EndSect  // FRACTION_1
+
+      EndSect  // MODEL_DEFINITION
+
+      [TIME]
+         Touched = 0
+         start_time_step = 0
+         time_step_factor = 1
+         time_step_factor_AD = 1
+      EndSect  // TIME
+
+      [SOLUTION_TECHNIQUE]
+         Touched = 0
+         scheme_of_time_integration = 1
+         scheme_of_space_discretization_horizontal = 1
+         scheme_of_space_discretization_vertical = 1
+         method_of_space_discretization_horizontal = 0
+         number_of_iterations = 1
+         time_step = 30.0
+      EndSect  // SOLUTION_TECHNIQUE
+
+      [SEDIMENT_PROPERTIES]
+         Touched = 0
+         porosity = 0.4
+         [SEDIMENT_DATA]
+            Touched = 1
+            format = 0
+            grain_diameter = 0.2
+            grading_coefficient = 1.1
+            file_name = ||
+            item_number_for_grain_diameter = 1
+            item_number_for_grading_coefficient = 2
+            item_name_for_grain_diameter = ''
+            item_name_for_grading_coefficient = ''
+            relative_density = 2.65
+            critical_Shields_parameter = 0.05
+            grain_diameter_for_fractions = 0.2, 0.2
+            density_for_fractions = 2650.0, 2650.0
+         EndSect  // SEDIMENT_DATA
+
+      EndSect  // SEDIMENT_PROPERTIES
+
+      [BED_RESISTANCE]
+         Touched = 0
+         type = 2
+         [CHEZY_NUMBER]
+            Touched = 0
+            type = 1
+            format = 0
+            constant_value = 32.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // CHEZY_NUMBER
+
+         [MANNING_NUMBER]
+            Touched = 0
+            type = 1
+            format = 0
+            constant_value = 32.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // MANNING_NUMBER
+
+         [ALLUVIAL_RESISTANCE]
+            Touched = 0
+            resistance_power = 0.0
+            minimum_resistance = 5.0
+            maximum_resistance = 100.0
+            type = 1
+            format = 0
+            constant_value = 32.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // ALLUVIAL_RESISTANCE
+
+      EndSect  // BED_RESISTANCE
+
+      [FORCINGS]
+         [WAVES]
+            Touched = 0
+            minimum_waterdepth_for_including_waves = 0
+            include_liquefaction = false
+            liquefaction_factor = 1.0
+            shearstress_formulation = 0
+            type = 1
+            [WAVE_FIELD]
+               Touched = 0
+               format = 0
+               type_of_wave_height = 2
+               type_of_wave_period = 1
+               wave_height = 1.0
+               wave_period = 3.0
+               wave_direction = 180.0
+               file_name = ||
+               item_number_for_wave_height = 1
+               item_number_for_wave_period = 2
+               item_number_for_wave_direction = 3
+               item_name_for_wave_height = ''
+               item_name_for_wave_period = ''
+               item_name_for_wave_direction = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+            EndSect  // WAVE_FIELD
+
+            [WAVE_DATABASE]
+               Touched = 0
+               MzSEPfsListItemCount = 1
+               [Data_Base_Item_1_1_1]
+                  file_name = ||
+                  item_number_for_wave_height = 1
+                  item_number_for_wave_period = 2
+                  item_number_for_wave_direction = 3
+               EndSect  // Data_Base_Item_1_1_1
+
+               [WIND_SPEED]
+                  Touched = 0
+                  starting_value_of_wind_speed = 5
+                  increment_value_of_wind_speed = 5
+                  number_of_wind_speeds = 1
+               EndSect  // WIND_SPEED
+
+               [WIND_DIRECTION]
+                  Touched = 0
+                  starting_value_of_wind_direction = 90
+                  increment_value_of_wind_direction = 90
+                  number_of_wind_directions = 1
+               EndSect  // WIND_DIRECTION
+
+               [WATER_LEVEL]
+                  Touched = 0
+                  starting_value_of_water_level = 0
+                  increment_value_of_water_level = 1
+                  number_of_water_levels = 1
+               EndSect  // WATER_LEVEL
+
+            EndSect  // WAVE_DATABASE
+
+         EndSect  // WAVES
+
+         [FLOW]
+            Touched = 0
+            type = 1
+            minimum_water_depth = 0.01
+            [FLOW_FIELD]
+               Touched = 0
+               format = 3
+               file_name = ||
+               item_number_for_s = 1
+               item_number_for_u = 2
+               item_number_for_v = 3
+               item_name_for_s = ''
+               item_name_for_u = ''
+               item_name_for_v = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+            EndSect  // FLOW_FIELD
+
+         EndSect  // FLOW
+
+      EndSect  // FORCINGS
+
+      [DISPERSION]
+         [HORIZONTAL_DISPERSION]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            [SSC_FRACTION_1]
+               Touched = 0
+               type = 2
+               [SCALED_EDDY_VISCOSITY]
+                  format = 0
+                  sigma = 1.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // SCALED_EDDY_VISCOSITY
+
+               [DISPERSION_COEFFICIENT]
+                  format = 0
+                  constant_value = 0.01
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // DISPERSION_COEFFICIENT
+
+            EndSect  // SSC_FRACTION_1
+
+         EndSect  // HORIZONTAL_DISPERSION
+
+         [VERTICAL_DISPERSION]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            [SSC_FRACTION_1]
+               Touched = 0
+               type = 2
+               [SCALED_EDDY_VISCOSITY]
+                  format = 0
+                  sigma = 1.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // SCALED_EDDY_VISCOSITY
+
+               [DISPERSION_COEFFICIENT]
+                  format = 0
+                  constant_value = 0.01
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // DISPERSION_COEFFICIENT
+
+            EndSect  // SSC_FRACTION_1
+
+         EndSect  // VERTICAL_DISPERSION
+
+      EndSect  // DISPERSION
+
+      [SOURCES]
+         Touched = 0
+         MzSEPfsListItemCount = 0
+      EndSect  // SOURCES
+
+      [INITIAL_CONDITIONS]
+         [SSC_FRACTION_1]
+            Touched = 0
+            type = 2
+            format = 0
+            constant_value = 0.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // SSC_FRACTION_1
+
+         [BED_THICKNESS_LAYER_1]
+            Touched = 0
+            type = 1
+            format = 0
+            constant_value = 0.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // BED_THICKNESS_LAYER_1
+
+         [BED_THICKNESS_MULTI_LAYER_1]
+            type = 1
+            format = 0
+            constant_value = 0.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0
+            reference_value = 0
+            type_of_time_interpolation = 1
+         EndSect  // BED_THICKNESS_MULTI_LAYER_1
+
+         [BED_DISTRIBUTION_MULTI_LAYER_1]
+            format = 0
+            constant_value = 50.0, 50.0
+            file_name = ||
+            item_number = 1, 2
+            item_name = '', ''
+         EndSect  // BED_DISTRIBUTION_MULTI_LAYER_1
+
+         [BED_THICKNESS_MULTI_LAYER_2]
+            type = 1
+            format = 0
+            constant_value = 0.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0
+            reference_value = 0
+            type_of_time_interpolation = 1
+         EndSect  // BED_THICKNESS_MULTI_LAYER_2
+
+         [BED_DISTRIBUTION_MULTI_LAYER_2]
+            format = 0
+            constant_value = 50.0, 50.0
+            file_name = ||
+            item_number = 1, 2
+            item_name = '', ''
+         EndSect  // BED_DISTRIBUTION_MULTI_LAYER_2
+
+      EndSect  // INITIAL_CONDITIONS
+
+      [BOUNDARY_CONDITIONS]
+         Touched = 0
+         MzSEPfsListItemCount = 2
+         [CODE_1]
+         EndSect  // CODE_1
+
+         [CODE_3]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            [SSC_FRACTION_1]
+               Touched = 0
+               type = 4
+               format = 0
+               constant_value = 0.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+               type_of_space_interpolation = 1
+            EndSect  // SSC_FRACTION_1
+
+         EndSect  // CODE_3
+
+         [CODE_2]
+            Touched = 0
+            MzSEPfsListItemCount = 1
+            [SSC_FRACTION_1]
+               Touched = 0
+               type = 4
+               format = 0
+               constant_value = 0.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+               type_of_space_interpolation = 1
+            EndSect  // SSC_FRACTION_1
+
+         EndSect  // CODE_2
+
+      EndSect  // BOUNDARY_CONDITIONS
+
+      [MORPHOLOGY]
+         [MODEL_DEFINITION]
+            Touched = 0
+            method = 1
+            max_bed_level_change = 1.0
+            include_morphology_update = 1
+            [SPEEDUP_FACTOR]
+               format = 0
+               constant_value = 1.0
+               file_name = ||
+               item_number = 1
+               soft_time_interval = 0.0
+            EndSect  // SPEEDUP_FACTOR
+
+         EndSect  // MODEL_DEFINITION
+
+         [TIME]
+            Touched = 0
+            start_time_step = 0
+         EndSect  // TIME
+
+         [BANK_EROSION]
+            Touched = 1
+            type = 0
+            [ANGLE_OF_REPOSE]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 30.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+            EndSect  // ANGLE_OF_REPOSE
+
+         EndSect  // BANK_EROSION
+
+         [BOUNDARY_CONDITIONS]
+            Touched = 0
+            MzSEPfsListItemCount = 2
+            [CODE_1]
+            EndSect  // CODE_1
+
+            [CODE_3]
+               Touched = 0
+               type = 2
+            EndSect  // CODE_3
+
+            [CODE_2]
+               Touched = 0
+               type = 2
+            EndSect  // CODE_2
+
+         EndSect  // BOUNDARY_CONDITIONS
+
+         [ONE_LINE_MODEL]
+            [BOUNDARY_CONDITIONS]
+               type_of_boundary_conditions = 1
+            EndSect  // BOUNDARY_CONDITIONS
+
+            [FILTER]
+               n = 0
+               gamma = 0
+               order = 0
+            EndSect  // FILTER
+
+            [BLEND_FACTOR]
+               type = 0
+               blend_type = 0
+               file_name = ||
+               item_number = 1
+            EndSect  // BLEND_FACTOR
+
+            [STRUCTURES]
+               [GROINS]
+                  number_of_groins = 0
+               EndSect  // GROINS
+
+            EndSect  // STRUCTURES
+
+            [SOLUTION_TECHNIQUE]
+               Touched = 1
+               tolerance = 0.001
+               maximum_number_of_iterations = 100
+               relaxation_factor = 0.5
+               include_offshore_transport = 0
+               type_of_print = 1
+               method = 1
+               type = 1
+               distance_method = 1
+               minimum_active_area = 1000
+               type_of_volume_limit = 1
+            EndSect  // SOLUTION_TECHNIQUE
+
+            [BASELINE]
+               Touched = 1
+               MzSEPfsListItemCount = 0
+               input_format = 2
+               input_file_name = ||
+               coordinate_type = ''
+            EndSect  // BASELINE
+
+            [COASTLINE]
+               Touched = 1
+               MzSEPfsListItemCount = 0
+               line_type = 1
+               input_format = 2
+               input_file_name = ||
+               coordinate_type = ''
+               file_name = ||
+               item_x = 1
+               item_y = 2
+            EndSect  // COASTLINE
+
+            [ELEMENT_2_EDGE_MAP]
+               Touched = 1
+               file_name = ||
+               item_number = 1
+            EndSect  // ELEMENT_2_EDGE_MAP
+
+            [PROFILE]
+               Touched = 1
+               profile_type = 1
+               profile_update_type = 1
+               [BASIS_PROFILE]
+                  input_format = 2
+                  input_file_name = ||
+                  file_name = ||
+                  item_distance = 1
+                  item_bedlevel = 2
+               EndSect  // BASIS_PROFILE
+
+               [CLOSURE_DEPTH]
+                  type = 1
+                  format = 0
+                  constant_closure_depth = 5
+                  file_name = |closuredepth.dfs1|
+                  item_number = 1
+               EndSect  // CLOSURE_DEPTH
+
+               [DUNE_HEIGHT]
+                  type = 1
+                  format = 0
+                  constant_dune_height = 0
+                  file_name = 'duneheight.dfs1'
+                  item_number = 1
+               EndSect  // DUNE_HEIGHT
+
+            EndSect  // PROFILE
+
+            [INITIAL_CONDITIONS]
+               Touched = 1
+               type = 0
+               file_name = ||
+            EndSect  // INITIAL_CONDITIONS
+
+            [DUNE_EROSION]
+               Touched = 1
+               dune_erosion_type = 0
+               line_type = 1
+               input_format = 2
+               input_file_name = ||
+               coordinate_type = ''
+               dune_erosion_slope = 0.1
+               dune_height = 2.5
+               dune_max_slope = 0.2
+               dune_off_shore_depth = 0.5
+               dune_gamma = 0.9
+               dune_cs = 0.002
+               dune_max_iter = 100
+               dune_active_area_min = 0.01
+               dune_tol = 1e-07
+               dune_repose_angle = 80.0
+               dune_relax = 0.5
+            EndSect  // DUNE_EROSION
+
+         EndSect  // ONE_LINE_MODEL
+
+         [BED_LEVEL_SOURCES]
+            Touched = 1
+            number_of_sources = 0
+         EndSect  // BED_LEVEL_SOURCES
+
+      EndSect  // MORPHOLOGY
+
+      [HELICAL_FLOW_MODULE]
+         mode = 0
+         [STATE_VARIABLE]
+            Touched = 0
+            max_deviation_angle = 45.0
+         EndSect  // STATE_VARIABLE
+
+         [TIME]
+            Touched = 0
+            start_time_step = 0
+            time_step_factor = 1.0
+            time_step_factor_AD = 1.0
+         EndSect  // TIME
+
+         [SOLUTION_TECHNIQUE]
+            Touched = 0
+            scheme_of_time_integration = 1
+            scheme_of_space_discretization_horizontal = 1
+            scheme_of_space_discretization_vertical = 1
+            method_of_space_discretization_horizontal = 0
+            number_of_iterations = 1
+            time_step = 30.0
+         EndSect  // SOLUTION_TECHNIQUE
+
+         [FLOW]
+            Touched = 0
+            minimum_water_depth = 0.01
+         EndSect  // FLOW
+
+         [INITIAL_CONDITIONS]
+            [DEVIATION]
+               Touched = 0
+               type = 2
+               format = 0
+               constant_value = 0.0
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // DEVIATION
+
+         EndSect  // INITIAL_CONDITIONS
+
+         [BOUNDARY_CONDITIONS]
+            Touched = 0
+            MzSEPfsListItemCount = 2
+            [CODE_1]
+            EndSect  // CODE_1
+
+            [CODE_3]
+               Touched = 0
+               MzSEPfsListItemCount = 1
+               [DEVIATION]
+                  Touched = 0
+                  type = 4
+                  format = 0
+                  constant_value = 0.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 1
+               EndSect  // DEVIATION
+
+            EndSect  // CODE_3
+
+            [CODE_2]
+               Touched = 0
+               MzSEPfsListItemCount = 1
+               [DEVIATION]
+                  Touched = 0
+                  type = 4
+                  format = 0
+                  constant_value = 0.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+                  type_of_space_interpolation = 1
+               EndSect  // DEVIATION
+
+            EndSect  // CODE_2
+
+         EndSect  // BOUNDARY_CONDITIONS
+
+      EndSect  // HELICAL_FLOW_MODULE
+
+      [OUTPUTS]
+         Touched = 0
+         MzSEPfsListItemCount = 0
+         number_of_outputs = 0
+      EndSect  // OUTPUTS
+
+   EndSect  // SAND_TRANSPORT_MODULE
+
+   [PARTICLE_TRACKING_MODULE]
+      mode = 0
+      [TIME]
+         start_time_step = 0
+         time_step_factor = 1
+      EndSect  // TIME
+
+      [MODEL_DEFINITION]
+         Touched = 1
+      EndSect  // MODEL_DEFINITION
+
+      [CLASSES]
+         Touched = 1
+         MzSEPfsListItemCount = 1
+         number_of_classes = 1
+         [CLASS_1]
+            Touched = 1
+            include = true
+            name = 'Class 1'
+            EUM_unit = 1200
+            EUM_type = 100039
+            description = ''
+            minimum_particle_mass = 0.0
+            maximum_particle_age = 0.0
+            prng_offset = 1
+         EndSect  // CLASS_1
+
+      EndSect  // CLASSES
+
+      [SOURCES]
+         Touched = 1
+         MzSEPfsListItemCount = 0
+         number_of_sources = 0
+      EndSect  // SOURCES
+
+      [DECAY]
+         Touched = 1
+         MzSEPfsListItemCount = 1
+         [CLASS_1]
+            Touched = 1
+            type = 1
+            format = 0
+            constant_value = 0.0
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+         EndSect  // CLASS_1
+
+      EndSect  // DECAY
+
+      [SETTLING]
+         Touched = 1
+         MzSEPfsListItemCount = 1
+         [CLASS_1]
+            Touched = 1
+            type = 2
+            format = 0
+            constant_value = 0.1
+            file_name = ||
+            item_number = 1
+            item_name = ''
+            type_of_soft_start = 2
+            soft_time_interval = 0.0
+            reference_value = 0.0
+            type_of_time_interpolation = 1
+            [DENSITY]
+               density = 2600.0
+            EndSect  // DENSITY
+
+            [FLOCCULATION]
+               min_conc_floc = 0.01
+               max_conc_floc = 10.0
+               alfa = 1.0
+               gamma = 1.0
+            EndSect  // FLOCCULATION
+
+            [HINDERED_SETTLING]
+               gelling_point = 50.0
+            EndSect  // HINDERED_SETTLING
+
+            [SALINITY]
+               c1 = 0.5
+               c2 = -0.33
+            EndSect  // SALINITY
+
+         EndSect  // CLASS_1
+
+      EndSect  // SETTLING
+
+      [DISPERSION]
+         [HORIZONTAL_DISPERSION]
+            Touched = 1
+            MzSEPfsListItemCount = 1
+            [CLASS_1]
+               Touched = 1
+               type = 2
+               [SCALED_EDDY_VISCOSITY]
+                  format = 0
+                  sigma = 1.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // SCALED_EDDY_VISCOSITY
+
+               [DISPERSION_COEFFICIENT]
+                  format = 0
+                  constant_value = 0.01
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // DISPERSION_COEFFICIENT
+
+               [SCALED_EDDY_VISCOSITY]
+                  Touched = 1
+                  type = 1
+                  format = 0
+                  constant_value = 1.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+               EndSect  // SCALED_EDDY_VISCOSITY
+
+               [DISPERSION_COEFFICIENT]
+                  Touched = 1
+                  type = 1
+                  format = 0
+                  constant_value = 0.01
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+               EndSect  // DISPERSION_COEFFICIENT
+
+            EndSect  // CLASS_1
+
+         EndSect  // HORIZONTAL_DISPERSION
+
+         [VERTICAL_DISPERSION]
+            Touched = 1
+            MzSEPfsListItemCount = 1
+            [CLASS_1]
+               Touched = 1
+               type = 2
+               [SCALED_EDDY_VISCOSITY]
+                  format = 0
+                  sigma = 1.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // SCALED_EDDY_VISCOSITY
+
+               [DISPERSION_COEFFICIENT]
+                  format = 0
+                  constant_value = 0.01
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+               EndSect  // DISPERSION_COEFFICIENT
+
+               [SCALED_EDDY_VISCOSITY]
+                  Touched = 1
+                  type = 1
+                  format = 0
+                  constant_value = 1.0
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+               EndSect  // SCALED_EDDY_VISCOSITY
+
+               [DISPERSION_COEFFICIENT]
+                  Touched = 1
+                  type = 1
+                  format = 0
+                  constant_value = 0.01
+                  file_name = ||
+                  item_number = 1
+                  item_name = ''
+                  type_of_soft_start = 2
+                  soft_time_interval = 0.0
+                  reference_value = 0.0
+                  type_of_time_interpolation = 1
+               EndSect  // DISPERSION_COEFFICIENT
+
+            EndSect  // CLASS_1
+
+         EndSect  // VERTICAL_DISPERSION
+
+      EndSect  // DISPERSION
+
+      [EROSION]
+         Touched = 1
+         MzSEPfsListItemCount = 1
+         [CLASS_1]
+            Touched = 1
+            type = 0
+            [CRITICAL_SHEAR_PARAMETER]
+               Touched = 1
+               type = 1
+               format = 0
+               constant_value = 0.001
+               file_name = ||
+               item_number = 1
+               item_name = ''
+               type_of_soft_start = 2
+               soft_time_interval = 0.0
+               reference_value = 0.0
+               type_of_time_interpolation = 1
+            EndSect  // CRITICAL_SHEAR_PARAMETER
+
+         EndSect  // CLASS_1
+
+      EndSect  // EROSION
+
+      [DRIFT_PROFILE]
+         Touched = 1
+         type = 0
+         [WIND_INDUCED_PROFILE]
+            wind_drift_factor = 1.0
+            depth_of_wind_influence = 100.0
+            offshore_limit = 100.0
+         EndSect  // WIND_INDUCED_PROFILE
+
+         [SURFACE_WIND_ACCELERATION]
+            wind_weight = 0.1
+            wind_drift_angle_parameter = 28.0
+            kinematic_viscosity = 1.14e-06
+         EndSect  // SURFACE_WIND_ACCELERATION
+
+      EndSect  // DRIFT_PROFILE
+
+      [HYDRODYNAMIC_CONDITIONS]
+         Touched = 1
+         type_of_2d_information = 1
+         type_of_still_water_depth = 0
+         file_name_area = ||
+         item_numbers_area = 1
+         file_name_volume = ||
+         item_numbers_volume = 1, 2, 3
+         type_of_space_interpolation = 1
+         include_temperature = 0
+         include_salinity = 0
+         include_density = 1
+         include_wind = 1
+      EndSect  // HYDRODYNAMIC_CONDITIONS
+
+      [TEMPERATURE]
+         Touched = 1
+         type = 2
+         format = 0
+         constant_value = 20.0
+         file_name = ||
+         item_number = 1
+         item_name = ''
+         type_of_space_interpolation = 1
+      EndSect  // TEMPERATURE
+
+      [SALINITY]
+         Touched = 1
+         type = 1
+         format = 0
+         constant_value = 20.0
+         file_name = ||
+         item_number = 1
+         item_name = ''
+         type_of_space_interpolation = 1
+      EndSect  // SALINITY
+
+      [DENSITY]
+         Touched = 1
+         type = 2
+         format = 0
+         constant_value = 1000.0
+         file_name = ||
+         item_number = 1
+         item_name = ''
+         type_of_space_interpolation = 1
+      EndSect  // DENSITY
+
+      [BED_ROUGHNESS]
+         Touched = 1
+         type = 1
+         format = 0
+         constant_value = 0.001
+         file_name = ||
+         item_number = 1
+         item_name = ''
+         type_of_soft_start = 2
+         soft_time_interval = 0.0
+         reference_value = 0.0
+         type_of_time_interpolation = 1
+      EndSect  // BED_ROUGHNESS
+
+      [WIND_FORCING]
+         Touched = 1
+         type = 3
+         format = 0
+         constant_speed = 0.0
+         constant_direction = 0.0
+         file_name = ||
+         soft_time_interval = 0.0
+      EndSect  // WIND_FORCING
+
+      [OUTPUTS]
+         Touched = 1
+         MzSEPfsListItemCount = 0
+         number_of_outputs = 0
+      EndSect  // OUTPUTS
+
+   EndSect  // PARTICLE_TRACKING_MODULE
+
+EndSect  // FemEngineHD
+


### PR DESCRIPTION
## Summary

Creating 3D initial conditions (e.g. temperature/salinity from CTD profiles) requires a 3D geometry, but users often only have a 2D mesh and the vertical discretization from their `.m3fm` setup file — no existing 3D dfsu to read from.

`GeometryFM3D.from_2d_geometry()` fills this gap by extruding a 2D mesh vertically using sigma or sigma-z layer parameters, producing a geometry that can be used to construct and write 3D dfsu files.

Also fixes the dfsu writer to derive `zn` from node coordinates when not explicitly provided, which is needed for freshly created (not read-from-file) geometries.