### PR TITLE
Expose `Geometry` as a public alias for type hinting

### DIFF
--- a/src/mikeio/__init__.py
+++ b/src/mikeio/__init__.py
@@ -21,6 +21,7 @@ from .eum import EUMType, EUMUnit, ItemInfo
 from .pfs import PfsDocument, PfsSection, read_pfs
 
 from .spatial import (
+    Geometry,
     Grid1D,
     Grid2D,
     Grid3D,
@@ -202,6 +203,7 @@ __all__ = [
     "PfsDocument",
     "PfsSection",
     "read_pfs",
+    "Geometry",
     "Grid1D",
     "Grid2D",
     "Grid3D",

--- a/src/mikeio/spatial/__init__.py
+++ b/src/mikeio/spatial/__init__.py
@@ -1,4 +1,10 @@
-from ._geometry import Geometry0D, GeometryPoint3D, GeometryPoint2D, GeometryUndefined
+from ._geometry import (
+    Geometry,
+    Geometry0D,
+    GeometryPoint3D,
+    GeometryPoint2D,
+    GeometryUndefined,
+)
 from ._FM_geometry import (
     GeometryFM2D,
 )
@@ -19,6 +25,7 @@ from ._grid_geometry import Grid1D, Grid2D, Grid3D
 
 
 __all__ = [
+    "Geometry",
     "Geometry0D",
     "GeometryPoint3D",
     "GeometryPoint2D",

--- a/src/mikeio/spatial/_geometry.py
+++ b/src/mikeio/spatial/_geometry.py
@@ -216,3 +216,10 @@ class GeometryPoint3D(_Geometry):
         from shapely.geometry import Point
 
         return Point(self.x, self.y, self.z)
+
+
+# Public alias for the geometry base class. Use this for type hints rather
+# than the private `_Geometry` import (the private name remains available
+# for backwards compatibility and is the actual class identity).
+# See https://github.com/DHI/mikeio/issues/967
+Geometry = _Geometry


### PR DESCRIPTION
Closes #967.

Users currently have to import the private \`_Geometry\` base class to type-hint geometry objects:

\`\`\`python
from mikeio.spatial._geometry import _Geometry
\`\`\`

That's fragile — it pierces a private module the API doesn't promise to keep stable. This PR adds a public \`Geometry\` alias so users can import it the normal way:

\`\`\`python
from mikeio import Geometry         # top-level
from mikeio.spatial import Geometry # also works
\`\`\`

## Changes

Purely additive — no internal imports moved, the private name stays:

- \`spatial/_geometry.py\` — \`Geometry = _Geometry\` alias at module bottom.
- \`spatial/__init__.py\` — re-export \`Geometry\` and add it to \`__all__\`.
- \`mikeio/__init__.py\` — re-export \`Geometry\` and add it to \`__all__\`.

The private \`_Geometry\` name is preserved (and is still the actual class identity, since \`Geometry\` is just an alias), so any existing internal users continue to work. A future PR could rename the class proper and keep \`_Geometry\` as the alias — I left that out of scope here to keep the diff minimal.

## Verification

I couldn't run the test suite locally (mikecore doesn't support macOS), but the change is mechanical re-export and the three modified files AST-parse cleanly. Happy to follow up on any CI or review feedback.

3 files changed, 17 insertions(+), 1 deletion(-).