### PR TITLE
Drop the hand-written Grid1D/Grid2D attribute lists

### DIFF
--- a/docs/user-guide/dfs1.qmd
+++ b/docs/user-guide/dfs1.qmd
@@ -22,15 +22,7 @@ The spatial information is available in the `geometry` attribute (accessible fro
 ds.geometry
 ```
 
-Grid1D's primary properties and methods are: 
-
-* `x` 
-* `nx`
-* `dx`
-* `find_index()`
-* `isel()`
-
-See [API specification](`mikeio.Grid1D`) for details.
+See the [API reference](`mikeio.Grid1D`) for the full set of properties and methods.
 
 
 ## Creating a dfs1 file

--- a/docs/user-guide/dfs2.qmd
+++ b/docs/user-guide/dfs2.qmd
@@ -41,24 +41,7 @@ The spatial information is available in the `geometry` attribute (accessible fro
 ds.geometry
 ```
 
-Grid2D's primary properties and methods are: 
-
-* `x` 
-* `nx`
-* `dx`
-* `y`
-* `ny`
-* `dy`
-* `origin`
-* `projection`
-* `xy` 
-* `bbox`
-* `contains()`
-* `find_index()`
-* `isel()`
-* `to_mesh()`
-
-See [API specification](`mikeio.Grid2D`) for details.
+See the [API reference](`mikeio.Grid2D`) for the full set of properties and methods.
 
 
 ## Extract data at a point


### PR DESCRIPTION
Both the dfs1 and dfs2 pages print the geometry repr, then list the same property names as bare bullets, then link to the API reference that documents them properly. The middle step adds nothing to either neighbour — the repr already shows `x`, `nx`, `dx` with real values, and the API reference gives signatures and descriptions.

It is also a second source of truth. The names were copied by hand and nothing keeps them in step with the code, unlike the generated reference. `Grid2D`'s list advertises `contains()`, `bbox` and `xy`, which `Grid3D` does not have (#1050) — so the same list pattern on the dfs3 page would have been quietly wrong from the start.

### Where these came from

They date from the Sphinx-era pages: [`3f035cca`](https://github.com/DHI/mikeio/commit/3f035cca) (June 2022) added the Grid2D list to `docs/dfs2.md`, where the closing line read *"See API specification **below** for details"* — the API reference was rendered further down the same page, so the list worked as a hand-written table of contents for it.

When the docs moved to Quarto in [`f4aedf5f`](https://github.com/DHI/mikeio/commit/f4aedf5f), the API reference became a separate page. "Below" became a link elsewhere, and the list lost the job it was doing. Nobody removed it.

The equivalent list on the new dfs3 page is removed in #1046, which replaces it with the things a reader cannot infer from the repr — that a single-layer dfs3 reads as a `Grid2D`, and that `layers="top"`/`"bottom"` pick the highest and lowest cell holding data in each column rather than fixed layer numbers.

Both pages were rendered to check the surrounding prose still reads correctly.