### PR TITLE
Add spectral dfsu user guide page

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -45,6 +45,7 @@ website:
         - user-guide/dfs1.qmd
         - user-guide/dfs2.qmd
         - user-guide/dfsu.qmd
+        - user-guide/dfsu-spectral.qmd
         - user-guide/mesh.qmd
         - user-guide/eum.qmd
         - user-guide/statistics.qmd

--- a/docs/user-guide/dfsu-spectral.qmd
+++ b/docs/user-guide/dfsu-spectral.qmd
@@ -1,0 +1,118 @@
+---
+title: Dfsu - spectral data
+---
+
+MIKE 21 SW can output the full wave spectrum, not just integrated parameters such as Hm0. Those files are dfsu files with up to two extra axes, **frequency** and **direction**, and they come in three shapes:
+
+* **point** — the spectrum at a single position
+* **line** — spectra along a line crossing the domain
+* **area** — spectra at every element of a mesh
+
+The geometry tells you which one you have, and `is_spectral` distinguishes these files from ordinary dfsu output.
+
+```{python}
+import numpy as np
+import mikeio
+
+da = mikeio.read("../data/spectra/pt_spectra.dfsu")[0]
+da
+```
+
+```{python}
+da.dims
+```
+
+The frequency and direction axes are on the geometry:
+
+```{python}
+np.round(da.geometry.frequencies[:5], 4), np.round(da.geometry.directions[:5], 1)
+```
+
+## Point spectra
+
+Plotting a point spectrum gives a polar plot of the first time step:
+
+```{python}
+da.plot();
+```
+
+`plot.patch` takes the same arguments and returns the axes, so the plot can be adjusted — here the radial limit is capped and the spokes labelled with the actual direction values:
+
+```{python}
+ax = da.plot.patch(rmax=8)
+dird = np.round(da.geometry.directions, 2)
+ax.set_thetagrids(dird, labels=dird);
+```
+
+## Line spectra
+
+Line spectra are **node-based**, unlike most dfsu files, which store values per element. The extra `node` axis is selected with `isel`:
+
+```{python}
+da = mikeio.read("../data/spectra/line_spectra.dfsu").Energy_density
+da.dims
+```
+
+```{python}
+spec = da[0].isel(node=3)
+spec.plot(cmap="Greys", rmax=8, r_as_periods=True);
+```
+
+`r_as_periods=True` labels the radial axis with wave periods rather than frequencies.
+
+Plotting the whole line, rather than one node, gives the integrated Hm0 along it:
+
+```{python}
+da.plot(title="Hm0 on a line crossing the domain");
+```
+
+## Area spectra
+
+For an area file the default plot is again the integrated Hm0, over the mesh:
+
+```{python}
+da = mikeio.read("../data/spectra/area_spectra.dfsu", items="Energy density")[0]
+da.plot();
+```
+
+Selecting a position with `sel` gives back the spectrum there, which plots as a polar plot:
+
+```{python}
+da_pt = da.sel(x=2.9, y=52.5)
+da_pt.plot(rmax=9);
+```
+
+## Directional sectors
+
+MIKE 21 SW can discretise directions over a sector rather than the full circle. Such files are read the same way, and the plot covers only the sector:
+
+```{python}
+da = mikeio.read("../data/spectra/MIKE21SW_dir_sector_area_spectra.dfsu", time=0)["Energy density"]
+da.isel(element=0).plot(rmax=10, vmin=0);
+```
+
+## Frequency and direction spectra
+
+A file need not carry both axes. Frequency spectra have no directions, and directional spectra have no frequencies; `n_frequencies` and `n_directions` report which case you are in, one of them being zero.
+
+```{python}
+da = mikeio.read("../data/spectra/pt_freq_spectra.dfsu")[0]
+da.geometry.n_frequencies, da.geometry.n_directions
+```
+
+With no directions to plot around a circle, the plot becomes an ordinary spectrum against frequency:
+
+```{python}
+da.sel(time="2017-10-27 02:00").plot();
+```
+
+The reverse case, a directional spectrum with no frequency axis:
+
+```{python}
+da = mikeio.read("../data/spectra/line_dir_spectra.dfsu")[0]
+da.geometry.n_frequencies, da.geometry.n_directions
+```
+
+```{python}
+da.isel(time=0).isel(node=5).plot();
+```


### PR DESCRIPTION
Spectral dfsu has no worked example anywhere in the documentation. [`user-guide/dfsu.qmd`](https://dhi.github.io/mikeio/user-guide/dfsu.html) mentions spectral files three times — all prose describing file types — plus a link to the `DfsuSpectral` class. Nothing shows how to read one, and nothing shows a polar plot.

Until now the two spectral notebooks were the only real documentation of it. They are removed in #1045, so this closes the largest gap tracked in #887.

The page covers what a reader cannot get from the API reference:

- the three shapes MIKE 21 SW produces — point, line and area — and that `is_spectral` is what distinguishes these files
- polar plotting, and adjusting it via `plot.patch` (radial cap, direction spokes, `r_as_periods`)
- that **line spectra are node-based**, unlike most dfsu files, so the extra axis is selected with `isel(node=...)`
- that the default plot for a line or area file is the integrated Hm0, not a spectrum — you get a spectrum by selecting a position first
- directional-sector runs, where directions cover only part of the circle
- frequency-only and direction-only files, where one of `n_frequencies`/`n_directions` is zero

Every one of the 15 code blocks was executed against `tests/testdata/spectra/` and the page renders with 9 figures and no errors in the output.

Note the file is named `dfsu-spectral.qmd` to sit next to `dfsu.qmd` in the sidebar. If #1052 leads to a restructure this page moves with the rest, but it should not wait on that.