### PR TITLE
Support point selection on rotated Grid2D

### DIFF
--- a/src/mikeio/__init__.py
+++ b/src/mikeio/__init__.py
@@ -43,7 +43,7 @@ def read(
     All dfs files can be subsetted with the *items* and *time* arguments. But
     the following file types also have the shown additional arguments:
 
-    * Dfs2: area
+    * Dfs2: (x,y), area
     * Dfs3: layers
     * Dfsu-2d: (x,y), elements, area
     * Dfsu-layered: (xy,z), elements, area, layers

--- a/src/mikeio/dfs/_dfs2.py
+++ b/src/mikeio/dfs/_dfs2.py
@@ -162,6 +162,8 @@ class Dfs2(_Dfs123):
         *,
         items: str | int | Sequence[str | int] | None = None,
         time: int | str | slice | Sequence[int] | None = None,
+        x: float | None = None,
+        y: float | None = None,
         area: tuple[float, float, float, float] | None = None,
         keepdims: bool = False,
         dtype: Any = np.float32,
@@ -174,12 +176,16 @@ class Dfs2(_Dfs123):
             Read only selected items, by number (0-based), or by name
         time: int, str, datetime, pd.TimeStamp, sequence, slice or pd.DatetimeIndex, optional
             Read only selected time steps, by default None (=all)
-        keepdims: bool, optional
-            When reading a single time step only, should the time-dimension be kept
-            in the returned Dataset? by default: False
+        x: float, optional
+            x-coordinate of point to extract
+        y: float, optional
+            y-coordinate of point to extract
         area: array[float], optional
             Read only data inside (horizontal) area given as a
             bounding box (tuple with left, lower, right, upper) coordinates
+        keepdims: bool, optional
+            When reading a single time step only, should the time-dimension be kept
+            in the returned Dataset? by default: False
         dtype: data-type, optional
             Define the dtype of the returned dataset (default = np.float32)
         Returns
@@ -187,6 +193,9 @@ class Dfs2(_Dfs123):
         Dataset
 
         """
+        if x is not None and area is not None:
+            raise ValueError("x/y and area cannot be given at the same time!")
+
         self._open()
 
         item_numbers = _valid_item_numbers(self._dfs.ItemInfo, items)
@@ -198,7 +207,14 @@ class Dfs2(_Dfs123):
 
         shape: tuple[int, ...]
 
-        if area is not None:
+        if x is not None and y is not None:
+            take_subset = True
+            ii, jj = self.geometry.find_index(x=x, y=y)
+            shape = (nt, len(jj), len(ii))
+            geometry = self.geometry._index_to_Grid2D(ii, jj)
+        elif x is not None or y is not None:
+            raise ValueError("Both x and y must be provided for point selection")
+        elif area is not None:
             take_subset = True
             ii, jj = self.geometry.find_index(area=area)  # type: ignore
             shape = (nt, len(jj), len(ii))

--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -822,16 +822,26 @@ class Grid2D(_Geometry):
         self, x: np.ndarray, y: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray]:
         """Convert projected (world) coordinates to grid-local coordinates."""
-        cart = Cartography.CreateProjOrigin(
-            projectionString=self.projection_string,
-            east=self.origin[0],
-            north=self.origin[1],
-            orientationProj=self.orientation,
-        )
+        if self.is_geo:
+            cart = Cartography.CreateGeoOrigin(
+                projectionString=self.projection_string,
+                lonOrigin=self.origin[0],
+                latOrigin=self.origin[1],
+                orientation=self.orientation,
+            )
+            transform = cart.Geo2Xy
+        else:
+            cart = Cartography.CreateProjOrigin(
+                projectionString=self.projection_string,
+                east=self.origin[0],
+                north=self.origin[1],
+                orientationProj=self.orientation,
+            )
+            transform = cart.Proj2Xy
         x_local = np.empty_like(x, dtype=float)
         y_local = np.empty_like(y, dtype=float)
         for k in range(len(x)):
-            x_local[k], y_local[k] = cart.Proj2Xy(x[k], y[k])
+            x_local[k], y_local[k] = transform(x[k], y[k])
         return x_local, y_local
 
     def _xy_to_index(self, xy: ArrayLike) -> tuple[np.ndarray, np.ndarray]:

--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -822,26 +822,16 @@ class Grid2D(_Geometry):
         self, x: np.ndarray, y: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray]:
         """Convert projected (world) coordinates to grid-local coordinates."""
-        if self.is_geo:
-            cart = Cartography.CreateGeoOrigin(
-                projectionString=self.projection_string,
-                lonOrigin=self.origin[0],
-                latOrigin=self.origin[1],
-                orientation=self.orientation,
-            )
-            transform = cart.Geo2Xy
-        else:
-            cart = Cartography.CreateProjOrigin(
-                projectionString=self.projection_string,
-                east=self.origin[0],
-                north=self.origin[1],
-                orientationProj=self.orientation,
-            )
-            transform = cart.Proj2Xy
+        cart = Cartography.CreateProjOrigin(
+            projectionString=self.projection_string,
+            east=self.origin[0],
+            north=self.origin[1],
+            orientationProj=self.orientation,
+        )
         x_local = np.empty_like(x, dtype=float)
         y_local = np.empty_like(y, dtype=float)
         for k in range(len(x)):
-            x_local[k], y_local[k] = transform(x[k], y[k])
+            x_local[k], y_local[k] = cart.Proj2Xy(x[k], y[k])
         return x_local, y_local
 
     def _xy_to_index(self, xy: ArrayLike) -> tuple[np.ndarray, np.ndarray]:

--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -794,10 +794,18 @@ class Grid2D(_Geometry):
                 raise ValueError("x,y and coords cannot be given at the same time!")
             coords = np.column_stack([np.atleast_1d(x), np.atleast_1d(y)])
         elif x is not None:
+            if self._is_rotated:
+                raise ValueError(
+                    "Single-axis sel(x=) not supported for rotated grids; provide both x and y"
+                )
             if x < self.x[0] or x > self.x[-1]:
                 raise OutsideModelDomainError(x=x, y=None)
             return np.atleast_1d(np.argmin(np.abs(self.x - x))), None
         elif y is not None:
+            if self._is_rotated:
+                raise ValueError(
+                    "Single-axis sel(y=) not supported for rotated grids; provide both x and y"
+                )
             if y < self.y[0] or y > self.y[-1]:
                 raise OutsideModelDomainError(x=None, y=y)
             return None, np.atleast_1d(np.argmin(np.abs(self.y - y)))

--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -810,18 +810,46 @@ class Grid2D(_Geometry):
         else:
             raise ValueError("Provide x,y or coords")
 
+    def _proj_to_local(
+        self, x: np.ndarray, y: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Convert projected (world) coordinates to grid-local coordinates."""
+        cart = Cartography.CreateProjOrigin(
+            projectionString=self.projection_string,
+            east=self.origin[0],
+            north=self.origin[1],
+            orientationProj=self.orientation,
+        )
+        x_local = np.empty_like(x, dtype=float)
+        y_local = np.empty_like(y, dtype=float)
+        for k in range(len(x)):
+            x_local[k], y_local[k] = cart.Proj2Xy(x[k], y[k])
+        return x_local, y_local
+
     def _xy_to_index(self, xy: ArrayLike) -> tuple[np.ndarray, np.ndarray]:
         """Find specific points in this geometry."""
         xy = np.atleast_2d(xy)
         y = xy[:, 1]
         x = xy[:, 0]
 
+        if self._is_rotated:
+            x, y = self._proj_to_local(x, y)
+
         ii = (-999999999) * np.ones_like(x, dtype=int)
         jj = (-999999999) * np.ones_like(y, dtype=int)
 
-        inside = self.contains(xy)
+        inside = (
+            self.contains(xy)
+            if not self._is_rotated
+            else (
+                (x >= self.x[0] - self.dx / 2)
+                & (x <= self.x[-1] + self.dx / 2)
+                & (y >= self.y[0] - self.dy / 2)
+                & (y <= self.y[-1] + self.dy / 2)
+            )
+        )
         if np.any(~inside):
-            raise OutsideModelDomainError(x=x[~inside], y=y[~inside])
+            raise OutsideModelDomainError(x=xy[~inside, 0], y=xy[~inside, 1])
 
         # get index in x, and y for points inside based on the grid spacing and origin
         ii = np.floor((x - (self.x[0] - self.dx / 2)) / self.dx).astype(int)

--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -743,12 +743,22 @@ class Grid2D(_Geometry):
 
         """
         coords = np.atleast_2d(coords)
-        y = coords[:, 1]
         x = coords[:, 0]
+        y = coords[:, 1]
 
-        xinside = (self.bbox.left <= x) & (x <= self.bbox.right)
-        yinside = (self.bbox.bottom <= y) & (y <= self.bbox.top)
-        return xinside & yinside
+        if self._is_rotated:
+            x, y = self._proj_to_local(x, y)
+            x_min = self.x[0] - self.dx / 2
+            x_max = self.x[-1] + self.dx / 2
+            y_min = self.y[0] - self.dy / 2
+            y_max = self.y[-1] + self.dy / 2
+        else:
+            x_min = self.bbox.left
+            x_max = self.bbox.right
+            y_min = self.bbox.bottom
+            y_max = self.bbox.top
+
+        return (x >= x_min) & (x <= x_max) & (y >= y_min) & (y <= y_max)
 
     def __contains__(self, pt: Any) -> Any:
         return self.contains(pt)
@@ -846,16 +856,7 @@ class Grid2D(_Geometry):
         ii = (-999999999) * np.ones_like(x, dtype=int)
         jj = (-999999999) * np.ones_like(y, dtype=int)
 
-        inside = (
-            self.contains(xy)
-            if not self._is_rotated
-            else (
-                (x >= self.x[0] - self.dx / 2)
-                & (x <= self.x[-1] + self.dx / 2)
-                & (y >= self.y[0] - self.dy / 2)
-                & (y <= self.y[-1] + self.dy / 2)
-            )
-        )
+        inside = self.contains(xy)
         if np.any(~inside):
             raise OutsideModelDomainError(x=xy[~inside, 0], y=xy[~inside, 1])
 
@@ -923,6 +924,8 @@ class Grid2D(_Geometry):
     ) -> Grid2D | GeometryUndefined:
         ii = range(self.nx) if ii is None else ii
         jj = range(self.ny) if jj is None else jj
+        if len(ii) == 1 and len(jj) == 1:
+            return GeometryUndefined()
         assert len(ii) > 1 and len(jj) > 1, "Index must be at least len 2"
         assert ii[-1] < self.nx and jj[-1] < self.ny, "Index out of bounds"
         di = np.diff(ii)

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -468,12 +468,12 @@ def test_sel_point_rotated_grid() -> None:
         north=g.origin[1],
         orientationProj=g.orientation,
     )
-    # grid-local center of cell (10, 20): x=10*5+2.5=52.5, y=20*5+2.5=102.5
-    east, north = cart.Xy2Proj(52.5, 102.5)
+    # grid-local center of cell (116, 2): x=116*5=580, y=2*5=10
+    east, north = cart.Xy2Proj(580.0, 10.0)
 
     da = ds[0]
     da_sel = da.sel(x=east, y=north)
-    expected = da.values[:, 20, 10]
+    expected = da.values[:, 2, 116]
     assert da_sel.values == pytest.approx(expected)
 
 

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -548,7 +548,7 @@ def test_read_point_rotated_grid() -> None:
 
     from mikecore.Projections import Cartography
 
-    g = mikeio.open(filepath).geometry
+    g = Dfs2(filepath).geometry
     cart = Cartography.CreateProjOrigin(
         projectionString=g.projection_string,
         east=g.origin[0],

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -492,7 +492,7 @@ def test_sel_point_rotated_grid() -> None:
     filepath = Path("tests/testdata/BW_Ronne_Layout1998_rotated.dfs2")
     ds = mikeio.read(filepath)
     g = ds.geometry
-    assert g._is_rotated
+    assert g.orientation != 0
 
     # pick a grid cell and get its world coordinates
     from mikecore.Projections import Cartography
@@ -510,6 +510,57 @@ def test_sel_point_rotated_grid() -> None:
     da_sel = da.sel(x=east, y=north)
     expected = da.values[:, 2, 116]
     assert da_sel.values == pytest.approx(expected)
+
+
+def test_contains_rotated_grid() -> None:
+    filepath = Path("tests/testdata/BW_Ronne_Layout1998_rotated.dfs2")
+    g = mikeio.read(filepath).geometry
+
+    from mikecore.Projections import Cartography
+
+    cart = Cartography.CreateProjOrigin(
+        projectionString=g.projection_string,
+        east=g.origin[0],
+        north=g.origin[1],
+        orientationProj=g.orientation,
+    )
+    # a point inside the grid
+    east_in, north_in = cart.Xy2Proj(580.0, 10.0)
+    assert g.contains([[east_in, north_in]])[0]
+
+    # a point far outside the grid
+    assert not g.contains([[east_in + 1e6, north_in]])[0]
+
+
+def test_read_point() -> None:
+    filename = "tests/testdata/eq.dfs2"
+    ds_full = mikeio.read(filename)
+    g = ds_full.geometry
+    x = g.x[3]
+    y = g.y[2]
+    ds_point = mikeio.read(filename, x=x, y=y)
+    expected = ds_full[0].values[:, 2, 3]
+    assert ds_point[0].to_numpy().ravel() == pytest.approx(expected)
+
+
+def test_read_point_rotated_grid() -> None:
+    filepath = Path("tests/testdata/BW_Ronne_Layout1998_rotated.dfs2")
+
+    from mikecore.Projections import Cartography
+
+    g = mikeio.open(filepath).geometry
+    cart = Cartography.CreateProjOrigin(
+        projectionString=g.projection_string,
+        east=g.origin[0],
+        north=g.origin[1],
+        orientationProj=g.orientation,
+    )
+    east, north = cart.Xy2Proj(580.0, 10.0)
+
+    ds_point = mikeio.read(filepath, x=east, y=north)
+    ds_full = mikeio.read(filepath)
+    expected = ds_full[0].values[:, 2, 116]
+    assert ds_point[0].to_numpy().ravel() == pytest.approx(expected)
 
 
 def test_sel_single_axis_rotated_grid_raises() -> None:

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -477,6 +477,18 @@ def test_sel_point_rotated_grid() -> None:
     assert da_sel.values == pytest.approx(expected)
 
 
+def test_sel_single_axis_rotated_grid_raises() -> None:
+    filepath = Path("tests/testdata/BW_Ronne_Layout1998_rotated.dfs2")
+    ds = mikeio.read(filepath)
+    da = ds[0]
+
+    with pytest.raises(ValueError, match="rotated"):
+        da.sel(x=0.0)
+
+    with pytest.raises(ValueError, match="rotated"):
+        da.sel(y=0.0)
+
+
 def test_write_selected_item_to_new_file(
     dfs2_random_2items: Dfs2, tmp_path: Path
 ) -> None:

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -453,6 +453,30 @@ def test_select_area_rotated_UTM_2() -> None:
     assert g1.projection_string == g2.projection_string
 
 
+def test_sel_point_rotated_grid() -> None:
+    filepath = Path("tests/testdata/BW_Ronne_Layout1998_rotated.dfs2")
+    ds = mikeio.read(filepath)
+    g = ds.geometry
+    assert g._is_rotated
+
+    # pick a grid cell and get its world coordinates
+    from mikecore.Projections import Cartography
+
+    cart = Cartography.CreateProjOrigin(
+        projectionString=g.projection_string,
+        east=g.origin[0],
+        north=g.origin[1],
+        orientationProj=g.orientation,
+    )
+    # grid-local center of cell (10, 20): x=10*5+2.5=52.5, y=20*5+2.5=102.5
+    east, north = cart.Xy2Proj(52.5, 102.5)
+
+    da = ds[0]
+    da_sel = da.sel(x=east, y=north)
+    expected = da.values[:, 20, 10]
+    assert da_sel.values == pytest.approx(expected)
+
+
 def test_write_selected_item_to_new_file(
     dfs2_random_2items: Dfs2, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- Make `contains()` handle rotated grids by projecting world coordinates to local grid space, removing the duplicated inline bounds check in `_xy_to_index()`
- Add `x`/`y` point selection to `Dfs2.read()` so large rotated grids don't require full array allocation just to extract a single point

Closes #959