### PR TITLE
Raise a clear error instead of crashing when a file cannot be written

### DIFF
--- a/src/mikeio/_path.py
+++ b/src/mikeio/_path.py
@@ -32,3 +32,44 @@ def normalize_path(filename: str | Path) -> str:
 
     """
     return os.path.expanduser(os.fspath(filename))
+
+
+def normalize_output_path(filename: str | Path) -> str:
+    """Convert a path to write to a string, expanding a leading `~`.
+
+    Same as normalize_path, but also checks that the file can be created,
+    creating missing parent directories if necessary. The underlying
+    *mikecore* library does not check this: writing to a path that cannot be
+    created crashes the interpreter.
+
+    Parameters
+    ----------
+    filename
+        Path to normalize.
+
+    Returns
+    -------
+    str
+        The path as a string, with a leading `~` expanded.
+
+    Raises
+    ------
+    IsADirectoryError
+        If the path is an existing directory.
+    OSError
+        If the file cannot be created, e.g. in a read-only directory.
+
+    """
+    path = normalize_path(filename)
+
+    if os.path.isdir(path):
+        raise IsADirectoryError(f"Cannot write to {path}, it is a directory")
+
+    folder = os.path.dirname(os.path.abspath(path))
+    os.makedirs(folder, exist_ok=True)
+
+    # mikecore fails silently on a path it cannot create, so create it here
+    with open(path, "ab"):
+        pass
+
+    return path

--- a/src/mikeio/dfs/_dfs0.py
+++ b/src/mikeio/dfs/_dfs0.py
@@ -27,7 +27,7 @@ from ._custom_blocks import (
 from ..eum import EUMType, EUMUnit, ItemInfo, TimeStepUnit, ItemInfoList
 from .._time import DateTimeSelector
 from .._options import _item_txt
-from .._path import normalize_path
+from .._path import normalize_output_path, normalize_path
 
 
 def write_dfs0(
@@ -36,7 +36,7 @@ def write_dfs0(
     title: str = "",
     dtype: DfsSimpleType | np.float32 | np.float64 = DfsSimpleType.Float,
 ) -> None:
-    filename = normalize_path(filename)
+    filename = normalize_output_path(filename)
 
     factory = DfsFactory()
     builder = DfsBuilder.Create(title, "mikeio", __dfs_version__)

--- a/src/mikeio/dfs/_dfs1.py
+++ b/src/mikeio/dfs/_dfs1.py
@@ -24,7 +24,7 @@ from ._custom_blocks import readonly_custom_blocks, write_custom_blocks
 from ..eum import TimeStepUnit
 from ..spatial import Grid1D
 from .._options import _show_progress
-from .._path import normalize_path
+from .._path import normalize_output_path
 
 
 def write_dfs1(filename: str | Path, ds: Dataset, title: str = "") -> None:
@@ -70,10 +70,7 @@ def _write_dfs1_header(filename: str | Path, ds: Dataset, title: str) -> DfsFile
 
     write_custom_blocks(builder, ds.custom_blocks)
 
-    try:
-        builder.CreateFile(normalize_path(filename))
-    except OSError:
-        print("cannot create dfs file: ", filename)
+    builder.CreateFile(normalize_output_path(filename))
 
     return builder.GetFile()
 

--- a/src/mikeio/dfs/_dfs2.py
+++ b/src/mikeio/dfs/_dfs2.py
@@ -28,7 +28,7 @@ from ._custom_blocks import readonly_custom_blocks, write_custom_blocks
 from ..eum import TimeStepUnit
 from ..spatial import Grid2D
 from .._options import _show_progress
-from .._path import normalize_path
+from .._path import normalize_output_path, normalize_path
 
 
 def write_dfs2(filename: str | Path, ds: Dataset, title: str = "") -> None:
@@ -89,10 +89,7 @@ def _write_dfs2_header(filename: str | Path, ds: Dataset, title: str = "") -> Df
 
     write_custom_blocks(builder, ds.custom_blocks)
 
-    try:
-        builder.CreateFile(normalize_path(filename))
-    except OSError:
-        print("cannot create dfs file: ", filename)
+    builder.CreateFile(normalize_output_path(filename))
 
     return builder.GetFile()
 

--- a/src/mikeio/dfs/_dfs3.py
+++ b/src/mikeio/dfs/_dfs3.py
@@ -28,7 +28,7 @@ from ._custom_blocks import readonly_custom_blocks, write_custom_blocks
 from ..eum import TimeStepUnit
 from ..spatial import Grid3D
 from .._options import _show_progress
-from .._path import normalize_path
+from .._path import normalize_output_path, normalize_path
 
 
 def write_dfs3(filename: str | Path, ds: Dataset, title: str = "") -> None:
@@ -97,10 +97,7 @@ def _write_dfs3_header(filename: str | Path, ds: Dataset, title: str) -> DfsFile
 
     write_custom_blocks(builder, ds.custom_blocks)
 
-    try:
-        builder.CreateFile(normalize_path(filename))
-    except OSError:
-        print("cannot create dfs file: ", filename)
+    builder.CreateFile(normalize_output_path(filename))
 
     return builder.GetFile()
 

--- a/src/mikeio/dfsu/_dfsu.py
+++ b/src/mikeio/dfsu/_dfsu.py
@@ -34,7 +34,7 @@ from .._track import _extract_track
 from ._topology import get_elements_from_source, get_nodes_from_source
 from ..eum import ItemInfo, TimeStepUnit
 from .._options import _item_txt, _show_progress
-from .._path import normalize_path
+from .._path import normalize_output_path, normalize_path
 
 
 def write_dfsu(filename: str | Path, data: Dataset, title: str = "") -> None:
@@ -50,7 +50,7 @@ def write_dfsu(filename: str | Path, data: Dataset, title: str = "") -> None:
         Title of the dfsu file (default: "")
 
     """
-    filename = normalize_path(filename)
+    filename = normalize_output_path(filename)
 
     geometry = data.geometry
     dfsu_filetype = DfsuFileType.Dfsu2D

--- a/src/mikeio/generic.py
+++ b/src/mikeio/generic.py
@@ -36,7 +36,7 @@ from . import __dfs_version__
 from ._options import _show_progress
 from .dfs._dfs import _get_item_info, _valid_item_numbers
 from .eum import EUMType, EUMUnit, ItemInfo
-from ._path import normalize_path
+from ._path import normalize_output_path, normalize_path
 
 TimeAxis = Union[
     DfsEqTimeAxis, DfsNonEqTimeAxis, DfsEqCalendarAxis, DfsNonEqCalendarAxis
@@ -99,7 +99,7 @@ def _clone(
     datatype: int | None = None,
 ) -> DfsFile:
     infilename = normalize_path(infilename)
-    outfilename = normalize_path(outfilename)
+    outfilename = normalize_output_path(outfilename)
     source = DfsFileFactory.DfsGenericOpen(infilename)
     fi = source.FileInfo
 
@@ -183,7 +183,7 @@ def scale(
 
     """
     infilename = normalize_path(infilename)
-    outfilename = normalize_path(outfilename)
+    outfilename = normalize_output_path(outfilename)
     copyfile(infilename, outfilename)
     dfs = DfsFileFactory.DfsGenericOpenEdit(outfilename)
 
@@ -233,7 +233,7 @@ def fill_corrupt(
 
     """
     infilename = normalize_path(infilename)
-    outfilename = normalize_path(outfilename)
+    outfilename = normalize_output_path(outfilename)
     dfs_i = DfsFileFactory.DfsGenericOpen(infilename)
 
     item_numbers = _valid_item_numbers(dfs_i.ItemInfo, items)
@@ -296,7 +296,7 @@ def _process_dfs_files(
     """
     infilename_a = normalize_path(infilename_a)
     infilename_b = normalize_path(infilename_b)
-    outfilename = normalize_path(outfilename)
+    outfilename = normalize_output_path(outfilename)
     copyfile(infilename_a, outfilename)
 
     dfs_i_a = DfsFileFactory.DfsGenericOpen(infilename_a)
@@ -404,7 +404,7 @@ def concat(
 
     """
     infilenames = [normalize_path(f) for f in infilenames]
-    outfilename = normalize_path(outfilename)
+    outfilename = normalize_output_path(outfilename)
     # fast path for Dfs0
     suffix = pathlib.Path(infilenames[0]).suffix
     if suffix == ".dfs0":
@@ -591,7 +591,7 @@ def extract(
 
     """
     infilename = normalize_path(infilename)
-    outfilename = normalize_path(outfilename)
+    outfilename = normalize_output_path(outfilename)
     dfs_i = DfsFileFactory.DfsGenericOpenEdit(infilename)
 
     is_layered_dfsu = dfs_i.ItemInfo[0].Name == "Z coordinate"
@@ -795,7 +795,7 @@ def avg_time(
 
     """
     infilename = normalize_path(infilename)
-    outfilename = normalize_path(outfilename)
+    outfilename = normalize_output_path(outfilename)
     dfs_i = DfsFileFactory.DfsGenericOpen(infilename)
 
     dfs_o = _clone(infilename, outfilename)
@@ -883,7 +883,7 @@ def quantile(
 
     """
     infilename = normalize_path(infilename)
-    outfilename = normalize_path(outfilename)
+    outfilename = normalize_output_path(outfilename)
     func = np.nanquantile if skipna else np.quantile
 
     dfs_i = DfsFileFactory.DfsGenericOpen(infilename)
@@ -1023,7 +1023,7 @@ def change_datatype(
 
     """
     infilename = normalize_path(infilename)
-    outfilename = normalize_path(outfilename)
+    outfilename = normalize_output_path(outfilename)
     dfs_out = _clone(infilename, outfilename, datatype=datatype)
     dfs_in = DfsFileFactory.DfsGenericOpen(infilename)
 
@@ -1131,7 +1131,7 @@ def transform(
 
     """
     infilename = normalize_path(infilename)
-    outfilename = normalize_path(outfilename)
+    outfilename = normalize_output_path(outfilename)
     dfs_i = DfsFileFactory.DfsGenericOpen(infilename)
 
     item_numbers = _valid_item_numbers(dfs_i.ItemInfo)

--- a/src/mikeio/spatial/_FM_geometry.py
+++ b/src/mikeio/spatial/_FM_geometry.py
@@ -33,7 +33,7 @@ from ._geometry import Geometry0D, GeometryPoint2D, _Geometry
 
 from ._grid_geometry import Grid2D
 from ._distance import xy_to_bbox
-from .._path import normalize_path
+from .._path import normalize_output_path
 
 
 if TYPE_CHECKING:
@@ -1140,7 +1140,7 @@ class GeometryFM2D(_GeometryFM):
 
         """
         builder = MeshBuilder()
-        outfilename = normalize_path(outfilename)
+        outfilename = normalize_output_path(outfilename)
 
         nc = self.node_coordinates
         builder.SetNodes(nc[:, 0], nc[:, 1], nc[:, 2], self.codes)

--- a/tests/test_write_path_validation.py
+++ b/tests/test_write_path_validation.py
@@ -1,0 +1,70 @@
+"""Tests that writing to a path that cannot be created raises a clear error.
+
+The underlying mikecore library does not check the output path: writing to a
+path it cannot create used to crash the interpreter.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import mikeio
+from mikeio import generic
+
+FILES_BY_EXTENSION = {
+    ".dfs0": "da_diagnostic.dfs0",
+    ".dfs1": "tide1.dfs1",
+    ".dfs2": "gebco_sound.dfs2",
+    ".dfs3": "test_dfs3.dfs3",
+    ".dfsu": "oresundHD_run1.dfsu",
+}
+
+
+@pytest.mark.parametrize("extension", list(FILES_BY_EXTENSION))
+def test_to_dfs_creates_missing_directory(tmp_path: Path, extension: str) -> None:
+    ds = mikeio.read("tests/testdata/" + FILES_BY_EXTENSION[extension])
+    outfilename = tmp_path / "new_folder" / f"out{extension}"
+
+    ds.to_dfs(outfilename)
+
+    assert outfilename.exists()
+
+
+@pytest.mark.parametrize("extension", list(FILES_BY_EXTENSION))
+def test_to_dfs_impossible_path(tmp_path: Path, extension: str) -> None:
+    ds = mikeio.read("tests/testdata/" + FILES_BY_EXTENSION[extension])
+    not_a_folder = tmp_path / "a_file"
+    not_a_folder.touch()
+
+    with pytest.raises(OSError):
+        ds.to_dfs(not_a_folder / f"out{extension}")
+
+
+def test_to_dfs_existing_directory(tmp_path: Path) -> None:
+    ds = mikeio.read("tests/testdata/gebco_sound.dfs2")
+    folder = tmp_path / "out.dfs2"
+    folder.mkdir()
+
+    with pytest.raises(IsADirectoryError):
+        ds.to_dfs(folder)
+
+
+def test_mesh_write_impossible_path(tmp_path: Path) -> None:
+    msh = mikeio.Mesh("tests/testdata/odense_rough.mesh")
+    not_a_folder = tmp_path / "a_file"
+    not_a_folder.touch()
+
+    with pytest.raises(OSError):
+        msh.write(not_a_folder / "out.mesh")
+
+
+def test_generic_scale_impossible_path(tmp_path: Path) -> None:
+    not_a_folder = tmp_path / "a_file"
+    not_a_folder.touch()
+
+    with pytest.raises(OSError):
+        generic.scale(
+            "tests/testdata/gebco_sound.dfs2",
+            not_a_folder / "out.dfs2",
+            factor=2.0,
+        )


### PR DESCRIPTION
Writing to a path mikecore cannot create — a read-only directory, or a path under a regular file — segfaults the interpreter: `CreateFile` fails silently and the following write dereferences a file that was never created. A typo in an output folder should not take down the process, least of all at the end of a long script that has already done its work.

Output paths are now normalized where read paths already are, at the API edge:

- missing parent directories are created (mikecore already did this, so no behaviour change),
- a path that cannot be created raises `OSError`,
- an existing directory raises `IsADirectoryError`.

This also removes the `except OSError: print("cannot create dfs file: ", ...)` in the dfs1/2/3 writers, which reported the problem and then carried on into the crash.