### PR TITLE
Raise minimum Python to 3.12 per SPEC 0

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.12", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.12", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.12", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,18 @@
 8. Make a pull request with a summary of the changes
 
 Run `just --list` to see all available recipes.
+
+## Supported Python versions
+
+MIKE IO follows [SPEC 0](https://scientific-python.org/specs/spec-0000/), the Scientific
+Python ecosystem's support policy (which superseded [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html)):
+
+- **Python versions** are supported for **36 months** after their release, then dropped.
+- **Core dependencies** (NumPy, pandas, SciPy, …) are supported for **24 months** after release.
+
+In practice this means the minimum supported Python tracks the SPEC 0 schedule rather than
+the latest end-of-life date. When raising the floor, update `requires-python`, the
+`python_version` under `[tool.mypy]`, the Python classifiers in `pyproject.toml`, and the
+CI matrices in `.github/workflows/`. Dropping a Python version is a routine, scheduled
+change — not a breaking feature removal — and it lets us adopt dependency releases that
+require a newer interpreter.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ MIKE IO facilitates common data processing workflows for [MIKE files](https://ww
 ## Requirements
 
 * Windows or Linux operating system
-* Python x64 3.11 - 3.14
+* Python x64 3.12 - 3.14
 * (Windows) [VC++ redistributables](https://aka.ms/vs/17/release/vc_redist.x64.exe) (already installed if you have MIKE)
 
 ## Installation

--- a/docs/user-guide/getting-started.qmd
+++ b/docs/user-guide/getting-started.qmd
@@ -3,7 +3,7 @@
 ## Requirements
 
 * Windows or Linux operating system
-* Python x64 3.11 - 3.14
+* Python x64 3.12 - 3.14
 * (Windows) [VC++ redistributables](https://aka.ms/vs/17/release/vc_redist.x64.exe) (already installed if you have MIKE)
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,13 @@ authors = [
 description = "A package that uses the DHI dfs libraries to create, write and read dfs and mesh files."
 license = "BSD-3-Clause"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 classifiers = [
     "License :: OSI Approved :: BSD License",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -112,7 +111,7 @@ exclude = [
     "test_pfs",
     "docs",
 ]
-python_version = "3.11"
+python_version = "3.12"
 warn_return_any = false
 allow_redefinition = true
 warn_unreachable = true

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -585,11 +585,15 @@ class Dataset:
             return
         delattr(self, name)
 
+    # `slice` must precede `Hashable | int`: since Python 3.12 slice objects are
+    # hashable, so the broader `Hashable` overload would otherwise shadow this one
+    # and slicing would be mistyped as `DataArray`. The overlap is disambiguated at
+    # runtime by isinstance checks in `_key_to_str`.
     @overload
-    def __getitem__(self, key: Hashable | int) -> DataArray: ...
+    def __getitem__(self, key: slice) -> Dataset: ...  # type: ignore[overload-overlap]
 
     @overload
-    def __getitem__(self, key: slice) -> Dataset: ...
+    def __getitem__(self, key: Hashable | int) -> DataArray: ...
 
     @overload
     def __getitem__(self, key: Iterable[Hashable]) -> Dataset: ...

--- a/src/mikeio/spatial/_distance.py
+++ b/src/mikeio/spatial/_distance.py
@@ -48,7 +48,7 @@ def dist_in_meters(
 
 def _get_dist_geo(
     lon: float | np.ndarray, lat: float | np.ndarray, lon1: float, lat1: float
-) -> float:
+) -> np.ndarray:
     # assuming input in degrees!
     R = 6371e3  # Earth radius in metres
     dlon = np.deg2rad(lon1 - lon)


### PR DESCRIPTION
## Why

Per [SPEC 0](https://scientific-python.org/specs/spec-0000/) — which the project follows — Python versions are supported for 36 months after release. [Python 3.11](https://docs.python.org/3/whatsnew/3.11.html) (released 2022-10) passed that window in 2025-Q4, so the floor should already be 3.12. The recent [3.10→3.11 bump (#980)](https://github.com/DHI/mikeio/pull/980) was itself behind the schedule.

This is also the clean fix for the current CI breakage. The project does not commit a lockfile, so CI resolves the latest dependencies on every run. [numpy 2.5.0](https://pypi.org/project/numpy/2.5.0/) requires Python ≥3.12 and ships [PEP 695](https://peps.python.org/pep-0695/) `type` statements in its stubs, which mypy rejects when targeting 3.11 — failing the 3.14 CI job. Raising the mypy target to 3.12 resolves it without capping numpy.

## Changes

- `requires-python = ">=3.12"`, drop the 3.11 classifier, and set mypy `python_version = "3.12"`; bump the CI matrices and docs accordingly.
- Targeting 3.12 surfaced two latent typing issues, now fixed:
  - `Dataset.__getitem__`: since [slice objects became hashable in 3.12](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes), the `slice → Dataset` overload was shadowed by the broader `Hashable` overload, mistyping slices as `DataArray`. Reordered so slicing types as `Dataset`.
  - `_get_dist_geo` was annotated `-> float` but returns an `ndarray`.
- Document the SPEC 0 support policy in CONTRIBUTING.md.