### PR TITLE
Make dead-link check tolerant of transient failures

### DIFF
--- a/.github/workflows/docs_dead_links.yml
+++ b/.github/workflows/docs_dead_links.yml
@@ -1,20 +1,42 @@
 name: Check docs for broken links
-on: 
+on:
   workflow_dispatch: # allow manual trigger
   schedule:
-    # run daily at 4 am
-    - cron:  '0 4 * * 1'
+    # run weekly, Monday 04:00 UTC
+    - cron: '0 4 * * 1'
+
+permissions:
+  contents: read
+
 jobs:
-  crawl_for_broken_links:
+  check_links:
     runs-on: ubuntu-latest
-    name: Broken-Links-Crawler
+    name: Check links
     steps:
-    - name: Checking links
-      uses: ScholliYT/Broken-Links-Crawler-Action@v3
-      with:
-        website_url: 'https://dhi.github.io/mikeio/'
-        exclude_url_prefix: 'https://github.com/DHI/mikeio/edit/main/docs/api/,https://docs.mikepoweredbydhi.com/'
-        verbose: true
-        max_retry_time: 60
-        max_retries: 5
-        max_depth: -1
+      - uses: actions/checkout@v4
+
+      - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Build documentation
+        run: just docs
+
+      # lychee cannot recursively crawl a live site, so we check the built
+      # HTML. --accept-timeouts keeps slow servers from failing the run, and
+      # 403/429 are tolerated as rate-limiting; genuine 404/410 still fail.
+      - name: Check links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: >-
+            --accept-timeouts
+            --accept 200..=299,403,429
+            --no-progress
+            'docs/_site/**/*.html'
+          fail: true

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+# "Edit this page" links to GitHub — not real content links, and GitHub rate-limits them
+github\.com/DHI/mikeio/edit/
+# MIKE Powered by DHI doc/help portals throttle/reject automated crawlers
+# (connection-reset / 403), so they can't be link-checked reliably
+mikepoweredbydhi\.


### PR DESCRIPTION
The scheduled [broken-links check](https://github.com/DHI/mikeio/actions/workflows/docs_dead_links.yml) fails intermittently on slow or bot-hostile external servers — e.g. [run 27932206514](https://github.com/DHI/mikeio/actions/runs/27932206514) failed only because a citation host (`archimer.ifremer.fr`) timed out after retries. That is alert noise, not a broken link.

The previous action, [`ScholliYT/Broken-Links-Crawler-Action`](https://github.com/ScholliYT/Broken-Links-Crawler-Action), treats a timeout identically to a 404 and exposes no option to accept transient errors. So the workflow cannot express "only fail on links that are permanently gone".

This switches to [`lycheeverse/lychee-action`](https://github.com/lycheeverse/lychee-action), which can: [`--accept-timeouts`](https://github.com/lycheeverse/lychee) makes timeouts non-fatal, and `--accept 200..=299,403,429` tolerates rate-limiting/bot-blocking, while genuine 404/410 still fail the run.

Because lychee [does not recursively crawl a live site](https://github.com/lycheeverse/lychee/issues/78), the workflow now builds the docs (`just docs`, same recipe as the docs deploy) and checks the rendered HTML under `docs/_site/`. The two URL exclusions from the old config move to `.lycheeignore` (GitHub "edit" links and the crawler-hostile MIKE Powered by DHI doc/help portals).

Verified locally against a fresh build: 3713 links OK, 0 errors (exit 0); an injected dead `dhi.github.io` URL still fails (exit 2).