### PR TITLE
Fix ruff failures outside src/

### DIFF
--- a/notebooks/Dfs2 - Snow Compare.ipynb
+++ b/notebooks/Dfs2 - Snow Compare.ipynb
@@ -102,7 +102,7 @@
     "    modisSingleDataArray.attrs[\"units\"] = \"Fraction\"\n",
     "\n",
     "    # 3 column layout\n",
-    "    fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(21, 5))\n",
+    "    _, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(21, 5))\n",
     "    modisSingleDataArray.plot.pcolormesh(ax=ax1, vmin=0.0, vmax=1.0, cmap=\"jet\")\n",
     "    ax1.set_title(\"MODIS\")\n",
     "\n",

--- a/roadmap/scripts/generate_overview.py
+++ b/roadmap/scripts/generate_overview.py
@@ -34,6 +34,7 @@ def parse_frontmatter(path: Path) -> dict:
 
 
 def main():
+    """Render roadmap/README.md from the feature frontmatter."""
     features = []
     for path in sorted(FEATURES_DIR.glob("*.md")):
         features.append(parse_frontmatter(path))

--- a/tests/test_dfs0.py
+++ b/tests/test_dfs0.py
@@ -78,7 +78,7 @@ def test_write_with_title(tmp_path: Path) -> None:
     nt = 100
 
     da = mikeio.DataArray(
-        data=np.random.random([nt]).astype(np.float32),
+        data=np.random.default_rng(42).random(nt).astype(np.float32),
         time=pd.date_range("2000", periods=nt, freq="h"),
     )
 

--- a/tests/test_pfs.py
+++ b/tests/test_pfs.py
@@ -276,7 +276,6 @@ def test_pfssection_write(d1, tmp_path: Path) -> None:
     assert pfs2.root.key1 == sct.key1
 
 
-
 def test_basic() -> None:
     pfs = mikeio.PfsDocument("tests/testdata/pfs/simple.pfs")
 


### PR DESCRIPTION
Running `ruff check .` or `ruff format --check .` from the repo root failed on four files outside `src/`. That means anyone following the `ruff check .` step in [CLAUDE.md](https://github.com/DHI/mikeio/blob/main/CLAUDE.md) had to already know which failures were expected, which makes the check useless as a gate — a real new failure is indistinguishable from the standing noise.

- `notebooks/Dfs2 - Snow Compare.ipynb` — `fig` from `plt.subplots` is never used; now `_`.
- `roadmap/scripts/generate_overview.py` — `main()` had no docstring.
- `tests/test_dfs0.py` — legacy `np.random.random`, replaced with a seeded `np.random.default_rng(42)` matching the convention in `test_dfsu2dv.py` and `test_roundtrip.py`. Seeded rather than unseeded so the test is reproducible.
- `tests/test_pfs.py` — stray blank line.

Both commands are now clean from the repo root, so `just check` gates on something meaningful.