### PR TITLE
Remove link to archived book-learn-mikeio-modelskill

### DIFF
--- a/docs/user-guide/getting-started.qmd
+++ b/docs/user-guide/getting-started.qmd
@@ -111,5 +111,4 @@ generic.concat(["fileA.dfs2", "fileB.dfs2"], "new_file.dfs2")
 ## {{< fa book >}} Additional resources
 
 * Online book: [Getting started with Dfs files in Python using MIKE IO](https://dhi.github.io/getting-started-with-mikeio)
-* Online book: [Python for marine modelers using MIKE IO and ModellSkill](https://dhi.github.io/book-learn-mikeio-modelskill)
 * [DFS file system specification](https://docs.mikepoweredbydhi.com/core_libraries/dfs/dfs-file-system)


### PR DESCRIPTION
`DHI/book-learn-mikeio-modelskill` has been archived and its GitHub Pages site unpublished, so the "Online book" link in the user guide now returns a 404:

https://dhi.github.io/book-learn-mikeio-modelskill

This removes that one bullet from `docs/user-guide/getting-started.qmd`. The adjacent link to [Getting started with dfs files in Python using MIKE IO](https://dhi.github.io/getting-started-with-mikeio) is unaffected — that site is still live.

The material itself is superseded by the 2026 ModelSkill course (DHI-internal); the archived repo's README now points there.

Docs-only change, no code touched, so `just test` / `just format` were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)