### PR TITLE
Triage TODO comments in src

### DIFF
--- a/src/mikeio/__init__.py
+++ b/src/mikeio/__init__.py
@@ -126,7 +126,7 @@ def read(
     return dfs.read(items=items, time=time, keepdims=keepdims, **kwargs)
 
 
-# TODO Mesh doesn't comply with the interface of dfs files
+# TODO Mesh doesn't comply with the interface of dfs files (see gh-1008)
 def open(
     filename: str | Path, **kwargs: Any
 ) -> Dfs0 | Dfs1 | Dfs2 | Dfs3 | Dfsu2DH | Dfsu2DV | Dfsu3D | DfsuSpectral | Mesh:

--- a/src/mikeio/_spectral.py
+++ b/src/mikeio/_spectral.py
@@ -154,7 +154,7 @@ def plot_2dspectrum(
             f"plot_type '{plot_type}' not supported (contour, contourf, patch, shaded)"
         )
 
-    # TODO: optional
+    # TODO: optional (see gh-1024)
     ax.set_thetagrids(  # type: ignore
         [0.0, 45, 90.0, 135, 180.0, 225, 270.0, 315],
         labels=["N", "N-E", "E", "S-E", "S", "S-W", "W", "N-W"],

--- a/src/mikeio/_track.py
+++ b/src/mikeio/_track.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 from pathlib import Path
 from collections.abc import Sequence
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Callable, TYPE_CHECKING
 
 import numpy as np
+from numpy.typing import DTypeLike
 import pandas as pd
 
 from .eum import ItemInfo, EUMUnit, EUMType
@@ -24,13 +25,14 @@ def _extract_track(
     items: Sequence[ItemInfo],
     item_numbers: Sequence[int],
     time_steps: Sequence[int],
-    n_elements: int,
     method: str,
-    dtype: Any,  # TODO DTypeLike?
+    dtype: DTypeLike,
     data_read_func: Callable[[int, int], tuple[np.ndarray, float]],
 ) -> Dataset:
     if not isinstance(geometry, GeometryFM2D):
         raise NotImplementedError("Only implemented for 2d flexible mesh geometries")
+
+    n_elements = geometry.n_elements
 
     n_items = len(item_numbers)
 
@@ -139,7 +141,6 @@ def _extract_track(
         w = (t_rel[t] - t1) / timestep  # time-weight
         eid = interpolant.ids[i_interp]
         weights = interpolant.weights
-        # TODO move to interpolation module?
         if np.any(eid > 0):
             dati = (1 - w) * np.dot(d1[:, eid], weights[i_interp])
             dati = dati + w * np.dot(d2[:, eid], weights[i_interp])

--- a/src/mikeio/dataset/_data_plot.py
+++ b/src/mikeio/dataset/_data_plot.py
@@ -771,7 +771,7 @@ class DataArrayPlotterPointSpectrum(DataArrayPlotter):
         ax = self._plot_1dspectrum(self.da.geometry.directions, ax, figsize, **kwargs)  # type: ignore
         ax.set_xlabel("directions [degrees]")
         ax.set_ylabel("directional spectral energy [m*m*s]")
-        # TODO: consider using matplotlib's default tick locator instead of arbitrary ::2
+        # TODO: consider using matplotlib's default tick locator instead of arbitrary ::2 (see gh-1025)
         ax.set_xticks(self.da.geometry.directions[::2])  # type: ignore
         return ax
 

--- a/src/mikeio/dataset/_dataarray.py
+++ b/src/mikeio/dataset/_dataarray.py
@@ -158,7 +158,6 @@ class DataArray:
         dims: Sequence[str] | None = None,
         dt: float = 1.0,
     ) -> None:
-        # TODO consider np.asarray, e.g. self._values = np.asarray(data)
         self._values = self._parse_data(data)
 
         self.time: pd.DatetimeIndex | pd.TimedeltaIndex = self._parse_time(time)
@@ -228,7 +227,6 @@ class DataArray:
     ) -> np.ndarray | None:
         if zn is not None:
             if isinstance(geometry, _GeometryFMLayered):
-                # TODO: np.squeeze(zn) if n_timesteps=1 ?
                 if (n_timesteps > 1) and (zn.shape[0] != n_timesteps):
                     raise ValueError(
                         f"zn has wrong shape ({zn.shape}). First dimension should be of size n_timesteps ({n_timesteps})"
@@ -276,7 +274,6 @@ class DataArray:
         return len(problems) == 0
 
     def _get_plotter_by_geometry(self) -> Any:
-        # TODO: this is explicit, but with consistent naming, we could create this mapping automatically
         PLOTTER_MAP: Any = {
             GeometryFMVerticalProfile: DataArrayPlotterFMVerticalProfile,
             GeometryFMVerticalColumn: DataArrayPlotterFMVerticalColumn,
@@ -337,7 +334,7 @@ class DataArray:
     @property
     def end_time(self) -> datetime:
         """Last time instance (as datetime)."""
-        # TODO: use pd.Timestamp instead
+        # TODO: use pd.Timestamp instead (see gh-1020)
         return self.time[-1].to_pydatetime()
 
     @cached_property
@@ -515,7 +512,6 @@ class DataArray:
         )
         data = np.squeeze(self.values)
 
-        # TODO: should geometry stay the same?
         return DataArray(
             data=data,
             time=self.time,
@@ -700,9 +696,7 @@ class DataArray:
             assert isinstance(parsed_axis, int)
             idx = list(range(*idx.indices(self.shape[parsed_axis])))
         if idx is None or (not np.isscalar(idx) and len(idx) == 0):  # type: ignore
-            raise ValueError(
-                "Empty index is not allowed"
-            )  # TODO other option would be to have a NullDataArray
+            raise ValueError("Empty index is not allowed")
 
         idx = np.atleast_1d(idx)
         single_index = len(idx) == 1
@@ -865,9 +859,9 @@ class DataArray:
         if len(kwargs) > 0:
             idx = self.geometry.find_index(**kwargs)
 
-            # TODO this seems fragile
+            # TODO this seems fragile (see gh-1018)
             if isinstance(idx, tuple):
-                # TODO: support for dfs3
+                # TODO: support for dfs3 (see gh-1018)
                 assert len(idx) == 2
                 ii, jj = idx
                 if jj is not None:
@@ -919,9 +913,9 @@ class DataArray:
         return self
 
     def interp(
-        # TODO find out optimal syntax to allow interpolation to single point, new time, grid, mesh...
+        # TODO find out optimal syntax to allow interpolation to single point, new time, grid, mesh... (see gh-1019)
         self,
-        # *, # TODO: make this a keyword-only argument in the future
+        # *, # TODO: make this a keyword-only argument in the future (see gh-1019)
         time: pd.DatetimeIndex | DataArray | Dataset | int | float | None = None,
         x: float | None = None,
         y: float | None = None,
@@ -1084,7 +1078,6 @@ class DataArray:
             end_time=self.end_time,
             timestep=self.timestep,
             geometry=self.geometry,
-            n_elements=self.shape[1],  # TODO is there a better way to find out this?
             track=track,
             items=deepcopy([self.item]),
             time_steps=list(range(self.n_timesteps)),
@@ -1803,7 +1796,7 @@ class DataArray:
         except TypeError:
             raise TypeError("Math operation could not be applied to DataArray")
 
-        new_da = self.copy()  # TODO: alternatively: create new dataset (will validate)
+        new_da = self.copy()
         new_da.values = data
 
         return new_da
@@ -2056,7 +2049,9 @@ class DataArray:
             return time
 
         if time is None:
-            time = [pd.Timestamp(2018, 1, 1)]  # TODO is this the correct epoch?
+            time = [
+                pd.Timestamp(2018, 1, 1)
+            ]  # TODO is this the correct epoch? (see gh-1021)
         if isinstance(time, str) or (not isinstance(time, Iterable)):
             time = [time]
 
@@ -2075,7 +2070,6 @@ class DataArray:
         self,
         axis: int | tuple[int, ...] | str | None,
     ) -> int | tuple[int, ...]:
-        # TODO change to return tuple always
         dims = self.dims
         data_shape = self.shape
         has_time = self._has_time_axis

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -711,7 +711,7 @@ class Dataset:
         ```
 
         """
-        # TODO deprecate idx, axis to prefer x= instead
+        # TODO deprecate idx, axis to prefer x= instead (see gh-1022)
 
         res = [
             da.isel(
@@ -882,7 +882,7 @@ class Dataset:
 
             if isinstance(
                 self.geometry, GeometryFM2D
-            ):  # TODO remove this when all geometries implements the same method
+            ):  # TODO remove this when all geometries implements the same method (see gh-1023)
                 interpolant = self.geometry.get_2d_interpolant(
                     xy,  # type: ignore
                     **kwargs,  # type: ignore
@@ -948,7 +948,6 @@ class Dataset:
             end_time=self.end_time,
             timestep=self.timestep,
             geometry=self.geometry,
-            n_elements=self.shape[1],  # TODO is there a better way to find out this?
             track=track,
             items=deepcopy(self.items),
             time_steps=time_steps,

--- a/src/mikeio/dfs/_dfs.py
+++ b/src/mikeio/dfs/_dfs.py
@@ -22,6 +22,10 @@ from ..eum import ItemInfo, ItemInfoList
 from ..exceptions import ItemsError
 from .._time import DateTimeSelector
 
+# dfs files with a relative time axis carry no start date; the Unix epoch is used
+# as an arbitrary but stable reference so that times can be represented as datetimes.
+RELATIVE_TIME_EPOCH = datetime(1970, 1, 1)
+
 
 @dataclass
 class DfsHeader:
@@ -135,8 +139,7 @@ def _valid_timesteps(
     nt = time_axis.NumberOfTimeSteps
 
     if time_axis.TimeAxisType != TimeAxisType.CalendarEquidistant:
-        # TODO is this the proper epoch, should this magic number be somewhere else?
-        start_time_file = datetime(1970, 1, 1)
+        start_time_file = RELATIVE_TIME_EPOCH
     else:
         start_time_file = time_axis.StartDateTime
 
@@ -312,9 +315,7 @@ class _Dfs123:
         }:
             self._start_time = dfs.FileInfo.TimeAxis.StartDateTime
         else:  # relative time axis
-            self._start_time = datetime(
-                1970, 1, 1
-            )  # TODO is this the proper epoch, should this magic number be somewhere else?
+            self._start_time = RELATIVE_TIME_EPOCH
 
         if hasattr(dfs.FileInfo.TimeAxis, "TimeStep"):
             self._timestep = (
@@ -322,7 +323,7 @@ class _Dfs123:
                 dfs.FileInfo.TimeAxis.TimeStepInSeconds()
                 if dfs.FileInfo.TimeAxis.TimeStepInSeconds() > 0
                 else 1
-            )  # TODO handle other timeunits
+            )
 
             freq = pd.Timedelta(seconds=self._timestep)
             self._time = pd.date_range(

--- a/src/mikeio/dfs/_dfs0.py
+++ b/src/mikeio/dfs/_dfs0.py
@@ -36,7 +36,8 @@ def write_dfs0(
 
     if dataset.is_equidistant:
         if len(dataset.time) == 1:
-            dt = 1.0  # TODO
+            # a single timestep has no timestep to derive; 1 s is written as placeholder
+            dt = 1.0
         else:
             dt = (dataset.time[1] - dataset.time[0]).total_seconds()
 
@@ -183,7 +184,7 @@ class Dfs0:
             # relative time use timedelta
             ftime = pd.to_timedelta(t_seconds, unit="s")
 
-        # TODO common for all dfs files , extract
+        # TODO common for all dfs files , extract (see gh-1029)
         # select items
         item_numbers = _valid_item_numbers(dfs.ItemInfo, items)
         if items is not None:

--- a/src/mikeio/dfs/_dfs3.py
+++ b/src/mikeio/dfs/_dfs3.py
@@ -113,7 +113,6 @@ class Dfs3(_Dfs123):
     def __init__(self, filename: str | Path):
         super().__init__(str(filename))
 
-        # TODO
         self._x0 = 0.0
         self._y0 = 0.0
         self._z0 = 0.0

--- a/src/mikeio/dfsu/_dfsu.py
+++ b/src/mikeio/dfsu/_dfsu.py
@@ -78,7 +78,7 @@ def write_dfsu(filename: str | Path, data: Dataset, title: str = "") -> None:
         DfsuFileType.DfsuSpectral2D,
     ):
         builder.SetFrequencies(geometry.frequencies)
-        # TODO should directions always be converted to radians
+        # TODO should directions always be converted to radians (see gh-1027)
         builder.SetDirections(np.deg2rad(geometry.directions))
 
     builder.SetNodes(xn, yn, zn, geometry.codes)
@@ -239,7 +239,7 @@ class Dfsu2DH:
             )
         return str.join("\n", out)
 
-    # TODO change to GeometryFM2D
+    # TODO change to GeometryFM2D (see gh-1028)
     @property
     def geometry(self) -> Any:
         """Flexible Mesh Geometry of the file (e.g. [](`mikeio.spatial.GeometryFM2D`))."""
@@ -636,7 +636,6 @@ class Dfsu2DH:
             end_time=self.end_time,
             timestep=self.timestep,
             geometry=self.geometry,
-            n_elements=self.geometry.n_elements,
             track=track,
             items=deepcopy(items),
             time_steps=time_steps,

--- a/src/mikeio/dfsu/_mesh.py
+++ b/src/mikeio/dfsu/_mesh.py
@@ -72,7 +72,7 @@ class Mesh:
         ]
         return str.join("\n", out)
 
-    # TODO re-consider if all of these properties are needed, since they all are available in the geometry
+    # TODO re-consider if all of these properties are needed, since they all are available in the geometry (see gh-1008)
     @property
     def n_elements(self) -> int:
         """Number of elements."""

--- a/src/mikeio/dfsu/_spectral.py
+++ b/src/mikeio/dfsu/_spectral.py
@@ -345,7 +345,7 @@ class DfsuSpectral:
             if elements is None:
                 elements = self._parse_geometry_sel(area=area, x=x, y=y)
         else:
-            # TODO move to _parse_geometry_sel
+            # TODO move to _parse_geometry_sel (see gh-1026)
             if (area is not None) or (x is not None) or (y is not None):
                 raise ValueError(
                     f"Arguments area/x/y are not supported for {self._type}"
@@ -486,7 +486,7 @@ class DfsuSpectral:
             else:
                 elements = (
                     [elements] if np.isscalar(elements) else list(elements)  # type: ignore
-                )  # TODO check this
+                )
                 geometry = self.geometry.elements_to_geometry(elements)  # type: ignore
             return geometry, elements  # type: ignore
 

--- a/src/mikeio/generic.py
+++ b/src/mikeio/generic.py
@@ -303,7 +303,26 @@ def _process_dfs_files(
 
     n_time_steps = dfs_i_a.FileInfo.TimeAxis.NumberOfTimeSteps
     n_items = len(dfs_i_a.ItemInfo)
-    # TODO Add checks to verify identical structure of file a and b
+
+    n_time_steps_b = dfs_i_b.FileInfo.TimeAxis.NumberOfTimeSteps
+    n_items_b = len(dfs_i_b.ItemInfo)
+    if n_items != n_items_b:
+        raise ValueError(
+            f"Number of items must match ({infilename_a}: {n_items}, {infilename_b}: {n_items_b})"
+        )
+    if n_time_steps != n_time_steps_b:
+        raise ValueError(
+            f"Number of timesteps must match ({infilename_a}: {n_time_steps}, {infilename_b}: {n_time_steps_b})"
+        )
+    for item, (ia, ib) in enumerate(zip(dfs_i_a.ItemInfo, dfs_i_b.ItemInfo)):
+        if ia.Quantity.Item != ib.Quantity.Item:
+            raise ValueError(
+                f"Item {item} must have the same type ({infilename_a}: {ia.Name}, {infilename_b}: {ib.Name})"
+            )
+        if ia.ElementCount != ib.ElementCount:
+            raise ValueError(
+                f"Item {item} ({ia.Name}) must have the same number of elements ({ia.ElementCount} != {ib.ElementCount})"
+            )
 
     for timestep in trange(n_time_steps):
         for item in range(n_items):
@@ -327,7 +346,6 @@ def _process_dfs_files(
     dfs_o.Close()
 
 
-# TODO sum is conflicting with the built-in sum function, which we could haved used above.
 def sum(
     infilename_a: str | pathlib.Path,
     infilename_b: str | pathlib.Path,
@@ -887,7 +905,7 @@ def quantile(
 
     n_time_steps = dfs_i.FileInfo.TimeAxis.NumberOfTimeSteps
 
-    # TODO: better handling of different item sizes (zn...)
+    # TODO: better handling of different item sizes (zn...) (see gh-1009)
 
     ci = _ChunkInfo.from_dfs(dfs_i, item_numbers, buffer_size)
 
@@ -942,7 +960,7 @@ def quantile(
 
     if is_dfsu_3d:
         znitemdata = dfs_i.ReadItemTimeStep(1, 0)
-        # TODO should this be static Z coordinates instead?
+        # TODO should this be static Z coordinates instead? (see gh-1009)
         dfs_o.WriteItemTimeStepNext(0.0, znitemdata.Data)
 
     for item in range(n_items_out):

--- a/src/mikeio/pfs/_pfssection.py
+++ b/src/mikeio/pfs/_pfssection.py
@@ -29,8 +29,12 @@ def _merge_dict(a: dict[str, Any], b: Mapping[str, Any]) -> dict[str, Any]:
 
 
 class PfsNonUniqueList(list):
-    # TODO do we really need this, regular lists are not unique
-    pass
+    """List of values belonging to repeated keywords or sections with the same name.
+
+    A distinct type is needed because a plain list is also a valid *single* pfs
+    value (e.g. `x = 1, 2, 3`); this marker tells the writer to emit one entry
+    per element instead of a single comma-separated value.
+    """
 
 
 class PfsSection(SimpleNamespace, MutableMapping[str, Any]):
@@ -400,7 +404,7 @@ class PfsSection(SimpleNamespace, MutableMapping[str, Any]):
             n_sections = len(sections)
         else:
             n_sections = -1
-            # TODO: check that value is a PfsSection
+            # TODO: check that value is a PfsSection (see gh-1030)
             sections = [k for k in self.keys() if k[-1].isdigit()]
             for k in self.keys():
                 if isinstance(k, str) and k.startswith("number_of_"):

--- a/src/mikeio/spatial/_FM_geometry.py
+++ b/src/mikeio/spatial/_FM_geometry.py
@@ -26,8 +26,8 @@ from ._FM_plot import (
     _plot_map,
     BoundaryPolygons,
     Polygon,
-    _set_xy_label_by_projection,  # TODO remove
-    _to_polygons,  # TODO remove
+    _set_xy_label_by_projection,  # TODO remove (see gh-1013)
+    _to_polygons,  # TODO remove (see gh-1013)
 )
 from ._geometry import Geometry0D, GeometryPoint2D, _Geometry
 
@@ -147,7 +147,7 @@ class GeometryFMPlotter:
         ```
 
         """
-        # TODO this must be a duplicate, delegate
+        # TODO this must be a duplicate, delegate (see gh-1013)
 
         from matplotlib.collections import PatchCollection  # type: ignore
 
@@ -309,7 +309,7 @@ class _GeometryFM(_Geometry):
         if validate:
             max_node_id = self._node_ids.max()
             for i, e in enumerate(element_table):
-                # TODO: avoid looping through all elements (could be +1e6)!
+                # TODO: avoid looping through all elements (could be +1e6)! (see gh-1012)
                 if not isinstance(e, np.ndarray):
                     e = np.asarray(e)
                     element_table[i] = e
@@ -324,7 +324,6 @@ class _GeometryFM(_Geometry):
             element_ids = np.arange(len(element_table))
         element_ids = np.asarray(element_ids)
 
-        # TODO make sure return type is np.ndarray
         return element_table, element_ids
 
     def _reindex(self) -> None:
@@ -622,8 +621,6 @@ class GeometryFM2D(_GeometryFM):
     def _find_n_nearest_2d_elements(
         self, x: float | np.ndarray, y: float | np.ndarray | None = None, n: int = 1
     ) -> tuple[Any, Any]:
-        # TODO return arguments in the same order than KDTree.query?
-
         if n > self.n_elements:
             raise ValueError(
                 f"Cannot find {n} nearest! Number of elements: {self.n_elements}"
@@ -670,7 +667,7 @@ class GeometryFM2D(_GeometryFM):
             if not element_found and self.n_elements > 1:
                 many_nearest, _ = self._find_n_nearest_2d_elements(
                     coords[k, :],
-                    n=min(self.n_elements, 10),  # TODO is 10 enough?
+                    n=min(self.n_elements, 10),  # TODO is 10 enough? (see gh-1014)
                 )
                 for p in many_nearest[2:]:  # we have already tried the two first above
                     nodes = self.element_table[p]

--- a/src/mikeio/spatial/_FM_geometry_layered.py
+++ b/src/mikeio/spatial/_FM_geometry_layered.py
@@ -254,20 +254,25 @@ class _GeometryFMLayered(_GeometryFM):
             reindex=True,
         )
 
-        # TODO do this before creating the geometry
-
-        # TODO extract method
-        # Fix z-coordinate for sigma-z:
+        # TODO do this before creating the geometry (see gh-1015)
         if self._type == DfsuFileType.Dfsu3DSigmaZ:
-            zn = geom.node_coordinates[:, 2].copy()
-            for j, elem_nodes in enumerate(geom.element_table):
-                elem_nodes3d = self.element_table[self.bottom_elements[j]]
-                for jn in range(len(elem_nodes)):
-                    znj_3d = self.node_coordinates[elem_nodes3d[jn], 2]
-                    zn[elem_nodes[jn]] = min(zn[elem_nodes[jn]], znj_3d)
-            geom.node_coordinates[:, 2] = zn
+            geom.node_coordinates[:, 2] = self._sigma_z_bottom_node_z(geom)
 
         return geom
+
+    def _sigma_z_bottom_node_z(self, geom: GeometryFM2D) -> np.ndarray:
+        """Deepest z-coordinate per node of the 2d geometry derived from a sigma-z mesh.
+
+        The bottom nodes of the top elements sit at the top of the z-layers, so the
+        z-coordinate is lowered to the corresponding bottom element's node z.
+        """
+        zn = geom.node_coordinates[:, 2].copy()
+        for j, elem_nodes in enumerate(geom.element_table):
+            elem_nodes3d = self.element_table[self.bottom_elements[j]]
+            for jn in range(len(elem_nodes)):
+                znj_3d = self.node_coordinates[elem_nodes3d[jn], 2]
+                zn[elem_nodes[jn]] = min(zn[elem_nodes[jn]], znj_3d)
+        return zn
 
     @property
     def is_layered(self) -> bool:
@@ -495,7 +500,7 @@ class _GeometryFMLayered(_GeometryFM):
         self, elem2d: int | np.ndarray, z: np.ndarray | float
     ) -> np.ndarray:
         """Find 3d element ids from 2d element ids and z-values."""
-        # TODO: coordinate with _find_3d_from_2d_points()
+        # TODO: coordinate with _find_3d_from_2d_points() (see gh-1016)
 
         elem2d = [elem2d] if np.isscalar(elem2d) else elem2d
         elem2d = np.asarray(elem2d)

--- a/src/mikeio/spatial/_FM_plot.py
+++ b/src/mikeio/spatial/_FM_plot.py
@@ -341,7 +341,7 @@ def _get_tris(
     zn = _get_node_centered_data(nc, elem_table, ec, z)
 
     if n_refinements > 0:
-        # TODO: refinements doesn't seem to work for 3d files?
+        # TODO: refinements doesn't seem to work for 3d files? (see gh-1017)
         refiner = tri.UniformTriRefiner(triang)
         triang, zn = refiner.refine_field(zn, subdiv=n_refinements)
 

--- a/src/mikeio/spatial/_geometry.py
+++ b/src/mikeio/spatial/_geometry.py
@@ -179,10 +179,6 @@ class GeometryPoint2D(_Geometry):
     def __repr__(self) -> str:
         return f"GeometryPoint2D(x={self.x}, y={self.y})"
 
-    # TODO should we use wkt here
-    # def __str__(self) -> str:
-    #    return self.wkt
-
     @property
     def wkt(self) -> str:
         return f"POINT ({self.x} {self.y})"

--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -1124,7 +1124,7 @@ class Grid3D(_Geometry):
         z0: float = 0.0,
         dz: float | None = None,
         nz: int | None = None,
-        projection: str = "NON-UTM",  # TODO LONG/LAT
+        projection: str = "NON-UTM",  # TODO LONG/LAT (see gh-1011)
         origin: tuple[float, float] = (0.0, 0.0),
         orientation: float = 0.0,
     ) -> None:
@@ -1172,7 +1172,7 @@ class Grid3D(_Geometry):
         self._y0, self._dy, self._ny = _parse_grid_axis("y", y, y0, dy, ny)
         self._z0, self._dz, self._nz = _parse_grid_axis("z", z, z0, dz, nz)
 
-        self._projstr = projection  # TODO handle other types than string
+        self._projstr = projection  # TODO handle other types than string (see gh-1011)
         self._origin = origin
         self._orientation = orientation
 
@@ -1282,7 +1282,7 @@ class Grid3D(_Geometry):
 
         if axis == 0:
             # z is the first axis! return x-y Grid2D
-            # TODO: origin, how to pass self.z[idx]?
+            # TODO: origin, how to pass self.z[idx]? (see gh-1010)
             return Grid2D(
                 x0=self._x0,
                 y0=self._y0,
@@ -1296,7 +1296,7 @@ class Grid3D(_Geometry):
             )
         elif axis == 1:
             # y is the second axis! return x-z Grid2D
-            # TODO: origin, how to pass self.y[idx]?
+            # TODO: origin, how to pass self.y[idx]? (see gh-1010)
             return Grid2D(
                 x=self.x,
                 y=self.z,
@@ -1304,7 +1304,7 @@ class Grid3D(_Geometry):
             )
         elif axis == 2:
             # x is the last axis! return y-z Grid2D
-            # TODO: origin, how to pass self.x[idx]?
+            # TODO: origin, how to pass self.x[idx]? (see gh-1010)
             return Grid2D(
                 x=self.y,
                 y=self.z,

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -843,3 +843,22 @@ def test_transform_func_with_missing_item_reports_existing_items(
         transform(infilename, outfilename, items)
     assert "U velocity" in str(excinfo.value)
     assert not outfilename.exists()
+
+
+def test_diff_mismatching_grid_raises(tmp_path: Path) -> None:
+    # same item type, different number of elements
+    infilename_a = "tests/testdata/gebco_sound.dfs2"
+    infilename_b = "tests/testdata/gebco_sound_crop_rotate.dfs2"
+    fp = tmp_path / "diff.dfs2"
+
+    with pytest.raises(ValueError, match="same number of elements"):
+        diff(infilename_a, infilename_b, fp)
+
+
+def test_diff_mismatching_items_raises(tmp_path: Path) -> None:
+    infilename_a = "tests/testdata/gebco_sound.dfs2"
+    infilename_b = "tests/testdata/eq.dfs2"
+    fp = tmp_path / "diff.dfs2"
+
+    with pytest.raises(ValueError):
+        diff(infilename_a, infilename_b, fp)


### PR DESCRIPTION
Every `# TODO` in `src/` (56 of them) was triaged rather than bulk-deleted, so nothing is lost and nothing is left dangling without a home.

**Why this matters:** a TODO with no issue behind it is invisible — it never reaches a milestone, never gets prioritised, and reads to anyone browsing the source as work that was abandoned. Several of these turned out to be genuine bugs (Grid3D slicing drops the projection, the point-in-polygon fallback only inspects 10 candidates) that had been sitting in comments for years instead of in the tracker.

**Fixed here:**
- `generic._process_dfs_files` now rejects input files with mismatched items or timestep counts. Previously `diff`/`add` on incompatible files read item *i* from both and wrote whatever came out.
- `_extract_track` derives `n_elements` from the `GeometryFM2D` it already requires, removing a redundant parameter that three call sites had to compute.
- The relative-time epoch is a named `RELATIVE_TIME_EPOCH` constant rather than `datetime(1970, 1, 1)` repeated at two sites.
- `PfsNonUniqueList` documents why a distinct type is needed instead of asking the question in a TODO.
- The sigma-z depth correction is extracted to a named method, so `to_2d_geometry` no longer reads as build-then-patch.

**Removed:** 10 comments that recorded a musing or a rejected alternative with no task behind them (e.g. "other option would be to have a NullDataArray" — an ADR-shaped fact, not a todo).

**Filed:** the remaining 32 comments describe real open work and are now #1008–#1030. Each comment is kept in place and annotated with its issue, so the code still flags the rough edge and the tracker owns the decision.