### PR TITLE
Refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,11 @@
 [![PyPI version](https://badge.fury.io/py/mikeio.svg)](https://badge.fury.io/py/mikeio)
 ![OS](https://img.shields.io/badge/OS-Windows%20%7C%20Linux-blue)
 ![Downloads](https://img.shields.io/pypi/dm/mikeio)
-
-
+[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/DHI/mikeio/blob/main/License.txt)
 
 Read, write and manipulate dfs0, dfs1, dfs2, dfs3, dfsu and mesh files.
 
 MIKE IO facilitates common data processing workflows for [MIKE files](https://www.dhigroup.com/technologies/mikepoweredbydhi) using Python.
-
-[![MIKEIO. Read, write and analyze MIKE dfs files with Python on Vimeo](https://raw.githubusercontent.com/DHI/mikeio/main/images/youtube1.png)](https://player.vimeo.com/video/708275619)
-
-<!--[![MIKEIO. New workflow and data structures in MIKE IO 1.0 on Vimeo](https://raw.githubusercontent.com/DHI/mikeio/main/images/youtube2.png)](https://player.vimeo.com/video/708276337)-->
-
 
 ## Requirements
 
@@ -26,68 +20,72 @@ MIKE IO facilitates common data processing workflows for [MIKE files](https://ww
 
 ## Installation
 
-`pip install mikeio`
+```bash
+pip install mikeio
+```
 
-:warning: **Don't use conda to install MIKE IO!**, the version on conda is outdated.
+:warning: **Don't use conda to install MIKE IO!** The version on conda-forge is several major versions behind.
+
+## Getting started
+
+Read a file into a `Dataset` — a collection of named `DataArray`s sharing time and geometry:
+
+```python
+>>> import mikeio
+>>> ds = mikeio.read("HD2D.dfsu")
+>>> ds
+<mikeio.Dataset>
+title: Output 1
+dims: (time:9, element:884)
+time: 1985-08-06 07:00:00 - 1985-08-07 03:00:00 (9 records)
+geometry: Dfsu2D (884 elements, 529 nodes)
+items:
+  0:  Surface elevation <Surface Elevation> (meter)
+  1:  U velocity <u velocity component> (meter per sec)
+  2:  V velocity <v velocity component> (meter per sec)
+  3:  Current speed <Current Speed> (meter per sec)
+```
+
+Select an item and extract a time series at a point:
+
+```python
+>>> da = ds["Surface elevation"]
+>>> da.sel(x=606200, y=6905480)
+<mikeio.DataArray>
+name: Surface elevation
+dims: (time:9)
+time: 1985-08-06 07:00:00 - 1985-08-07 03:00:00 (9 records)
+geometry: GeometryPoint2D(x=606202.7806372638, y=6905474.639383219)
+values: [0.4595, 0.807, ..., -0.6322]
+```
+
+Convert to pandas, or write the result back to a dfs file:
+
+```python
+>>> df = mikeio.read("da_diagnostic.dfs0").to_dataframe()
+>>> ds.to_dfs("output.dfsu")
+```
+
+See the [user guide](https://dhi.github.io/mikeio/user-guide/getting-started.html) for more.
 
 ## Where can I get help?
 * Documentation - [https://dhi.github.io/mikeio/](https://dhi.github.io/mikeio/)
-* General help, new ideas and feature requests - [GitHub Discussions](http://github.com/DHI/mikeio/discussions) 
-* Bugs - [GitHub Issues](http://github.com/DHI/mikeio/issues)
+* General help, new ideas and feature requests - [GitHub Discussions](https://github.com/DHI/mikeio/discussions)
+* Bugs - [GitHub Issues](https://github.com/DHI/mikeio/issues)
 * Course material: [Getting started with Dfs files in Python using MIKE IO](https://dhi.github.io/getting-started-with-mikeio/intro.html)
 
+## Testing
 
-## Tested
+MIKE IO is tested extensively, with an overall statement coverage of ~95%. The test suite runs on every pull request against Python 3.12 and 3.14, and on a schedule on both Linux and Windows.
 
-MIKE IO is tested extensively.
-
-See detailed test coverage report below:
 ```bash
-$ pytest --cov=mikeio
+uv run pytest --cov=mikeio
 ```
-<pre>
----------- coverage: platform linux, python 3.13.0-final-0 -----------
-Name                                      Stmts   Miss  Cover
--------------------------------------------------------------
-mikeio/__init__.py                           33      5    85%
-mikeio/_interpolation.py                     68      6    91%
-mikeio/_spectral.py                          97      7    93%
-mikeio/_time.py                              28      1    96%
-mikeio/_track.py                            119      9    92%
-mikeio/dataset/__init__.py                    4      0   100%
-mikeio/dataset/_data_plot.py                359     38    89%
-mikeio/dataset/_data_utils.py                19      0   100%
-mikeio/dataset/_dataarray.py                725     46    94%
-mikeio/dataset/_dataset.py                  766     51    93%
-mikeio/dfs/__init__.py                        5      0   100%
-mikeio/dfs/_dfs0.py                         205     13    94%
-mikeio/dfs/_dfs1.py                          89      2    98%
-mikeio/dfs/_dfs2.py                         142      3    98%
-mikeio/dfs/_dfs3.py                         157     11    93%
-mikeio/dfs/_dfs.py                          251     14    94%
-mikeio/dfsu/__init__.py                       6      0   100%
-mikeio/dfsu/_common.py                       36      1    97%
-mikeio/dfsu/_dfsu.py                        239      6    97%
-mikeio/dfsu/_factory.py                      20      1    95%
-mikeio/dfsu/_layered.py                     204      9    96%
-mikeio/dfsu/_mesh.py                         54      8    85%
-mikeio/dfsu/_spectral.py                    234     42    82%
-mikeio/eum/__init__.py                        2      0   100%
-mikeio/eum/_eum.py                         1353      9    99%
-mikeio/exceptions.py                         24      4    83%
-mikeio/generic.py                           475     13    97%
-mikeio/pfs/__init__.py                        7      0   100%
-mikeio/pfs/_pfsdocument.py                  233      4    98%
-mikeio/pfs/_pfssection.py                   225     11    95%
-mikeio/spatial/_FM_geometry.py              511     13    97%
-mikeio/spatial/_FM_geometry_layered.py      417     30    93%
-mikeio/spatial/_FM_geometry_spectral.py      94      9    90%
-mikeio/spatial/_FM_utils.py                 306     22    93%
-mikeio/spatial/__init__.py                    6      0   100%
-mikeio/spatial/_geometry.py                 100      8    92%
-mikeio/spatial/_grid_geometry.py            629     41    93%
-mikeio/spatial/_utils.py                     38      0   100%
-mikeio/spatial/crs.py                        51      5    90%
--------------------------------------------------------------
-TOTAL                                      8331    442    95%
-</pre>
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](https://github.com/DHI/mikeio/blob/main/CONTRIBUTING.md). Key architectural decisions are documented as [ADRs](https://github.com/DHI/mikeio/tree/main/adr).
+
+## License
+
+[BSD-3-Clause](https://github.com/DHI/mikeio/blob/main/License.txt)


### PR DESCRIPTION
The README carried a hand-pasted coverage table that had drifted badly: module paths were pre-`src/` layout, four listed modules no longer exist, four current ones were missing, and most statement counts were wrong. A table that has to be regenerated by hand after every PR will always be wrong, so it is gone — the overall number and the CI matrix say the same thing without rotting.

Beyond that, the README had no usage example at all, which is the first thing a visitor looks for, and no license statement. Both added; the example output is copied from actual reprs against `tests/testdata`.

The 2022 intro video is dropped — it covers MIKE IO 1.0-era workflows and the embed link no longer resolves.

Links are now absolute and `https`, so they also work where the README is rendered as the PyPI long description.