### PR TITLE
Fix crash reading dfs0 with an item named like a reserved attribute

### DIFF
--- a/adr/009-item-attribute-access.md
+++ b/adr/009-item-attribute-access.md
@@ -1,0 +1,92 @@
+# ADR-009: Item Attribute Access on Dataset
+
+**Status:** Accepted — attribute access frozen; `ds["name"]` is canonical; full deprecation under evaluation for v4
+**Date:** 2026-06
+
+## Context
+
+A `Dataset` is a name-keyed collection of `DataArray` items (see
+[ADR-003](003-dataset-dataarray-pattern.md)). The canonical way to select an item
+is by key: `ds["Surface elevation"]`.
+
+Following the [pandas](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html)
+/ [xarray](https://docs.xarray.dev/en/stable/user-guide/data-structures.html#dictionary-like-methods)
+convention that MIKE IO's data structures were modelled on, items are *also*
+exposed as instance attributes for ergonomics and tab-completion:
+`ds.Surface_elevation`. This is implemented in `Dataset._set_name_attr` by
+`setattr(self, safe_name, da)`, where `safe_name` replaces non-alphanumeric
+characters with underscores. The feature is currently *taught*: the user guide
+lists `ds.itemA` as a selection method and demos it.
+
+Two forces now point away from this design:
+
+- **Familiarity has shifted.** Staying close to peer libraries is a deliberate
+  MIKE IO design goal. When the reference set was pandas + xarray, attribute access
+  was the familiar choice. But newer libraries — notably
+  [polars](https://docs.pola.rs/) — deliberately dropped it: there is no
+  `df.colname`, only `df["colname"]`/expressions, precisely to avoid the
+  namespace-collision and implicit-magic costs. "Be familiar" now points *away* from
+  attribute access for a post-2020 dataframe mental model.
+- **It is incompatible with the type-hint commitment.** The codebase enforces
+  `disallow_untyped_defs` under mypy, yet dynamically `setattr`-ed item attributes
+  are invisible to the type checker — every attribute-access line in the tests
+  carries `# type: ignore`. It is the one corner of the API that structurally cannot
+  honour the discipline the rest of the codebase holds.
+
+The cost is also concrete, not hypothetical: item names share a single namespace
+with the entire public API, so an item whose safe-name matches a class member —
+a property (`z`, `geometry`, `shape`, …) or a method (`mean`, `max`, …) — collides
+with it. MIKE IO itself manufactures such names: `aggregate(axis="items")` names the
+result after the aggregation function (`mean`, `nanmean`, `max`). And once `z` became
+a setter-less property in [#977](https://github.com/DHI/mikeio/pull/977), the
+`setattr` collision changed from *silently shadowing* the member to raising
+`AttributeError`, which broke `mikeio.read()` on any dfs0 carrying a `z` item
+([#982](https://github.com/DHI/mikeio/pull/982)).
+
+## Decision
+
+`ds["name"]` is the canonical item interface and the form documentation and examples
+should use going forward. It is also strictly more faithful: it represents real item
+names containing spaces (`ds["Surface elevation"]`), which the attribute form cannot
+without mangling.
+
+Attribute access is **frozen legacy**: still supported, but no new code or docs
+should rely on it, and it is on a path to deprecation (`DeprecationWarning`) and
+removal, targeted for v4.
+
+Until then, collisions are made safe rather than fatal. When an item's safe-name
+matches a class member, `Dataset._set_name_attr` **skips** setting the attribute;
+`ds.<name>` resolves to the real property/method and the item remains accessible via
+`ds["name"]`. The skip is **silent** — no warning, no error — because the collision
+is part of normal usage (aggregation generates method-like names), so a warning would
+fire on routine, correct code, and because it matches how `time`/`geometry` items
+already behave.
+
+## Alternatives Considered
+
+- **Bless attribute access and keep it indefinitely**: rejected — contradicts both
+  the type-hint direction and the polars-era familiarity argument above.
+- **Warn on every collision**: rejected — `aggregate(axis="items")` produces names
+  like `mean`/`nanmean` on a documented operation, so the warning would fire on
+  common, correct code.
+- **Raise on collision**: rejected — would make real files (dfs0 with a `z` item)
+  unreadable.
+- **Remove attribute access now**: rejected — too abrupt; needs a deprecation cycle
+  and a doc migration first.
+
+## Consequences
+
+- `ds["name"]` is the reliable, recommended way to access items.
+- For an item named like a class member, `ds.<name>` returns the member, not the
+  item — the same footgun pandas/xarray carry, now made safe rather than fatal.
+- The collision guard in `_set_name_attr`/`_del_name_attr` is transitional. The
+  planned deprecation mechanism — drop the `setattr` loop and route item lookup
+  through `__getattr__` (which fires only on failed normal lookup) — would make
+  collisions structurally impossible *and* provide the natural site for a
+  `DeprecationWarning` on use; the guard is removed when that lands.
+- Deprecation will require a doc migration: rewrite the user-guide selection list and
+  convert examples (`ds.elevation`, `ds.lon`/`ds.lat`, …) to `ds["..."]`. The
+  "named items for readability" guidance is unaffected — it is a named-vs-positional
+  recommendation that `ds["name"]` already satisfies.
+- Removal is a breaking change and a v4 candidate; it would be recorded in a later
+  ADR superseding this one.

--- a/adr/009-item-attribute-access.md
+++ b/adr/009-item-attribute-access.md
@@ -1,6 +1,6 @@
 # ADR-009: Item Attribute Access on Dataset
 
-**Status:** Accepted — attribute access frozen; `ds["name"]` is canonical; full deprecation under evaluation for v4
+**Status:** Accepted — frozen legacy, deprecation targeted for v4
 **Date:** 2026-06
 
 ## Context
@@ -11,82 +11,83 @@ is by key: `ds["Surface elevation"]`.
 
 Following the [pandas](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html)
 / [xarray](https://docs.xarray.dev/en/stable/user-guide/data-structures.html#dictionary-like-methods)
-convention that MIKE IO's data structures were modelled on, items are *also*
-exposed as instance attributes for ergonomics and tab-completion:
-`ds.Surface_elevation`. This is implemented in `Dataset._set_name_attr` by
-`setattr(self, safe_name, da)`, where `safe_name` replaces non-alphanumeric
-characters with underscores. The feature is currently *taught*: the user guide
-lists `ds.itemA` as a selection method and demos it.
+convention that MIKE IO's data structures were modelled on, items are also exposed as
+instance attributes for ergonomics and tab-completion: `ds.Surface_elevation`. This is
+implemented in `Dataset._set_name_attr` by `setattr(self, safe_name, da)`, where
+`safe_name` replaces non-alphanumeric characters with underscores. The feature is
+currently taught: the user guide lists `ds.itemA` as a selection method and demos it.
 
-Two forces now point away from this design:
+Two forces now point away from this design. The decisive one is the type-hint
+commitment; a shift in the dataframe ecosystem corroborates it.
 
-- **Familiarity has shifted.** Staying close to peer libraries is a deliberate
-  MIKE IO design goal. When the reference set was pandas + xarray, attribute access
-  was the familiar choice. But newer libraries — notably
-  [polars](https://docs.pola.rs/) — deliberately dropped it: there is no
-  `df.colname`, only `df["colname"]`/expressions, precisely to avoid the
-  namespace-collision and implicit-magic costs. "Be familiar" now points *away* from
-  attribute access for a post-2020 dataframe mental model.
-- **It is incompatible with the type-hint commitment.** The codebase enforces
-  `disallow_untyped_defs` under mypy, yet dynamically `setattr`-ed item attributes
-  are invisible to the type checker — every attribute-access line in the tests
-  carries `# type: ignore`. It is the one corner of the API that structurally cannot
-  honour the discipline the rest of the codebase holds.
+- **Incompatible with the type-hint commitment.** MIKE IO prefers explicitly-typed,
+  key-based APIs and enforces `disallow_untyped_defs` under mypy. Dynamically
+  `setattr`-ed item attributes are invisible to the type checker, so every
+  attribute-access line in the tests carries a `# type: ignore`. It is the one corner
+  of the API that cannot honour the discipline the rest of the codebase holds. Where
+  the typed-API commitment conflicts with the pandas/xarray convention MIKE IO was
+  modelled on, the commitment wins.
+- **The ecosystem has moved the same way.** This is not a lone deviation from peer
+  libraries. Newer dataframe libraries, notably [polars](https://docs.pola.rs/),
+  dropped attribute access altogether: there is no `df.colname`, only
+  `df["colname"]` and expressions, to avoid the namespace-collision and implicit-magic
+  costs. Explicit key-based access is the post-2020 norm, so deviating from
+  pandas/xarray here aligns MIKE IO with where the field has settled.
 
-The cost is also concrete, not hypothetical: item names share a single namespace
-with the entire public API, so an item whose safe-name matches a class member —
-a property (`z`, `geometry`, `shape`, …) or a method (`mean`, `max`, …) — collides
-with it. MIKE IO itself manufactures such names: `aggregate(axis="items")` names the
-result after the aggregation function (`mean`, `nanmean`, `max`). And once `z` became
-a setter-less property in [#977](https://github.com/DHI/mikeio/pull/977), the
-`setattr` collision changed from *silently shadowing* the member to raising
-`AttributeError`, which broke `mikeio.read()` on any dfs0 carrying a `z` item
-([#982](https://github.com/DHI/mikeio/pull/982)).
+The cost is concrete, not hypothetical. Item names share a single namespace with the
+entire public API, so an item whose safe-name matches a class member — a property
+(`z`, `geometry`, `shape`) or a method (`mean`, `max`) — collides with it. MIKE IO
+itself manufactures such names: `aggregate(axis="items")` names the result after the
+aggregation function (`mean`, `nanmean`, `max`). Once `z` became a setter-less property
+in [#977](https://github.com/DHI/mikeio/pull/977), the `setattr` collision changed from
+silently shadowing the member to raising `AttributeError`, which broke `mikeio.read()`
+on any dfs0 carrying a `z` item ([#982](https://github.com/DHI/mikeio/pull/982)).
 
 ## Decision
 
 `ds["name"]` is the canonical item interface and the form documentation and examples
-should use going forward. It is also strictly more faithful: it represents real item
-names containing spaces (`ds["Surface elevation"]`), which the attribute form cannot
-without mangling.
+should use going forward. It is also more faithful: it represents real item names
+containing spaces (`ds["Surface elevation"]`), which the attribute form cannot without
+mangling.
 
-Attribute access is **frozen legacy**: still supported, but no new code or docs
-should rely on it, and it is on a path to deprecation (`DeprecationWarning`) and
-removal, targeted for v4.
+Attribute access is frozen legacy: still supported, but no new code or docs should rely
+on it, and it is on a path to deprecation (`DeprecationWarning`) and removal, targeted
+for v4.
 
 Until then, collisions are made safe rather than fatal. When an item's safe-name
-matches a class member, `Dataset._set_name_attr` **skips** setting the attribute;
-`ds.<name>` resolves to the real property/method and the item remains accessible via
-`ds["name"]`. The skip is **silent** — no warning, no error — because the collision
-is part of normal usage (aggregation generates method-like names), so a warning would
-fire on routine, correct code, and because it matches how `time`/`geometry` items
-already behave.
+matches a class member (property or method), or one of the instance attributes set in
+`__init__` (`plot`, `title`, `_data_vars`, which are not class members and so are
+reserved explicitly), `Dataset._set_name_attr` skips setting the attribute. `ds.<name>`
+resolves to the real property, method, or accessor, and the item remains accessible via
+`ds["name"]`. The skip is silent: no warning, no error. A warning would fire on routine,
+correct code, since aggregation generates method-like names, and silence matches how
+`time` and `geometry` items already behave.
 
 ## Alternatives Considered
 
-- **Bless attribute access and keep it indefinitely**: rejected — contradicts both
-  the type-hint direction and the polars-era familiarity argument above.
-- **Warn on every collision**: rejected — `aggregate(axis="items")` produces names
-  like `mean`/`nanmean` on a documented operation, so the warning would fire on
-  common, correct code.
-- **Raise on collision**: rejected — would make real files (dfs0 with a `z` item)
+- **Bless attribute access and keep it indefinitely**: rejected. Contradicts both the
+  type-hint direction and the ecosystem shift above.
+- **Warn on every collision**: rejected. `aggregate(axis="items")` produces names like
+  `mean`/`nanmean` on a documented operation, so the warning would fire on common,
+  correct code.
+- **Raise on collision**: rejected. Would make real files (dfs0 with a `z` item)
   unreadable.
-- **Remove attribute access now**: rejected — too abrupt; needs a deprecation cycle
-  and a doc migration first.
+- **Remove attribute access now**: rejected. Too abrupt; needs a deprecation cycle and
+  a doc migration first.
 
 ## Consequences
 
 - `ds["name"]` is the reliable, recommended way to access items.
-- For an item named like a class member, `ds.<name>` returns the member, not the
-  item — the same footgun pandas/xarray carry, now made safe rather than fatal.
-- The collision guard in `_set_name_attr`/`_del_name_attr` is transitional. The
-  planned deprecation mechanism — drop the `setattr` loop and route item lookup
-  through `__getattr__` (which fires only on failed normal lookup) — would make
-  collisions structurally impossible *and* provide the natural site for a
-  `DeprecationWarning` on use; the guard is removed when that lands.
+- For an item named like a class member, `ds.<name>` returns the member, not the item —
+  the same footgun pandas/xarray carry, now made safe rather than fatal.
+- The collision guard in `_set_name_attr`/`_del_name_attr` is transitional. The planned
+  deprecation mechanism — drop the `setattr` loop and route item lookup through
+  `__getattr__`, which fires only on failed normal lookup — would make collisions
+  structurally impossible and provide the natural site for a `DeprecationWarning` on
+  use. The guard is removed when that lands.
 - Deprecation will require a doc migration: rewrite the user-guide selection list and
-  convert examples (`ds.elevation`, `ds.lon`/`ds.lat`, …) to `ds["..."]`. The
-  "named items for readability" guidance is unaffected — it is a named-vs-positional
-  recommendation that `ds["name"]` already satisfies.
-- Removal is a breaking change and a v4 candidate; it would be recorded in a later
-  ADR superseding this one.
+  convert examples (`ds.elevation`, `ds.lon`/`ds.lat`) to `ds["..."]`. The "named items
+  for readability" guidance is unaffected — it is a named-vs-positional recommendation
+  that `ds["name"]` already satisfies.
+- Removal is a breaking change and a v4 candidate; it would be recorded in a later ADR
+  superseding this one.

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -562,6 +562,8 @@ class Dataset:
     _RESERVED_INSTANCE_ATTRS = frozenset({"plot", "title", "_data_vars"})
 
     def _is_reserved_attr(self, name: str) -> bool:
+        # Probe the CLASS, not the instance: hasattr(self, ...) would invoke the
+        # z/geometry property getters on a partially-constructed Dataset.
         return name in self._RESERVED_INSTANCE_ATTRS or hasattr(type(self), name)
 
     def _set_name_attr(self, name: str, value: DataArray) -> None:

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -555,6 +555,15 @@ class Dataset:
 
         return ds
 
+    # Instance attributes assigned in __init__: not class members, so
+    # hasattr(type(self), ...) misses them. An item named like one of these
+    # would clobber internal state (e.g. "plot" destroys the DatasetPlotter,
+    # "_data_vars" corrupts the item dict), so reserve them explicitly.
+    _RESERVED_INSTANCE_ATTRS = frozenset({"plot", "title", "_data_vars"})
+
+    def _is_reserved_attr(self, name: str) -> bool:
+        return name in self._RESERVED_INSTANCE_ATTRS or hasattr(type(self), name)
+
     def _set_name_attr(self, name: str, value: DataArray) -> None:
         name = _to_safe_name(name)
         # Don't shadow a real class member (property or method) with a dynamic
@@ -564,13 +573,13 @@ class Dataset:
         # This is silent (not a warning) because mikeio routinely manufactures
         # such names itself — aggregate(axis="items") names the result after the
         # aggregation function (e.g. "mean", "nanmean", "max").
-        if hasattr(type(self), name):
+        if self._is_reserved_attr(name):
             return
         setattr(self, name, value)
 
     def _del_name_attr(self, name: str) -> None:
         name = _to_safe_name(name)
-        if hasattr(type(self), name):
+        if self._is_reserved_attr(name):
             return
         delattr(self, name)
 

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -345,6 +345,9 @@ class Dataset:
         Returns the accessor from the first DataArray; mirrors the ``_zn``
         delegation. Use ``ds.z.nodes`` for per-timestep node z-coordinates
         and ``ds.z.elements`` for element-center z-coordinates.
+
+        Like ``time`` and ``geometry``, ``z`` is a reserved attribute: a data
+        item literally named ``z`` is reached via ``ds["z"]``, not ``ds.z``.
         """
         return self[0].z
 
@@ -554,10 +557,18 @@ class Dataset:
 
     def _set_name_attr(self, name: str, value: DataArray) -> None:
         name = _to_safe_name(name)
+        # Don't shadow a real class member (property or method) with a dynamic
+        # item attribute — e.g. an item named "z" must not clobber the read-only
+        # z-coordinate accessor, nor "geometry"/"time"/"mean"/etc. The item stays
+        # accessible via ds[name]; only the convenience ds.<name> is reserved.
+        if hasattr(type(self), name):
+            return
         setattr(self, name, value)
 
     def _del_name_attr(self, name: str) -> None:
         name = _to_safe_name(name)
+        if hasattr(type(self), name):
+            return
         delattr(self, name)
 
     @overload

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -561,6 +561,9 @@ class Dataset:
         # item attribute — e.g. an item named "z" must not clobber the read-only
         # z-coordinate accessor, nor "geometry"/"time"/"mean"/etc. The item stays
         # accessible via ds[name]; only the convenience ds.<name> is reserved.
+        # This is silent (not a warning) because mikeio routinely manufactures
+        # such names itself — aggregate(axis="items") names the result after the
+        # aggregation function (e.g. "mean", "nanmean", "max").
         if hasattr(type(self), name):
             return
         setattr(self, name, value)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -186,6 +186,54 @@ def test_item_named_like_reserved_method() -> None:
     assert isinstance(reduced, Dataset)
 
 
+def test_item_named_like_instance_attr() -> None:
+    # The collision guard must also cover instance attributes set in __init__
+    # (plot, title, _data_vars), not just class members — an item named "plot"
+    # would otherwise clobber the DatasetPlotter and break ds.plot.scatter(...).
+    time = pd.date_range(start=datetime(2000, 1, 1), freq="s", periods=3)
+    da = mikeio.DataArray(name="Foo", data=np.ones(3), time=time)
+
+    ds = mikeio.Dataset([da])
+    # add an item named "plot" after construction (routes through _set_name_attr)
+    ds["plot"] = mikeio.DataArray(name="plot", data=np.zeros(3), time=time)
+
+    # the item is reachable via indexing
+    assert ds["plot"].name == "plot"
+    # ds.plot is still the plotter, not the item
+    assert ds.plot is not ds["plot"]
+
+
+def test_aggregate_over_items_produces_method_named_item() -> None:
+    # aggregate(axis="items") names the result after the aggregation function
+    # ("nanmean"), which collides with Dataset.nanmean. This is the documented
+    # operation the ADR cites as the reason the collision skip is silent.
+    time = pd.date_range(start=datetime(2000, 1, 1), freq="s", periods=3)
+    ds = mikeio.Dataset(
+        [
+            mikeio.DataArray(name="A", data=np.ones(3), time=time),
+            mikeio.DataArray(name="B", data=np.zeros(3), time=time),
+        ]
+    )
+
+    agg = ds.aggregate(axis="items")
+
+    assert "nanmean" in agg.names
+    assert agg["nanmean"].name == "nanmean"  # item reachable by key
+    assert callable(agg.nanmean)  # method not shadowed by the item
+
+
+def test_rename_item_into_reserved_name() -> None:
+    # rename routes through _del_name_attr (old name) and _set_name_attr (new
+    # name); renaming an item to a method-like name must not shadow the method.
+    time = pd.date_range(start=datetime(2000, 1, 1), freq="s", periods=3)
+    ds = mikeio.Dataset([mikeio.DataArray(name="Foo", data=np.ones(3), time=time)])
+
+    ds2 = ds.rename({"Foo": "mean"})
+
+    assert ds2["mean"].name == "mean"  # item reachable by key
+    assert callable(ds2.mean)  # method not shadowed by the renamed item
+
+
 def test_getitem_time_string_not_supported(ds3: Dataset) -> None:
     # time = pd.date_range("2000-1-2", freq="h", periods=100)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -234,6 +234,27 @@ def test_rename_item_into_reserved_name() -> None:
     assert callable(ds2.mean)  # method not shadowed by the renamed item
 
 
+def test_init_instance_attrs_are_collision_protected() -> None:
+    # Drift guard: every non-item attribute __init__ sets on the instance (plot,
+    # title, ...) must be protected from being clobbered by an item of the same
+    # name. The reservation list is maintained by hand; if a new instance
+    # attribute is added to __init__ without reserving it, this test fails.
+    time = pd.date_range(start=datetime(2000, 1, 1), freq="s", periods=3)
+    base = mikeio.Dataset([mikeio.DataArray(name="Foo", data=np.ones(3), time=time)])
+    # instance attributes that are not the item dict and not items themselves
+    instance_attrs = set(vars(base)) - set(base.names) - {"_data_vars"}
+    assert instance_attrs  # sanity: there is something to protect (plot, title)
+
+    for attr in instance_attrs:
+        original_type = type(getattr(base, attr))
+        ds = mikeio.Dataset([mikeio.DataArray(name="Foo", data=np.ones(3), time=time)])
+        ds[attr] = mikeio.DataArray(name=attr, data=np.zeros(3), time=time)
+        # the real instance attribute is preserved, not replaced by the item
+        assert type(getattr(ds, attr)) is original_type
+        # and the item is still reachable by key
+        assert ds[attr].name == attr
+
+
 def test_getitem_time_string_not_supported(ds3: Dataset) -> None:
     # time = pd.date_range("2000-1-2", freq="h", periods=100)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -148,6 +148,44 @@ def test_index_with_attribute() -> None:
     )  # This is now modfied, but both methods points to the same object
 
 
+def test_item_named_like_reserved_property(tmp_path: Path) -> None:
+    # An item whose safe-name matches a read-only Dataset property (e.g. the
+    # z-coordinate accessor) must not crash construction by shadowing it.
+    # Regression for the read-only `z` property added in #977: dfs0 files can
+    # carry a vertical-coordinate item literally named "z".
+    time = pd.date_range(start=datetime(2000, 1, 1), freq="s", periods=3)
+    da_z = mikeio.DataArray(name="z", data=np.zeros(3), time=time)
+    da_foo = mikeio.DataArray(name="Foo", data=np.ones(3), time=time)
+
+    ds = mikeio.Dataset([da_z, da_foo])
+
+    # item is reachable via indexing
+    assert ds["z"].name == "z"
+    # the reserved attribute still resolves to the z-accessor, not the item
+    assert ds.z is not ds["z"]
+
+    # survives a dfs0 round-trip (the exact modelskill failure path)
+    fp = tmp_path / "z_item.dfs0"
+    ds.to_dfs(fp)
+    ds2 = mikeio.read(fp)
+    assert ds2["z"].name == "z"
+
+
+def test_item_named_like_reserved_method() -> None:
+    # An item whose safe-name matches a Dataset method (e.g. "mean") must not
+    # shadow the method on the instance; the method stays callable and the item
+    # is reachable via indexing.
+    time = pd.date_range(start=datetime(2000, 1, 1), freq="s", periods=3)
+    da_mean = mikeio.DataArray(name="mean", data=np.arange(3.0), time=time)
+
+    ds = mikeio.Dataset([da_mean])
+
+    assert ds["mean"].name == "mean"
+    # ds.mean is the aggregation method, not the item
+    reduced = ds.mean(axis="time")
+    assert isinstance(reduced, Dataset)
+
+
 def test_getitem_time_string_not_supported(ds3: Dataset) -> None:
     # time = pd.date_range("2000-1-2", freq="h", periods=100)
 


### PR DESCRIPTION
`mikeio.read()` raises `AttributeError: property 'z' of 'Dataset' object has no setter` on any dfs0 whose vertical-coordinate item is literally named `z`.

### Why

[#977](https://github.com/DHI/mikeio/pull/977) added a read-only `z` property to `Dataset`. But `Dataset` also exposes every item as a dynamic instance attribute (`ds.Surface_Elevation`) by doing `setattr(self, safe_name, da)` during construction. An item named `z` therefore tries to assign to the setter-less `z` property and crashes — before any data can be returned.

This was caught by modelskill's ["test against mikeio main" canary](https://github.com/DHI/modelskill/actions/runs/26739203873/job/78798923746) (all failures are in its *vertical* tests, which read dfs0 files carrying a `z` item). It is entirely within mikeio — released mikeio is unaffected.

`z` is just the first one hit: the same `setattr` collision crashes for any item named after a setter-less property (`geometry`, `shape`, `values`, …) and *silently shadows* methods like `mean`/`max`, so `ds.mean()` would break for a file with a `mean` item.

### Fix

Skip the convenience attribute whenever an item's safe-name matches a class member (property or method). The item stays reachable via `ds["name"]`; `ds.<name>` keeps meaning the reserved member — the same `[]`-vs-`.` rule that already applies to `time` and `geometry`. This resolves the whole family of collisions in one place rather than patching `z` alone.

Behavior change worth flagging: for an item whose name matches a reserved member, `ds.<name>` now returns the method/property instead of the item. The item is always available via `ds["<name>"]`.

---

Also adds [ADR-009](adr/009-item-attribute-access.md), recording why item attribute access exists (pandas/xarray lineage), the reserved-name collision it causes, and the decision behind this fix (collisions made index-only and silent). It frames attribute access as **frozen legacy** — `ds["name"]` is canonical — with deprecation toward removal under evaluation for v4 (a separate follow-up; no doc or API changes here).