### PR TITLE
Fix dfs2 header round-trip tests under pytest 8.4

### DIFF
--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import datetime
-from typing import Any
 from matplotlib import pyplot as plt
 import numpy as np
 import pandas as pd
@@ -761,47 +760,34 @@ def test_read_single_precision() -> None:
     assert ds[0].dtype == np.float32
 
 
-def dfs2_props_to_list(d: Dfs2) -> list[Any]:
-    lon = d._dfs.FileInfo.Projection.Longitude
-    lat = d._dfs.FileInfo.Projection.Latitude
-    rot = d._dfs.FileInfo.Projection.Orientation
-    res = [
-        d.x0,
-        d.y0,
-        d.dx,
-        d.dy,
-        d.nx,
-        d.ny,
-        d._projstr,
-        lon,
-        lat,
-        rot,
-        d._n_timesteps,
-        d._start_time,
-        d._dfs.FileInfo.TimeAxis.TimeAxisType,
-        d.n_items,
-        # d._deletevalue,
-    ]
-
-    for item in d.items:
-        res.append(item.type)
-        res.append(item.unit)
-        res.append(item.name)
-
-    return res
-
-
 def is_header_unchanged_on_read_write(tmp_path: Path, filename: str) -> None:
-    dfsA = mikeio.Dfs2("tests/testdata/" + filename)
-    props_A = dfs2_props_to_list(dfsA)
-
-    ds = dfsA.read()
+    a = mikeio.Dfs2("tests/testdata/" + filename)
+    ds = a.read()
     filename_out = tmp_path / filename
     ds.to_dfs(filename_out)
-    dfsB = mikeio.Dfs2(filename_out)
-    props_B = dfs2_props_to_list(dfsB)
-    for pA, pB in zip(props_A, props_B):
-        assert pytest.approx(pA) == pB
+    b = mikeio.Dfs2(filename_out)
+
+    # float fields can pick up tiny round-trip error, so compare with a tolerance
+    assert b.x0 == pytest.approx(a.x0)
+    assert b.y0 == pytest.approx(a.y0)
+    assert b.dx == pytest.approx(a.dx)
+    assert b.dy == pytest.approx(a.dy)
+
+    pa, pb = a._dfs.FileInfo.Projection, b._dfs.FileInfo.Projection
+    assert pb.Longitude == pytest.approx(pa.Longitude)
+    assert pb.Latitude == pytest.approx(pa.Latitude)
+    assert pb.Orientation == pytest.approx(pa.Orientation)
+
+    # everything else must round-trip exactly
+    assert b.nx == a.nx
+    assert b.ny == a.ny
+    assert b._projstr == a._projstr
+    assert b._n_timesteps == a._n_timesteps
+    assert b._start_time == a._start_time
+    assert (
+        b._dfs.FileInfo.TimeAxis.TimeAxisType == a._dfs.FileInfo.TimeAxis.TimeAxisType
+    )
+    assert b.items == a.items
 
 
 def test_read_write_header_unchanged_utm_not_rotated(tmp_path: Path) -> None:


### PR DESCRIPTION
The [scheduled test workflow](https://github.com/DHI/mikeio/blob/main/.github/workflows/scheduled_test.yml) resolves dependencies fresh on each run and [started failing](https://github.com/DHI/mikeio/actions/runs/27599646202) when it picked up pytest 8.4+, which now rejects `pytest.approx()` on `datetime`/`timedelta` values without an explicit tolerance. The `dfs2` header round-trip tests applied `approx` to every element of a mixed-type property list — including the file start time (a `datetime`) — so they broke.

Pinning pytest would hide future upstream drift, which is exactly what the scheduled run exists to surface. Instead this fixes the test itself, and while doing so replaces the fragile `dfs2_props_to_list` helper: the positional, mixed-type list (which silently truncated under `zip` and reported failures by index) is gone, and the header check is now direct field-by-field assertions. Float fields use `pytest.approx`; everything else is compared exactly; each property is named at its assertion.

Closes #985.
