### PR TITLE
Bump minimum Python version from 3.10 to 3.11

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.11", "3.14"]
 
     steps:
     - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
       uses: astral-sh/setup-uv@v6
       with:
         enable-cache: true
-        python-version: "3.13"
+        python-version: "3.14"
     - name: Install dependencies
       run: uv sync --group test --no-dev
     - name: Build

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ MIKE IO facilitates common data processing workflows for [MIKE files](https://ww
 ## Requirements
 
 * Windows or Linux operating system
-* Python x64 3.10 - 3.14
+* Python x64 3.11 - 3.14
 * (Windows) [VC++ redistributables](https://aka.ms/vs/17/release/vc_redist.x64.exe) (already installed if you have MIKE)
 
 ## Installation

--- a/docs/user-guide/getting-started.qmd
+++ b/docs/user-guide/getting-started.qmd
@@ -3,7 +3,7 @@
 ## Requirements
 
 * Windows or Linux operating system
-* Python x64 3.10 - 3.14
+* Python x64 3.11 - 3.14
 * (Windows) [VC++ redistributables](https://aka.ms/vs/17/release/vc_redist.x64.exe) (already installed if you have MIKE)
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,13 @@ authors = [
 description = "A package that uses the DHI dfs libraries to create, write and read dfs and mesh files."
 license = "BSD-3-Clause"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "License :: OSI Approved :: BSD License",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -113,7 +112,7 @@ exclude = [
     "test_pfs",
     "docs",
 ]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = false
 allow_redefinition = true
 warn_unreachable = true


### PR DESCRIPTION
Python 3.10 is in security-only support and approaching end-of-life ([upstream EOL October 2026](https://devguide.python.org/versions/)). Dropping it now lets us:

- align the supported range with what scientific-Python downstreams (NumPy, pandas, xarray) are already moving to via [SPEC 0](https://scientific-python.org/specs/spec-0000/)
- unlock 3.11-only typing features (e.g. [`Self`](https://peps.python.org/pep-0673/), [`LiteralString`](https://peps.python.org/pep-0675/), [`Required`/`NotRequired`](https://peps.python.org/pep-0655/)) for future work without needing `typing_extensions`
- shrink the CI matrix floor

## Changes
- `pyproject.toml`: `requires-python = ">=3.11"`, mypy `python_version = "3.11"`, drop 3.10 classifier
- README + getting-started: supported range now `3.11 - 3.14`
- CI matrices in `full_test.yml`, `scheduled_test.yml`, `python-publish.yml` updated to `3.11` minimum; publish workflow also bumped from `3.13` → `3.14` for consistency

No source-code changes: the codebase has no `typing_extensions` imports, `sys.version_info` branches, or other 3.10 compatibility shims to remove.