### PR TITLE
docs: document previously-invisible attributes on core classes

### DIFF
--- a/src/mikeio/dataset/_dataarray.py
+++ b/src/mikeio/dataset/_dataarray.py
@@ -114,6 +114,18 @@ class DataArray:
     dt:
         placeholder timestep
 
+    Attributes
+    ----------
+    item : ItemInfo
+        ItemInfo with name, type and unit.
+    time : pandas.DatetimeIndex
+        Time instances of the data.
+    geometry
+        Geometry of the data (e.g. Grid2D, GeometryFM2D).
+    plot
+        Plotting accessor (chosen by geometry type).
+    deletevalue : float
+        Default delete value used to mark missing values (1.0e-35).
 
     Examples
     --------

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -70,6 +70,12 @@ class Dataset:
     validate:
         Optional validation of consistency of data arrays.
 
+    Attributes
+    ----------
+    plot : DatasetPlotter
+        Plotting accessor (e.g. ds.plot.scatter for dfs0, ds.plot() for timeseries).
+    title : str
+        Title of the dataset (empty string by default).
 
     Notes
     ---------------
@@ -1164,7 +1170,9 @@ class Dataset:
                     newdata[j][idx2] = other[j].to_numpy()
                     newdata[j][idx1] = ds[j].to_numpy()
                 case _:
-                    raise ValueError(f"Invalid keep value: {keep!r}, expected 'first' or 'last'")
+                    raise ValueError(
+                        f"Invalid keep value: {keep!r}, expected 'first' or 'last'"
+                    )
 
         zn = None
         if self._zn is not None and other._zn is not None:

--- a/src/mikeio/dfs/_dfs0.py
+++ b/src/mikeio/dfs/_dfs0.py
@@ -267,6 +267,7 @@ class Dfs0:
 
     @cached_property
     def end_time(self) -> datetime | None:
+        """File end time."""
         if self.start_time is None:
             return None
         if self._dfs.FileInfo.TimeAxis.IsEquidistant():

--- a/src/mikeio/dfsu/_dfsu.py
+++ b/src/mikeio/dfsu/_dfsu.py
@@ -242,6 +242,7 @@ class Dfsu2DH:
     # TODO change to GeometryFM2D
     @property
     def geometry(self) -> Any:
+        """Flexible Mesh Geometry of the file (e.g. [](`mikeio.spatial.GeometryFM2D`))."""
         return self._geometry
 
     @property
@@ -286,6 +287,7 @@ class Dfsu2DH:
 
     @property
     def time(self) -> pd.DatetimeIndex:
+        """File time axis (only available for equidistant files; otherwise read the data)."""
         if self._equidistant:
             return pd.date_range(
                 start=self.start_time,

--- a/src/mikeio/dfsu/_layered.py
+++ b/src/mikeio/dfsu/_layered.py
@@ -128,6 +128,7 @@ class DfsuLayered:
 
     @property
     def time(self) -> pd.DatetimeIndex:
+        """File time axis (only available for equidistant files; otherwise read the data)."""
         if self._equidistant:
             return pd.date_range(
                 start=self.start_time,
@@ -146,6 +147,7 @@ class DfsuLayered:
 
     @property
     def geometry(self) -> GeometryFM3D | GeometryFMVerticalProfile:
+        """Flexible Mesh Geometry of the file (3d or vertical profile)."""
         return self._geometry
 
     @staticmethod
@@ -502,6 +504,7 @@ class Dfsu2DV(DfsuLayered):
 
     @property
     def geometry(self) -> GeometryFMVerticalProfile:
+        """Flexible Mesh Geometry of the 2d vertical profile."""
         assert isinstance(self._geometry, GeometryFMVerticalProfile)
         return self._geometry
 

--- a/src/mikeio/eum/_eum.py
+++ b/src/mikeio/eum/_eum.py
@@ -1390,6 +1390,15 @@ class ItemInfo:
         One of the following strings: 'Instantaneous', 'Accumulated', 'StepAccumulated', 'MeanStepBackward',
         'MeanStepForward'. Default: 'Instantaneous'
 
+    Attributes
+    ----------
+    name : str
+        User defined name of the item.
+    type : EUMType
+        EUM type of the item.
+    data_value_type : DataValueType
+        How values relate to time (Instantaneous, Accumulated, ...).
+
     Examples
     --------
     ```{python}

--- a/src/mikeio/spatial/_FM_geometry.py
+++ b/src/mikeio/spatial/_FM_geometry.py
@@ -343,6 +343,7 @@ class _GeometryFM(_Geometry):
 
     @property
     def dims(self) -> tuple[str, ...]:
+        """Named array dimensions of data on this geometry."""
         return ("element",)
 
     @property
@@ -356,6 +357,7 @@ class _GeometryFM(_Geometry):
 
     @property
     def node_ids(self) -> np.ndarray:
+        """Node ids (0-based)."""
         return self._node_ids
 
     @property
@@ -365,6 +367,7 @@ class _GeometryFM(_Geometry):
 
     @property
     def element_ids(self) -> np.ndarray:
+        """Element ids (0-based)."""
         return self._element_ids
 
     @cached_property
@@ -423,7 +426,22 @@ class _GeometryFM(_Geometry):
 
 
 class GeometryFM2D(_GeometryFM):
-    """Flexible 2d mesh geometry."""
+    """Flexible 2d mesh geometry.
+
+    Attributes
+    ----------
+    node_coordinates : np.ndarray
+        N-by-3 array of node (x, y, z) coordinates.
+    element_table : np.ndarray
+        For each element, the 0-based indices of its nodes (counter-clockwise).
+        Length of the inner array determines the element type
+        (3=triangle, 4=quadrilateral).
+    projection_string : str
+        Projection string (e.g. "LONG/LAT" or a WKT/UTM string).
+    plot : GeometryFMPlotter
+        Plotting accessor for the geometry (bathymetry, mesh, outline, ...).
+
+    """
 
     def __init__(
         self,
@@ -477,6 +495,7 @@ class GeometryFM2D(_GeometryFM):
 
     @property
     def geometry2d(self) -> GeometryFM2D:
+        """The 2d horizontal geometry (returns self for 2d geometries)."""
         return self
 
     @property

--- a/src/mikeio/spatial/_FM_geometry.py
+++ b/src/mikeio/spatial/_FM_geometry.py
@@ -432,10 +432,8 @@ class GeometryFM2D(_GeometryFM):
     ----------
     node_coordinates : np.ndarray
         N-by-3 array of node (x, y, z) coordinates.
-    element_table : np.ndarray
-        For each element, the 0-based indices of its nodes (counter-clockwise).
-        Length of the inner array determines the element type
-        (3=triangle, 4=quadrilateral).
+    element_table
+        For each element, the 0-based indices of its nodes.
     projection_string : str
         Projection string (e.g. "LONG/LAT" or a WKT/UTM string).
     plot : GeometryFMPlotter

--- a/src/mikeio/spatial/_FM_geometry_layered.py
+++ b/src/mikeio/spatial/_FM_geometry_layered.py
@@ -271,6 +271,7 @@ class _GeometryFMLayered(_GeometryFM):
 
     @property
     def is_layered(self) -> bool:
+        """Type is layered dfsu (3d, vertical profile or vertical column)."""
         return True
 
     @cached_property

--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -139,6 +139,7 @@ class Grid1D(_Geometry):
 
     @property
     def dims(self) -> tuple[str, ...]:
+        """Named array dimensions of data on this grid."""
         return ("x",)
 
     def __repr__(self) -> str:
@@ -204,10 +205,12 @@ class Grid1D(_Geometry):
 
     @property
     def origin(self) -> tuple[float, float]:
+        """Coordinates of grid origo (in projection)."""
         return self._origin
 
     @property
     def orientation(self) -> float:
+        """Grid orientation (in degrees)."""
         return self._orientation
 
     def isel(
@@ -497,6 +500,7 @@ class Grid2D(_Geometry):
 
     @property
     def dims(self) -> tuple[str, ...]:
+        """Named array dimensions of data on this grid."""
         return ("y", "x")
 
     @property
@@ -1174,6 +1178,7 @@ class Grid3D(_Geometry):
 
     @property
     def dims(self) -> tuple[str, ...]:
+        """Named array dimensions of data on this grid."""
         return ("z", "y", "x")
 
     @property


### PR DESCRIPTION
[Quartodoc](https://machow.github.io/quartodoc/) (via [griffe](https://mkdocstrings.github.io/griffe/)) only renders a class attribute in the API page if it is either (a) a `@property`/`@cached_property` with a docstring, or (b) listed in an [`Attributes` section](https://mkdocstrings.github.io/griffe/reference/docstrings/#numpydoc-section-attributes) of the class docstring. Public instance attributes assigned bare in `__init__` (`self.foo = ...`) and properties without docstrings are silently dropped — so several attributes that the user guide refers to never appeared in the [API reference](https://dhi.github.io/mikeio/api/):

- `DataArray.item`, `DataArray.time`, `DataArray.geometry`, `DataArray.plot`, `DataArray.deletevalue`
- `Dataset.plot`, `Dataset.title`
- `Dfsu2DH.geometry`, `Dfsu2DH.time`, `DfsuLayered.geometry`, `DfsuLayered.time`, `Dfsu2DV.geometry`
- `Dfs0.end_time`
- `GeometryFM2D.node_coordinates`, `GeometryFM2D.element_table`, `GeometryFM2D.node_ids`, `GeometryFM2D.element_ids`, `GeometryFM2D.dims`, `GeometryFM2D.geometry2d`, `GeometryFM2D.plot`
- `GeometryFM3D.is_layered`
- `Grid1D/2D/3D.dims`, `Grid1D.origin`, `Grid1D.orientation`
- `ItemInfo.name`, `ItemInfo.type`, `ItemInfo.data_value_type`

The fix is purely additive — one-line docstrings on existing properties, and `Attributes` sections on `DataArray`, `Dataset`, `GeometryFM2D`, and `ItemInfo` class docstrings. No runtime behavior changes.