### PR TITLE
Restrict GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/docs_dead_links.yml
+++ b/.github/workflows/docs_dead_links.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     # run daily at 4 am
     - cron:  '0 4 * * 1'
+permissions:
+  contents: read
+
 jobs:
   crawl_for_broken_links:
     runs-on: ubuntu-latest

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/notebooks_test.yml
+++ b/.github/workflows/notebooks_test.yml
@@ -8,6 +8,9 @@ on:
     types: [review_requested, ready_for_review]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -7,6 +7,9 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 5 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,6 +8,9 @@ on:
     types: [published]
   workflow_dispatch:
     
+permissions:
+  contents: read
+
 jobs:
 
   test:
@@ -34,6 +37,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
 


### PR DESCRIPTION
Workflows without an explicit `permissions` block use the repository or organization default token permissions. For repositories created before February 2023 that default is read-write, so every job runs with a token that can push to the repo even though all it does is check out and run tests.

CodeQL flags this as [`actions/missing-workflow-permissions`](https://github.com/DHI/mikeio/security/code-scanning?query=is%3Aopen+rule%3Aactions%2Fmissing-workflow-permissions) (5 open alerts). Setting the permissions explicitly documents what each workflow actually needs and keeps it restricted if the default changes or the workflow is copied elsewhere.

`contents: read` at the workflow root is enough for all of them; the PyPI deploy job keeps `id-token: write` for trusted publishing and now states `contents: read` too, since a job-level block replaces rather than extends the root one.

See [Assigning permissions to jobs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs).