### PR TITLE
Encapsulate attributes that silently corrupted derived state

### DIFF
--- a/docs/user-guide/mesh.qmd
+++ b/docs/user-guide/mesh.qmd
@@ -121,15 +121,16 @@ Assume that we want to have a minimum depth of 2 meters and change the open boun
 ```{python}
 g = msh.geometry
 print(f'max z before: {g.node_coordinates[:,2].max()}')
-zc = g.node_coordinates[:,2]
-zc[zc>-2] = -2
-g.node_coordinates[:,2] = zc
+nc = g.node_coordinates.copy()
+nc[nc[:,2]>-2, 2] = -2
+g.node_coordinates = nc
 print(f'max z after: {g.node_coordinates[:,2].max()}')
 ```
 
+Note that `node_coordinates` and `codes` are read-only: modify a copy and assign it back, as above. Otherwise values derived from them (e.g. `element_coordinates`) would be left unchanged.
 
 ```{python}
-c = g.codes
+c = g.codes.copy()
 c[c==2] = 1
 g.codes = c
 ```

--- a/src/mikeio/_cache.py
+++ b/src/mikeio/_cache.py
@@ -1,0 +1,17 @@
+"""Invalidation of cached values."""
+
+from functools import cached_property
+from typing import Any
+
+
+def clear_cached_properties(obj: Any) -> None:
+    """Forget all cached_property values on obj, so that they are recomputed.
+
+    Call this from a setter that changes something the cached properties are
+    derived from, e.g. the node coordinates that element_coordinates is
+    calculated from.
+    """
+    for klass in type(obj).__mro__:
+        for name, attr in vars(klass).items():
+            if isinstance(attr, cached_property):
+                obj.__dict__.pop(name, None)

--- a/src/mikeio/dataset/_dataarray.py
+++ b/src/mikeio/dataset/_dataarray.py
@@ -25,6 +25,7 @@ import numpy as np
 import pandas as pd
 
 
+from .._cache import clear_cached_properties
 from ..eum import EUMType, EUMUnit, ItemInfo
 from .._time import _get_time_idx_list, _n_selected_timesteps
 from .._track import _extract_track
@@ -161,7 +162,7 @@ class DataArray:
         # TODO consider np.asarray, e.g. self._values = np.asarray(data)
         self._values = self._parse_data(data)
 
-        self.time: pd.DatetimeIndex | pd.TimedeltaIndex = self._parse_time(time)
+        self._time = self._parse_time(time)
         self._dt = dt
 
         geometry = GeometryUndefined() if geometry is None else geometry
@@ -175,13 +176,13 @@ class DataArray:
             )
 
         # geometries are very diverse without a common interface
-        self.geometry: Any = geometry
+        self._geometry: Any = geometry
 
         self._check_time_data_length(self.time)
 
         self.item = self._parse_item(item=item, name=name, type=type, unit=unit)
         self._zn = self._parse_zn(zn, self.geometry, self.n_timesteps)
-        self.plot = self._get_plotter_by_geometry()
+        self.plot: Any = self._get_plotter_by_geometry()
         self.z: ZAccessor | NullZAccessor = self._get_z_accessor_by_geometry()
 
     @staticmethod
@@ -306,6 +307,31 @@ class DataArray:
     # ============= Basic properties/methods ===========
 
     @property
+    def time(self) -> pd.DatetimeIndex | pd.TimedeltaIndex:
+        """Time axis."""
+        return self._time
+
+    @time.setter
+    def time(self, value: pd.DatetimeIndex | pd.TimedeltaIndex | str) -> None:
+        time = self._parse_time(value)
+        self._check_time_data_length(time)
+        self._time = time
+        clear_cached_properties(self)  # dims and is_equidistant are derived from time
+
+    @property
+    def geometry(self) -> Any:
+        """Geometry of the data (e.g. Grid2D, GeometryFM2D)."""
+        return self._geometry
+
+    @geometry.setter
+    def geometry(self, value: GeometryType) -> None:
+        self._geometry = value
+        clear_cached_properties(self)  # dims is derived from geometry
+        # plot and z are chosen by geometry type, so a new geometry needs new ones
+        self.plot = self._get_plotter_by_geometry()
+        self.z = self._get_z_accessor_by_geometry()
+
+    @property
     def name(self) -> str:
         """Name of this DataArray (=da.item.name)."""
         assert isinstance(self.item.name, str)
@@ -319,6 +345,10 @@ class DataArray:
     def type(self) -> EUMType:
         """EUMType."""
         return self.item.type
+
+    @type.setter
+    def type(self, value: EUMType) -> None:
+        self.item.type = value
 
     @property
     def unit(self) -> EUMUnit:

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -167,6 +167,14 @@ class Dataset:
         Derived from the DataArrays rather than stored, so that renaming one
         (da.name = "...") cannot leave the Dataset looking it up by the old name.
         """
+        names = self.names
+        if len(set(names)) != len(names):
+            duplicates = sorted({name for name in names if names.count(name) > 1})
+            dupes = ", ".join(duplicates)
+            raise ValueError(
+                f"Dataset has duplicate item names: {dupes}. "
+                "Rename items to unique names before name-based operations."
+            )
         return {da.name: da for da in self._das}
 
     @property
@@ -563,9 +571,13 @@ class Dataset:
         if name.startswith("_"):
             # never look up internals as items (also stops recursion on _das)
             raise AttributeError(name)
-        for da in self._das:
-            if _to_safe_name(da.name) == name:
-                return da
+        matches = [da for da in self._das if _to_safe_name(da.name) == name]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise AttributeError(
+                f"Dataset attribute {name!r} is ambiguous because multiple items match it"
+            )
         raise AttributeError(f"Dataset has no attribute or item named {name!r}")
 
     def __dir__(self) -> list[str]:

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -110,10 +110,7 @@ class Dataset:
             for da in rest:
                 first._is_compatible(da)
 
-        self._data_vars = data_vars
-
-        for key, value in data_vars.items():
-            self._set_name_attr(key, value)
+        self._das = list(data_vars.values())
         self.plot = DatasetPlotter(self)
 
         self.title = title
@@ -162,6 +159,15 @@ class Dataset:
         }
 
         return Dataset(data_vars, validate=validate, title=title)
+
+    @property
+    def _data_vars(self) -> dict[str, DataArray]:
+        """The DataArrays by name.
+
+        Derived from the DataArrays rather than stored, so that renaming one
+        (da.name = "...") cannot leave the Dataset looking it up by the old name.
+        """
+        return {da.name: da for da in self._das}
 
     @property
     def values(self) -> None:
@@ -299,7 +305,7 @@ class Dataset:
     @property
     def n_items(self) -> int:
         """Number of items/DataArrays, equivalent to len()."""
-        return len(self._data_vars)
+        return len(self._das)
 
     @property
     def names(self) -> list[str]:
@@ -399,9 +405,7 @@ class Dataset:
 
     def flipud(self) -> Dataset:
         """Flip data upside down (on first non-time axis)."""
-        self._data_vars = {
-            key: value.flipud() for (key, value) in self._data_vars.items()
-        }
+        self._das = [da.flipud() for da in self._das]
         return self
 
     def squeeze(self) -> Dataset:
@@ -444,10 +448,10 @@ class Dataset:
     # ============= Dataset is (almost) a MutableMapping ===========
 
     def __len__(self) -> int:
-        return len(self._data_vars)
+        return len(self._das)
 
     def __iter__(self) -> Iterator[DataArray]:
-        yield from self._data_vars.values()
+        yield from self._das
 
     def __setitem__(self, key: int | str, value: DataArray) -> None:
         self.__set_or_insert_item(key, value, insert=False)
@@ -465,19 +469,16 @@ class Dataset:
                     raise ValueError(
                         f"Item name {item_name} already in Dataset ({self.names})"
                     )
-                keys = list(self._data_vars.keys())
-                keys.insert(key, item_name)
-                values = list(self._data_vars.values())
-                values.insert(key, value)
-                self._data_vars = dict(zip(keys, values))
+                self._das.insert(key, value)
             else:
-                key_str = self.names[key]
-                self._data_vars[key_str] = value
-                self._set_name_attr(item_name, value)
+                self._das[key] = value
         else:
             value.name = key
-            self._data_vars[key] = value
-            self._set_name_attr(key, value)
+            names = self.names
+            if key in names:
+                self._das[names.index(key)] = value
+            else:
+                self._das.append(value)
 
     def insert(self, key: int, value: DataArray) -> None:
         """Insert DataArray in a specific position.
@@ -547,43 +548,29 @@ class Dataset:
             ds = self.copy()
 
         for old_name, new_name in mapper.items():
-            da = ds._data_vars.pop(old_name)
-            da.name = new_name
-            ds._data_vars[new_name] = da
-            ds._del_name_attr(old_name)
-            ds._set_name_attr(new_name, da)
+            ds[old_name].name = new_name
 
         return ds
 
-    # Instance attributes assigned in __init__: not class members, so
-    # hasattr(type(self), ...) misses them. An item named like one of these
-    # would clobber internal state (e.g. "plot" destroys the DatasetPlotter,
-    # "_data_vars" corrupts the item dict), so reserve them explicitly.
-    _RESERVED_INSTANCE_ATTRS = frozenset({"plot", "title", "_data_vars"})
+    def __getattr__(self, name: str) -> DataArray:
+        # Python only calls __getattr__ when normal lookup fails, so a real
+        # attribute, property or method always wins over an item of the same
+        # name: an item called "z" cannot clobber the z-coordinate accessor,
+        # nor "plot"/"geometry"/"mean"/etc. Such an item is still available as
+        # ds["z"]; only the convenience ds.z is reserved. mikeio itself
+        # manufactures such names, e.g. aggregate(axis="items") names the
+        # result after the aggregation function ("mean", "max", ...).
+        if name.startswith("_"):
+            # never look up internals as items (also stops recursion on _das)
+            raise AttributeError(name)
+        for da in self._das:
+            if _to_safe_name(da.name) == name:
+                return da
+        raise AttributeError(f"Dataset has no attribute or item named {name!r}")
 
-    def _is_reserved_attr(self, name: str) -> bool:
-        # Probe the CLASS, not the instance: hasattr(self, ...) would invoke the
-        # z/geometry property getters on a partially-constructed Dataset.
-        return name in self._RESERVED_INSTANCE_ATTRS or hasattr(type(self), name)
-
-    def _set_name_attr(self, name: str, value: DataArray) -> None:
-        name = _to_safe_name(name)
-        # Don't shadow a real class member (property or method) with a dynamic
-        # item attribute — e.g. an item named "z" must not clobber the read-only
-        # z-coordinate accessor, nor "geometry"/"time"/"mean"/etc. The item stays
-        # accessible via ds[name]; only the convenience ds.<name> is reserved.
-        # This is silent (not a warning) because mikeio routinely manufactures
-        # such names itself — aggregate(axis="items") names the result after the
-        # aggregation function (e.g. "mean", "nanmean", "max").
-        if self._is_reserved_attr(name):
-            return
-        setattr(self, name, value)
-
-    def _del_name_attr(self, name: str) -> None:
-        name = _to_safe_name(name)
-        if self._is_reserved_attr(name):
-            return
-        delattr(self, name)
+    def __dir__(self) -> list[str]:
+        # tab completion: real members plus the item names
+        return [*super().__dir__(), *(_to_safe_name(da.name) for da in self._das)]
 
     # `slice` must precede `Hashable | int`: since Python 3.12 slice objects are
     # hashable, so the broader `Hashable` overload would otherwise shadow this one
@@ -630,7 +617,7 @@ class Dataset:
         if isinstance(key, str):
             return key
         if isinstance(key, int):
-            return list(self._data_vars.keys())[key]
+            return self._das[key].name
         if isinstance(key, slice):
             start, stop, step = key.indices(len(self))
             return self._key_to_str(list(range(start, stop, step)))
@@ -640,8 +627,10 @@ class Dataset:
 
     def __delitem__(self, key: Hashable | int) -> None:
         key = self._key_to_str(key)
-        self._data_vars.__delitem__(key)
-        self._del_name_attr(key)
+        names = self.names
+        if key not in names:
+            raise KeyError(f"No item named: {key}. Valid items: {','.join(names)}")
+        del self._das[names.index(key)]
 
     # ============ select/interp =============
 

--- a/src/mikeio/dfsu/_mesh.py
+++ b/src/mikeio/dfsu/_mesh.py
@@ -42,8 +42,19 @@ class Mesh:
     """
 
     def __init__(self, filename: str | Path) -> None:
-        self.geometry: GeometryFM2D = self._read_header(filename)
+        self._geometry = self._read_header(filename)
         self.plot = self.geometry.plot
+
+    @property
+    def geometry(self) -> GeometryFM2D:
+        """Flexible Mesh geometry."""
+        return self._geometry
+
+    @geometry.setter
+    def geometry(self, value: GeometryFM2D) -> None:
+        self._geometry = value
+        # plot belongs to the geometry, a new geometry needs a new plotter
+        self.plot = value.plot
 
     def _read_header(self, filename: str | Path) -> GeometryFM2D:
         msh = MeshFile.ReadMesh(filename)
@@ -85,8 +96,12 @@ class Mesh:
 
     @property
     def node_coordinates(self) -> np.ndarray:
-        """Coordinates of nodes."""
+        """Coordinates of nodes (read-only, see GeometryFM2D.node_coordinates)."""
         return self.geometry.node_coordinates
+
+    @node_coordinates.setter
+    def node_coordinates(self, value: np.ndarray) -> None:
+        self.geometry.node_coordinates = value
 
     @property
     def n_nodes(self) -> int:
@@ -112,7 +127,9 @@ class Mesh:
     def zn(self, v: np.ndarray) -> None:
         if len(v) != self.n_nodes:
             raise ValueError(f"zn must have length of nodes ({self.n_nodes})")
-        self.geometry.node_coordinates[:, 2] = v
+        nc = self.geometry.node_coordinates.copy()
+        nc[:, 2] = v
+        self.geometry.node_coordinates = nc
 
     def write(
         self,

--- a/src/mikeio/eum/_eum.py
+++ b/src/mikeio/eum/_eum.py
@@ -1437,12 +1437,12 @@ class ItemInfo:
                 raise ValueError(
                     "Invalid type. Type should be supplied as EUMType, e.g. ItemInfo('WL',EUMType.Water_Level, EUMUnit.meter)"
                 )
-            self.type = itemtype
+            self._type = itemtype
 
             if name is None:
                 name = itemtype.display_name
         else:
-            self.type = EUMType.Undefined
+            self._type = EUMType.Undefined
 
         if unit is not None:
             if isinstance(unit, int):
@@ -1459,7 +1459,7 @@ class ItemInfo:
             else:
                 self._unit = self.type.units[0]
 
-        self.data_value_type = to_datatype(data_value_type)
+        self._data_value_type = to_datatype(data_value_type)
 
         if not isinstance(name, str):
             raise ValueError("Invalid name, name should be a string")
@@ -1482,6 +1482,31 @@ class ItemInfo:
             return f"{self.name} <{self.type.display_name}> ({self.unit.display_name})"
         else:
             return f"{self.name} <{self.type.display_name}> ({self.unit.display_name}) - {self.data_value_type.name}"
+
+    @property
+    def type(self) -> EUMType:
+        "Item type."
+        return self._type
+
+    @type.setter
+    def type(self, value: EUMType) -> None:
+        "Set type; the current unit must remain valid for the new type."
+        if self._unit not in value.units:
+            raise ValueError(
+                f"{self._unit} is not a correct unit for {value}. "
+                f"Create a new ItemInfo instead, e.g. ItemInfo(name, {value}, {value.units[0]})"
+            )
+        self._type = value
+
+    @property
+    def data_value_type(self) -> DataValueType:
+        "How values relate to time (Instantaneous, Accumulated, ...)."
+        return self._data_value_type
+
+    @data_value_type.setter
+    def data_value_type(self, value: str | int | DataValueType) -> None:
+        "Set data value type."
+        self._data_value_type = to_datatype(value)
 
     @property
     def unit(self) -> EUMUnit:

--- a/src/mikeio/eum/_eum.py
+++ b/src/mikeio/eum/_eum.py
@@ -1493,8 +1493,8 @@ class ItemInfo:
         "Set type; the current unit must remain valid for the new type."
         if self._unit not in value.units:
             raise ValueError(
-                f"{self._unit} is not a correct unit for {value}. "
-                f"Create a new ItemInfo instead, e.g. ItemInfo(name, {value}, {value.units[0]})"
+                f"{self._unit.display_name} is not a correct unit for {value.display_name}. "
+                f"Create a new ItemInfo instead, e.g. ItemInfo(name, EUMType.{value.name}, EUMUnit.{value.units[0].name})"
             )
         self._type = value
 
@@ -1518,7 +1518,8 @@ class ItemInfo:
         "Set unit."
         if value not in self.type.units:
             raise ValueError(
-                f"{value} is not a correct unit for {self.type}. Use {self.type.units}"
+                f"{value.display_name} is not a correct unit for {self.type.display_name}. "
+                f"Use one of {[u.display_name for u in self.type.units]}"
             )
         self._unit = value
 

--- a/src/mikeio/spatial/_FM_geometry.py
+++ b/src/mikeio/spatial/_FM_geometry.py
@@ -263,6 +263,12 @@ def _read_only(values: np.ndarray) -> np.ndarray:
     return view
 
 
+def _copy_element_table(
+    element_table: Sequence[Sequence[int] | np.ndarray],
+) -> list[np.ndarray]:
+    return [np.array(nodes, copy=True) for nodes in element_table]
+
+
 class _GeometryFM(_Geometry):
     def __init__(
         self,
@@ -278,11 +284,13 @@ class _GeometryFM(_Geometry):
         reindex: bool = False,
     ) -> None:
         super().__init__(projection=projection)
-        self._node_coordinates = np.asarray(node_coordinates)
+        self._node_coordinates = np.array(node_coordinates, copy=True)
 
         n_nodes = len(self._node_coordinates)
         self._codes = (
-            np.zeros((n_nodes,), dtype=int) if codes is None else np.asarray(codes)
+            np.zeros((n_nodes,), dtype=int)
+            if codes is None
+            else np.array(codes, copy=True)
         )
 
         self._node_ids = (
@@ -291,11 +299,12 @@ class _GeometryFM(_Geometry):
 
         self._type = dfsu_type
 
-        self._element_table, self._element_ids = self._check_elements(
+        element_table, self._element_ids = self._check_elements(
             element_table=element_table,  # type: ignore
             element_ids=element_ids,
             validate=validate,
         )
+        self._element_table = _copy_element_table(element_table)
 
         if reindex:
             self._reindex()
@@ -316,11 +325,9 @@ class _GeometryFM(_Geometry):
     ) -> tuple[Any, Any]:
         if validate:
             max_node_id = self._node_ids.max()
-            for i, e in enumerate(element_table):
+            for e in element_table:
                 # TODO: avoid looping through all elements (could be +1e6)!
-                if not isinstance(e, np.ndarray):
-                    e = np.asarray(e)
-                    element_table[i] = e
+                e = np.asarray(e)
 
                 # NOTE: this check "e.max()" takes the most of the time when constructing a new FM_geometry
                 if e.max() > max_node_id:
@@ -411,7 +418,7 @@ class _GeometryFM(_Geometry):
 
     @node_coordinates.setter
     def node_coordinates(self, value: ArrayLike) -> None:
-        nc = np.asarray(value)
+        nc = np.array(value, copy=True)
         if len(nc) != self.n_nodes:
             raise ValueError(
                 f"node_coordinates must have length of nodes ({self.n_nodes})"
@@ -420,13 +427,14 @@ class _GeometryFM(_Geometry):
         clear_cached_properties(self)
 
     @property
-    def element_table(self) -> np.ndarray:
+    def element_table(self) -> tuple[np.ndarray, ...]:
         """For each element: the 0-based indices of its nodes."""
-        return self._element_table
+        return tuple(_read_only(nodes) for nodes in self._element_table)
 
     @element_table.setter
     def element_table(self, value: np.ndarray) -> None:
-        self._element_table, self._element_ids = self._check_elements(value)
+        element_table, self._element_ids = self._check_elements(value)
+        self._element_table = _copy_element_table(element_table)
         clear_cached_properties(self)
 
     @property

--- a/src/mikeio/spatial/_FM_geometry.py
+++ b/src/mikeio/spatial/_FM_geometry.py
@@ -29,6 +29,7 @@ from ._FM_plot import (
     _set_xy_label_by_projection,  # TODO remove
     _to_polygons,  # TODO remove
 )
+from .._cache import clear_cached_properties
 from ._geometry import Geometry0D, GeometryPoint2D, _Geometry
 
 from ._grid_geometry import Grid2D
@@ -270,9 +271,9 @@ class _GeometryFM(_Geometry):
         reindex: bool = False,
     ) -> None:
         super().__init__(projection=projection)
-        self.node_coordinates = np.asarray(node_coordinates)
+        self._node_coordinates = np.asarray(node_coordinates)
 
-        n_nodes = len(self.node_coordinates)
+        n_nodes = len(self._node_coordinates)
         self._codes = (
             np.zeros((n_nodes,), dtype=int) if codes is None else np.asarray(codes)
         )
@@ -283,7 +284,7 @@ class _GeometryFM(_Geometry):
 
         self._type = dfsu_type
 
-        self.element_table, self._element_ids = self._check_elements(
+        self._element_table, self._element_ids = self._check_elements(
             element_table=element_table,  # type: ignore
             element_ids=element_ids,
             validate=validate,
@@ -336,7 +337,7 @@ class _GeometryFM(_Geometry):
             new_elem_nodes = np.zeros_like(elem_nodes)
             for jn, idx in enumerate(elem_nodes):
                 new_elem_nodes[jn] = node_dict[idx]
-            self.element_table[eid] = new_elem_nodes
+            self._element_table[eid] = new_elem_nodes
 
         self._node_ids = new_node_ids
         self._element_ids = new_element_ids
@@ -386,6 +387,44 @@ class _GeometryFM(_Geometry):
         return maxnodes
 
     @property
+    def node_coordinates(self) -> np.ndarray:
+        """N-by-3 array of node (x,y,z) coordinates.
+
+        The returned array is read-only, because element_coordinates and other
+        values are derived from it and cached. To change the coordinates,
+        assign a whole new array:
+
+        ```python
+        nc = geometry.node_coordinates.copy()
+        nc[:, 2] = new_bathymetry
+        geometry.node_coordinates = nc
+        ```
+        """
+        view = self._node_coordinates.view()
+        view.flags.writeable = False
+        return view
+
+    @node_coordinates.setter
+    def node_coordinates(self, value: ArrayLike) -> None:
+        nc = np.asarray(value)
+        if len(nc) != self.n_nodes:
+            raise ValueError(
+                f"node_coordinates must have length of nodes ({self.n_nodes})"
+            )
+        self._node_coordinates = nc
+        clear_cached_properties(self)
+
+    @property
+    def element_table(self) -> np.ndarray:
+        """For each element: the 0-based indices of its nodes."""
+        return self._element_table
+
+    @element_table.setter
+    def element_table(self, value: np.ndarray) -> None:
+        self._element_table, self._element_ids = self._check_elements(value)
+        clear_cached_properties(self)
+
+    @property
     def codes(self) -> np.ndarray:
         """Node codes of all nodes (0=water, 1=land, 2...=open boundaries)."""
         return self._codes
@@ -395,6 +434,7 @@ class _GeometryFM(_Geometry):
         if len(v) != self.n_nodes:
             raise ValueError(f"codes must have length of nodes ({self.n_nodes})")
         self._codes = np.array(v, dtype=np.int32)
+        clear_cached_properties(self)
 
     @property
     def boundary_codes(self) -> list[int]:
@@ -658,8 +698,7 @@ class GeometryFM2D(_GeometryFM):
 
             # step 2: if not, then try second nearest point
             if not element_found and self.n_elements > 1:
-                candidate = few_nearest[k, 1]
-                assert np.isscalar(candidate)
+                candidate = int(few_nearest[k, 1])  # a single element id
                 nodes = self.element_table[candidate]
                 element_found = self._point_in_polygon(
                     nc[nodes, 0], nc[nodes, 1], coords[k, 0], coords[k, 1]

--- a/src/mikeio/spatial/_FM_geometry.py
+++ b/src/mikeio/spatial/_FM_geometry.py
@@ -256,6 +256,13 @@ class GeometryFMPlotter:
             return "equal"
 
 
+def _read_only(values: np.ndarray) -> np.ndarray:
+    """A view of values that cannot be modified in place."""
+    view = values.view()
+    view.flags.writeable = False
+    return view
+
+
 class _GeometryFM(_Geometry):
     def __init__(
         self,
@@ -400,9 +407,7 @@ class _GeometryFM(_Geometry):
         geometry.node_coordinates = nc
         ```
         """
-        view = self._node_coordinates.view()
-        view.flags.writeable = False
-        return view
+        return _read_only(self._node_coordinates)
 
     @node_coordinates.setter
     def node_coordinates(self, value: ArrayLike) -> None:
@@ -426,8 +431,11 @@ class _GeometryFM(_Geometry):
 
     @property
     def codes(self) -> np.ndarray:
-        """Node codes of all nodes (0=water, 1=land, 2...=open boundaries)."""
-        return self._codes
+        """Node codes of all nodes (0=water, 1=land, 2...=open boundaries).
+
+        Read-only (as node_coordinates); assign a new array to change them.
+        """
+        return _read_only(self._codes)
 
     @codes.setter
     def codes(self, v: np.ndarray) -> None:

--- a/src/mikeio/spatial/_FM_geometry_layered.py
+++ b/src/mikeio/spatial/_FM_geometry_layered.py
@@ -259,13 +259,14 @@ class _GeometryFMLayered(_GeometryFM):
         # TODO extract method
         # Fix z-coordinate for sigma-z:
         if self._type == DfsuFileType.Dfsu3DSigmaZ:
-            zn = geom.node_coordinates[:, 2].copy()
+            nc = geom.node_coordinates.copy()
+            zn = nc[:, 2]
             for j, elem_nodes in enumerate(geom.element_table):
                 elem_nodes3d = self.element_table[self.bottom_elements[j]]
                 for jn in range(len(elem_nodes)):
                     znj_3d = self.node_coordinates[elem_nodes3d[jn], 2]
                     zn[elem_nodes[jn]] = min(zn[elem_nodes[jn]], znj_3d)
-            geom.node_coordinates[:, 2] = zn
+            geom.node_coordinates = nc
 
         return geom
 
@@ -728,7 +729,7 @@ class GeometryFMVerticalColumn(GeometryFM3D):
     @cached_property
     def _idx_e(self) -> np.ndarray:
         """Node indices per element as a 2D array."""
-        return np.stack(self.element_table)
+        return np.stack(list(self.element_table))
 
     @cached_property
     def _idx_f(self) -> np.ndarray:

--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -453,6 +453,7 @@ class Grid2D(_Geometry):
     _projstr: str
     _origin: tuple[float, float]
     _orientation: float
+    is_spectral: bool
 
     def __init__(
         self,
@@ -492,9 +493,8 @@ class Grid2D(_Geometry):
             dy = self._dx if dy is None else dy
             self._y0, self._dy, self._ny = _parse_grid_axis("y", y, y0, dy, ny)
 
-        # read-only: both change how the grid is interpreted and written to file
-        self._is_spectral = is_spectral
-        self._is_vertical = is_vertical
+        self.is_spectral = is_spectral
+        self.is_vertical = is_vertical
 
         self.plot = Grid2DPlotter(self)
 
@@ -502,16 +502,6 @@ class Grid2D(_Geometry):
     def dims(self) -> tuple[str, ...]:
         """Named array dimensions of data on this grid."""
         return ("y", "x")
-
-    @property
-    def is_spectral(self) -> bool:
-        """Is this a spectral grid (directions and frequencies)?"""
-        return self._is_spectral
-
-    @property
-    def is_vertical(self) -> bool:
-        """Is this a vertical grid (a vertical slice)?"""
-        return self._is_vertical
 
     @property
     def _is_rotated(self) -> Any:

--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -453,7 +453,6 @@ class Grid2D(_Geometry):
     _projstr: str
     _origin: tuple[float, float]
     _orientation: float
-    is_spectral: bool
 
     def __init__(
         self,
@@ -493,8 +492,9 @@ class Grid2D(_Geometry):
             dy = self._dx if dy is None else dy
             self._y0, self._dy, self._ny = _parse_grid_axis("y", y, y0, dy, ny)
 
-        self.is_spectral = is_spectral
-        self.is_vertical = is_vertical
+        # read-only: both change how the grid is interpreted and written to file
+        self._is_spectral = is_spectral
+        self._is_vertical = is_vertical
 
         self.plot = Grid2DPlotter(self)
 
@@ -502,6 +502,16 @@ class Grid2D(_Geometry):
     def dims(self) -> tuple[str, ...]:
         """Named array dimensions of data on this grid."""
         return ("y", "x")
+
+    @property
+    def is_spectral(self) -> bool:
+        """Is this a spectral grid (directions and frequencies)?"""
+        return self._is_spectral
+
+    @property
+    def is_vertical(self) -> bool:
+        """Is this a vertical grid (a vertical slice)?"""
+        return self._is_vertical
 
     @property
     def _is_rotated(self) -> Any:
@@ -1060,7 +1070,9 @@ class Grid2D(_Geometry):
                     raise ValueError(
                         "z must either be scalar or have length of nodes ((nx+1)*(ny+1))"
                     )
-            g.node_coordinates[:, 2] = z
+            nc = g.node_coordinates.copy()
+            nc[:, 2] = z
+            g.node_coordinates = nc
         g.to_mesh(outfilename=outfilename)
 
     def reduce(self, axis: str | tuple[str, ...]) -> Grid1D | Geometry0D:

--- a/tests/test_dataarray.py
+++ b/tests/test_dataarray.py
@@ -7,6 +7,7 @@ import pytest
 
 import mikeio
 from mikeio import EUMType, EUMUnit, ItemInfo, Mesh, DataArray
+from mikeio.dataset._data_plot import DataArrayPlotterGrid2D
 from mikeio.dfsu import DfsuSpectral
 from mikeio.exceptions import OutsideModelDomainError
 
@@ -1487,3 +1488,39 @@ def test_axis_spatial_deprecated() -> None:
         result = da.mean(axis="spatial")
     assert result.shape == (3,)
     assert result.dims == ("time",)
+
+
+def test_setting_time_of_wrong_length_is_rejected() -> None:
+    da = mikeio.DataArray(
+        data=np.zeros((3, 2)),
+        time=pd.date_range("2000-01-01", periods=3, freq="h"),
+        geometry=mikeio.Grid1D(nx=2, dx=1.0),
+    )
+    with pytest.raises(ValueError, match="Number of timesteps"):
+        da.time = pd.date_range("2000-01-01", periods=2, freq="h")
+
+    assert da.n_timesteps == 3
+
+
+def test_setting_time_updates_derived_values() -> None:
+    da = mikeio.DataArray(
+        data=np.zeros(3),
+        time=pd.DatetimeIndex(["2000-01-01", "2000-01-02", "2000-01-04"]),
+    )
+    assert da.timestep == 1.0  # not equidistant, so the dummy dt is returned
+
+    da.time = pd.date_range("2000-01-01", periods=3, freq="D")
+
+    # is_equidistant is cached; the setter must have dropped the cached answer
+    assert da.timestep == 24 * 3600
+    assert da.start_time == datetime(2000, 1, 1)
+
+
+def test_setting_geometry_updates_dims_and_plotter() -> None:
+    da = mikeio.read("tests/testdata/HD2D.dfsu")[0]
+    assert da.dims == ("time", "element")
+
+    da.geometry = mikeio.Grid2D(nx=884, ny=9, dx=1.0)
+
+    assert da.dims == ("time", "y", "x")
+    assert isinstance(da.plot, DataArrayPlotterGrid2D)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1225,6 +1225,19 @@ def test_renamed_dataset_has_updated_attributes(ds1: mikeio.Dataset) -> None:
     assert isinstance(ds2.Baz, mikeio.DataArray)
 
 
+def test_duplicate_item_names_raise_on_name_based_access(ds1: mikeio.Dataset) -> None:
+    ds1[0].name = ds1[1].name
+
+    with pytest.raises(ValueError, match="duplicate item names"):
+        _ = ds1["Bar"]
+
+    with pytest.raises(AttributeError, match="ambiguous"):
+        _ = ds1.Bar  # type: ignore[attr-defined]
+
+    with pytest.raises(ValueError, match="duplicate item names"):
+        ds1.fillna(0.0)
+
+
 def test_merge_by_item() -> None:
     ds1 = mikeio.read("tests/testdata/tide1.dfs1")
     ds2 = mikeio.read("tests/testdata/tide1.dfs1")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -223,8 +223,7 @@ def test_aggregate_over_items_produces_method_named_item() -> None:
 
 
 def test_rename_item_into_reserved_name() -> None:
-    # rename routes through _del_name_attr (old name) and _set_name_attr (new
-    # name); renaming an item to a method-like name must not shadow the method.
+    # renaming an item to a method-like name must not shadow the method
     time = pd.date_range(start=datetime(2000, 1, 1), freq="s", periods=3)
     ds = mikeio.Dataset([mikeio.DataArray(name="Foo", data=np.ones(3), time=time)])
 
@@ -236,9 +235,7 @@ def test_rename_item_into_reserved_name() -> None:
 
 def test_init_instance_attrs_are_collision_protected() -> None:
     # Drift guard: every non-item attribute __init__ sets on the instance (plot,
-    # title, ...) must be protected from being clobbered by an item of the same
-    # name. The reservation list is maintained by hand; if a new instance
-    # attribute is added to __init__ without reserving it, this test fails.
+    # title, ...) must be reachable, not clobbered by an item of the same name.
     time = pd.date_range(start=datetime(2000, 1, 1), freq="s", periods=3)
     base = mikeio.Dataset([mikeio.DataArray(name="Foo", data=np.ones(3), time=time)])
     # instance attributes that are not the item dict and not items themselves
@@ -1664,3 +1661,18 @@ def test_title_not_in_repr_when_empty() -> None:
         items=[ItemInfo("X")],
     )
     assert "title:" not in repr(ds)
+
+
+def test_renaming_a_dataarray_keeps_the_dataset_consistent() -> None:
+    # the Dataset looks item names up in the DataArrays, so a rename cannot
+    # leave it indexing by the old name
+    ds = mikeio.read("tests/testdata/HD2D.dfsu")
+    old_name = ds[0].name
+
+    ds[0].name = "Elevation"
+
+    assert ds.names[0] == "Elevation"
+    assert ds["Elevation"] is ds[0]
+    assert ds.Elevation is ds[0]
+    with pytest.raises(KeyError):
+        ds[old_name]

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -400,8 +400,10 @@ def test_properties_pt_spectrum_linearf(dfs2_pt_spectrum_linearf: Dfs2) -> None:
     assert g.dy == 10
     assert g.orientation == 0
 
-    g.is_spectral = True
-    assert g.x[-1] == 0.5  # still linear
+    g_spectral = mikeio.Grid2D(
+        x0=g.x[0], dx=g.dx, nx=g.nx, y0=g.y[0], dy=g.dy, ny=g.ny, is_spectral=True
+    )
+    assert g_spectral.x[-1] == 0.5  # still linear
 
 
 def test_dir_wave_spectra_relative_time_axis() -> None:

--- a/tests/test_dfs2.py
+++ b/tests/test_dfs2.py
@@ -400,10 +400,8 @@ def test_properties_pt_spectrum_linearf(dfs2_pt_spectrum_linearf: Dfs2) -> None:
     assert g.dy == 10
     assert g.orientation == 0
 
-    g_spectral = mikeio.Grid2D(
-        x0=g.x[0], dx=g.dx, nx=g.nx, y0=g.y[0], dy=g.dy, ny=g.ny, is_spectral=True
-    )
-    assert g_spectral.x[-1] == 0.5  # still linear
+    g.is_spectral = True
+    assert g.x[-1] == 0.5  # still linear
 
 
 def test_dir_wave_spectra_relative_time_axis() -> None:

--- a/tests/test_eum.py
+++ b/tests/test_eum.py
@@ -1,5 +1,7 @@
 import pytest
 from mikeio import EUMType, EUMUnit, ItemInfo
+from mikeio.eum._eum import DataValueType
+from mikeio.exceptions import InvalidDataValueType
 from mikeio.eum import ItemInfoList
 
 from mikecore.eum import eumItem, eumUnit
@@ -147,3 +149,25 @@ def test_default_name_from_type() -> None:
 def test_iteminfo_string_type_should_fail_with_helpful_message() -> None:
     with pytest.raises(ValueError):
         ItemInfo("Water level", "Water level")  # type: ignore
+
+
+def test_changing_type_keeps_unit_valid() -> None:
+    item = ItemInfo("WL", EUMType.Water_Level, EUMUnit.meter)
+
+    with pytest.raises(ValueError, match="not a correct unit"):
+        item.type = EUMType.Wind_speed  # meter is not a wind speed unit
+
+    assert item.type == EUMType.Water_Level
+    assert item.unit == EUMUnit.meter
+
+    item.type = EUMType.Bathymetry  # meter is fine here
+    assert item.type == EUMType.Bathymetry
+
+
+def test_data_value_type_can_be_set_as_string() -> None:
+    item = ItemInfo("WL", EUMType.Water_Level)
+    item.data_value_type = "Accumulated"
+    assert item.data_value_type == DataValueType.Accumulated
+
+    with pytest.raises(InvalidDataValueType):
+        item.data_value_type = "Cumulative"

--- a/tests/test_geometry_fm.py
+++ b/tests/test_geometry_fm.py
@@ -277,3 +277,32 @@ def test_equality_shifted_coords() -> None:
 
     g2 = GeometryFM2D(node_coordinates=nc2, element_table=el, projection="LONG/LAT")
     assert g != g2
+
+
+def test_node_coordinates_are_read_only() -> None:
+    g = GeometryFM2D(
+        node_coordinates=[(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0)],
+        element_table=[(0, 1, 2)],
+        projection="LONG/LAT",
+    )
+    # in-place edits would leave element_coordinates and friends stale
+    with pytest.raises(ValueError, match="read-only"):
+        g.node_coordinates[:, 2] = -3.0
+
+
+def test_setting_node_coordinates_updates_element_coordinates() -> None:
+    g = GeometryFM2D(
+        node_coordinates=[(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0)],
+        element_table=[(0, 1, 2)],
+        projection="LONG/LAT",
+    )
+    assert g.element_coordinates[0, 2] == 0.0
+
+    nc = g.node_coordinates.copy()
+    nc[:, 2] = -3.0
+    g.node_coordinates = nc
+
+    assert g.element_coordinates[0, 2] == -3.0
+
+    with pytest.raises(ValueError, match="length of nodes"):
+        g.node_coordinates = nc[:2]

--- a/tests/test_geometry_fm.py
+++ b/tests/test_geometry_fm.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from mikeio.exceptions import OutsideModelDomainError
@@ -306,3 +307,51 @@ def test_setting_node_coordinates_updates_element_coordinates() -> None:
 
     with pytest.raises(ValueError, match="length of nodes"):
         g.node_coordinates = nc[:2]
+
+
+def test_setting_node_coordinates_copies_input() -> None:
+    g = GeometryFM2D(
+        node_coordinates=[(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0)],
+        element_table=[(0, 1, 2)],
+        projection="LONG/LAT",
+    )
+    nc = g.node_coordinates.copy()
+    g.node_coordinates = nc
+    assert g.element_coordinates[0, 2] == 0.0
+
+    nc[:, 2] = -3.0
+
+    assert g.node_coordinates[0, 2] == 0.0
+    assert g.element_coordinates[0, 2] == 0.0
+
+
+def test_element_table_is_read_only() -> None:
+    g = GeometryFM2D(
+        node_coordinates=[(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0)],
+        element_table=[(0, 1, 2)],
+        projection="LONG/LAT",
+    )
+
+    with pytest.raises(ValueError, match="read-only"):
+        g.element_table[0][0] = 1
+
+
+def test_setting_element_table_copies_input() -> None:
+    g = GeometryFM2D(
+        node_coordinates=[
+            (0.0, 0.0, 0.0),
+            (1.0, 0.0, 0.0),
+            (1.0, 1.0, 0.0),
+            (0.0, 1.0, 0.0),
+        ],
+        element_table=[(0, 1, 2)],
+        projection="LONG/LAT",
+    )
+    el = [np.array([0, 1, 2]), np.array([0, 2, 3])]
+    g.element_table = el  # type: ignore[arg-type]
+    assert g.element_coordinates[1, 0] == pytest.approx(1.0 / 3.0)
+
+    el[1][0] = 1
+
+    assert g.element_table[1][0] == 0
+    assert g.element_coordinates[1, 0] == pytest.approx(1.0 / 3.0)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -103,21 +103,23 @@ def test_set_z_updates_element_coordinates(tri_mesh: Mesh) -> None:
 
 def test_set_codes(tri_mesh: Mesh) -> None:
     msh = tri_mesh
-    codes = msh.geometry.codes
     assert msh.geometry.codes[2] == 2
-    codes[codes == 2] = 7  # work directly on reference
-
-    assert msh.geometry.codes[2] == 7
 
     new_codes = msh.geometry.codes.copy()
-    new_codes[new_codes == 7] = 9
+    new_codes[new_codes == 2] = 9
     msh.geometry.codes = new_codes  # assign from copy
 
     assert msh.geometry.codes[2] == 9
 
+
+def test_codes_are_read_only(tri_mesh: Mesh) -> None:
+    # in-place edits would leave derived values (e.g. boundary_polygons) stale
+    with pytest.raises(ValueError, match="read-only"):
+        tri_mesh.geometry.codes[2] = 7
+
     with pytest.raises(ValueError):
         # not same length
-        msh.geometry.codes = codes[0:4]
+        tri_mesh.geometry.codes = tri_mesh.geometry.codes[0:4]
 
 
 def test_write(tri_mesh: Mesh, tmp_path: Path) -> None:

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -80,12 +80,25 @@ def test_get_land_node_coordinates(tri_mesh: Mesh) -> None:
 
 def test_set_z(tri_mesh: Mesh) -> None:
     msh = tri_mesh
-    zn = msh.node_coordinates[:, 2]
-    zn[zn < -3] = -3
+    nc = msh.node_coordinates.copy()
+    nc[nc[:, 2] < -3, 2] = -3
 
-    msh.node_coordinates[:, 2] = zn
-    zn = msh.node_coordinates[:, 2]
-    assert zn.min() == -3
+    msh.node_coordinates = nc
+    assert msh.node_coordinates[:, 2].min() == -3
+
+
+def test_node_coordinates_are_read_only(tri_mesh: Mesh) -> None:
+    # in-place edits would leave derived values (e.g. element_coordinates) stale
+    with pytest.raises(ValueError, match="read-only"):
+        tri_mesh.node_coordinates[:, 2] = -3
+
+
+def test_set_z_updates_element_coordinates(tri_mesh: Mesh) -> None:
+    msh = tri_mesh
+    assert msh.element_coordinates[:, 2].min() < -3
+
+    msh.zn = np.zeros_like(msh.zn)
+    assert msh.element_coordinates[:, 2].max() == 0.0
 
 
 def test_set_codes(tri_mesh: Mesh) -> None:


### PR DESCRIPTION
Several public attributes could be assigned or edited in place with no error, while values derived from them were cached or mirrored elsewhere. The result was a wrong number rather than an exception — the worst outcome for the many MIKE IO users who are engineers first and Python programmers second.

What could go wrong before this change:

- `da.time = pd.date_range(...)` with the wrong number of timestamps was accepted (the constructor checks it, assignment did not) and `to_dfs` then wrote a silently truncated file.
- `da.geometry = ...` left `dims`, `plot` and `z` pointing at the old geometry.
- `item.type = EUMType.Wind_speed` on a Water Level item in metres was accepted, although the `unit` setter refuses the same combination from the other side.
- `g.node_coordinates[:,2] = z` (the documented way to change bathymetry) left `element_coordinates`, `boundary_polygons` and the other cached values unchanged, and `g.node_coordinates = arr` accepted an array of the wrong length.
- `ds[0].name = "x"` renamed the item but not the Dataset's key for it, so `ds["x"]` raised `KeyError` while `ds[old_name]` still worked — and the written file used the new name.

These are now properties that validate and invalidate what they invalidate, `node_coordinates`/`codes` are handed out as read-only arrays, and the Dataset derives item names from the DataArrays instead of keeping a second copy. The name-mirroring rewrite also removes the hand-maintained list of reserved attribute names: `__getattr__` is only reached after normal attribute lookup fails, so a real member always wins over an item of the same name.

## Breaking changes

Code that edited these arrays in place must copy, modify and assign back:

```python
nc = geometry.node_coordinates.copy()
nc[:, 2] = new_bathymetry
geometry.node_coordinates = nc
```

- `GeometryFM*.node_coordinates` and `.codes` raise on in-place assignment (`Mesh.zn` and `Mesh.codes` are unaffected and remain the shortest route).
- `ItemInfo.type` rejects a type that the current unit is not valid for.
- `DataArray.time` rejects a time axis that does not match the data.

The [mesh user guide](https://dhi.github.io/mikeio/user-guide/mesh.html) is updated accordingly.
