### PR TITLE
Release v3.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mikeio"
-version = "3.2.0.dev0"
+version = "3.2.0"
 dependencies = [
     "mikecore>=0.2.2",
     "numpy>=1.26.0",


### PR DESCRIPTION
Bumps the version from `3.2.0.dev0` to `3.2.0` for the v3.2.0 release.

Highlights since v3.1.0:
- **Minimum Python raised to 3.12** ([#989](https://github.com/DHI/mikeio/pull/989)), per [SPEC 0](https://scientific-python.org/specs/spec-0000/)
- New public z-coordinate accessor for layered dfsu DataArrays ([#977](https://github.com/DHI/mikeio/pull/977))
- New `title` attribute on Dataset and DFS file readers ([#888](https://github.com/DHI/mikeio/pull/888))
- Fix crash reading dfs0 with an item named like a reserved attribute ([#982](https://github.com/DHI/mikeio/pull/982))
- `concat` now validates duplicate timestamps ([#957](https://github.com/DHI/mikeio/pull/957))

Full release notes accompany the GitHub release.