### PR TITLE
Update design philosophy: docs are now the primary learning resource

### DIFF
--- a/docs/design.qmd
+++ b/docs/design.qmd
@@ -19,12 +19,7 @@ $ pip install mikeio
 ```
 
 ## {{< fa book >}} Easy to get started
-By providing many examples to cut/paste from.
-
-Examples are available in two forms:
-
-* [Example notebooks](examples/index.qmd)
-* [Unit tests](https://github.com/DHI/mikeio/tree/main/tests)
+Comprehensive documentation with user guides, tutorials, and runnable examples organized by file type and task. You're reading it right now.
 
 
 ## {{< fa layer-group >}} Abstraction over mikecore


### PR DESCRIPTION
The 'Easy to get started' section in the design philosophy previously pointed to example notebooks and unit tests as learning resources. Documentation is now the primary source, with comprehensive user guides and examples organized by file type and task.

The change also adds a self-referential note: "You're reading it right now."