### PR TITLE
Docstrings for the whole public API, guarded by a test

### DIFF
--- a/src/mikeio/__init__.py
+++ b/src/mikeio/__init__.py
@@ -46,14 +46,15 @@ def read(
 
     * Dfs2: area
     * Dfs3: layers
-    * Dfsu-2d: (x,y), elements, area
-    * Dfsu-layered: (xy,z), elements, area, layers
+    * Dfsu-2d: (x,y), elements, area, error_bad_data, fill_bad_data_value
+    * Dfsu-layered: (xy,z), elements, area, layers, error_bad_data,
+      fill_bad_data_value
 
     Parameters
     ----------
     filename
         Full path and file name to the dfs file.
-        A leading ``~`` is expanded to the user's home directory.
+        A leading `~` is expanded to the user's home directory.
     items: int, str, list[int] or list[str], optional
         Read only selected items, by number (0-based), or by name,
         by default None (=all)
@@ -71,13 +72,9 @@ def read(
     layers: int, str or sequence, optional
         Dfs3/Dfsu-layered: read only data from specific layers,
         by default None (=all layers)
-    error_bad_data: bool, optional
-            raise error if data is corrupt, by default True,
-    fill_bad_data_value:
-            fill value for to impute corrupt data, used in conjunction with error_bad_data=False
-            default np.nan
     **kwargs: Any
-        Additional keyword arguments
+        Additional keyword arguments, e.g. the file type specific arguments
+        listed above
 
     Returns
     -------
@@ -144,7 +141,7 @@ def open(
     ----------
     filename
         Full path and file name to the dfs file.
-        A leading ``~`` is expanded to the user's home directory.
+        A leading `~` is expanded to the user's home directory.
     **kwargs: Any
         Additional keyword arguments, e.g. *type="spectral"*
 

--- a/src/mikeio/_interpolation.py
+++ b/src/mikeio/_interpolation.py
@@ -50,6 +50,7 @@ class Interpolant:
         return get_idw_interpolant(distances, p)
 
     def interp1d(self, data: np.ndarray) -> np.ndarray:
+        """Interpolate a time series of 1d data, e.g. element values."""
         ids = self.ids
         weights = self.weights
         result = np.dot(data[:, ids], weights)

--- a/src/mikeio/_path.py
+++ b/src/mikeio/_path.py
@@ -7,12 +7,12 @@ from pathlib import Path
 
 
 def normalize_path(filename: str | Path) -> str:
-    """Convert a path-like object to a string, expanding a leading ``~``.
+    """Convert a path-like object to a string, expanding a leading `~`.
 
-    MIKE IO accepts both strings and :class:`pathlib.Path` objects, but the
+    MIKE IO accepts both strings and `pathlib.Path` objects, but the
     underlying *mikecore* library only understands strings and does not expand
-    ``~`` to the user's home directory. Normalizing paths at the public API
-    boundary makes MIKE IO behave like pandas and xarray, which expand ``~``
+    `~` to the user's home directory. Normalizing paths at the public API
+    boundary makes MIKE IO behave like pandas and xarray, which expand `~`
     for both reading and writing.
 
     Parameters
@@ -23,7 +23,7 @@ def normalize_path(filename: str | Path) -> str:
     Returns
     -------
     str
-        The path as a string, with a leading ``~`` expanded.
+        The path as a string, with a leading `~` expanded.
 
     Examples
     --------

--- a/src/mikeio/dataset/_data_plot.py
+++ b/src/mikeio/dataset/_data_plot.py
@@ -723,6 +723,8 @@ class DataArrayPlotterFMVerticalProfile(DataArrayPlotter):
 
 
 class DataArrayPlotterPointSpectrum(DataArrayPlotter):
+    """Plot a point spectrum, e.g. da.plot() on a spectral DataArray."""
+
     def __call__(
         self,
         ax: Axes | None = None,
@@ -740,14 +742,17 @@ class DataArrayPlotterPointSpectrum(DataArrayPlotter):
             raise ValueError("Spectrum could not be plotted")
 
     def patch(self, **kwargs: Any) -> Axes:
+        """Plot the 2d spectrum as colored patches."""
         kwargs["plot_type"] = "patch"
         return self._plot_2dspectrum(**kwargs)
 
     def contour(self, **kwargs: Any) -> Axes:
+        """Plot the 2d spectrum as contour lines."""
         kwargs["plot_type"] = "contour"
         return self._plot_2dspectrum(**kwargs)
 
     def contourf(self, **kwargs: Any) -> Axes:
+        """Plot the 2d spectrum as filled contours."""
         kwargs["plot_type"] = "contourf"
         return self._plot_2dspectrum(**kwargs)
 
@@ -867,6 +872,8 @@ def _calc_Hm0(da: DataArray) -> DataArray:
 
 
 class DataArrayPlotterLineSpectrum(DataArrayPlotterGrid1D):
+    """Plot significant wave height along a line of spectra."""
+
     def __init__(self, da: DataArray) -> None:
         if da.n_timesteps > 1:
             Hm0 = _calc_Hm0(da[0])
@@ -876,6 +883,8 @@ class DataArrayPlotterLineSpectrum(DataArrayPlotterGrid1D):
 
 
 class DataArrayPlotterAreaSpectrum(DataArrayPlotterFM):
+    """Plot significant wave height on a mesh of spectra."""
+
     def __init__(self, da: DataArray) -> None:
         if da.n_timesteps > 1:
             Hm0 = _calc_Hm0(da[0])

--- a/src/mikeio/dataset/_dataarray.py
+++ b/src/mikeio/dataset/_dataarray.py
@@ -507,6 +507,16 @@ class DataArray:
         return deepcopy(self)
 
     def squeeze(self) -> DataArray:
+        """Remove axes of length 1.
+
+        Deprecated since v3.1: squeeze() will be removed in v4.0,
+        use isel() to select specific indices instead.
+
+        Returns
+        -------
+        DataArray
+
+        """
         warnings.warn(
             "squeeze() is deprecated and will be removed in v4.0. "
             "Use isel() to select specific indices.",
@@ -1852,6 +1862,13 @@ class DataArray:
 
     # ============= output methods: to_xxx() ===========
     def to_dataset(self) -> Dataset:
+        """Create a Dataset with this DataArray as its only item.
+
+        Returns
+        -------
+        Dataset
+
+        """
         return self._to_dataset()
 
     def _to_dataset(self) -> Dataset:

--- a/src/mikeio/dataset/_dataset.py
+++ b/src/mikeio/dataset/_dataset.py
@@ -180,6 +180,7 @@ class Dataset:
 
     @property
     def values(self) -> None:
+        """Not available for Dataset, use to_numpy() or DataArray.values."""
         raise AttributeError(
             "Dataset has no property 'values' - use to_numpy() instead or maybe you were looking for DataArray.values?"
         )
@@ -472,8 +473,8 @@ class Dataset:
     def squeeze(self) -> Dataset:
         """Remove axes of length 1.
 
-        .. deprecated:: 3.1
-            squeeze() will be removed in v4.0. Use isel() to select specific indices.
+        Deprecated since v3.1: squeeze() will be removed in v4.0,
+        use isel() to select specific indices instead.
 
         Returns
         -------
@@ -1128,6 +1129,23 @@ class Dataset:
         return Dataset(das, title=self.title, custom_blocks=self.custom_blocks)
 
     def interp_na(self, axis: str = "time", **kwargs: Any) -> Dataset:
+        """Fill in NaNs by interpolating according to different methods.
+
+        Wrapper of [](`xarray.DataArray.interpolate_na`)
+
+        Parameters
+        ----------
+        axis : str
+            Dimension to interpolate along, by default "time"
+        **kwargs : Any
+            Additional arguments passed on to
+            [](`xarray.DataArray.interpolate_na`)
+
+        Returns
+        -------
+        Dataset
+
+        """
         ds = self.copy()
         for da in ds:
             da.values = da.interp_na(axis=axis, **kwargs).values

--- a/src/mikeio/dfs/_dfs0.py
+++ b/src/mikeio/dfs/_dfs0.py
@@ -353,6 +353,7 @@ class Dfs0:
         unit: EUMUnit | None = None,
         items: Sequence[ItemInfo] | None = None,
     ) -> None:
+        """Create a dfs0 file from a pandas DataFrame (deprecated, use mikeio.from_pandas)."""
         return dataframe_to_dfs0(df, filename, itemtype, unit, items)
 
 

--- a/src/mikeio/dfs/_dfs1.py
+++ b/src/mikeio/dfs/_dfs1.py
@@ -189,6 +189,7 @@ class Dfs1(_Dfs123):
 
     @property
     def geometry(self) -> Grid1D:
+        """Spatial information."""
         assert isinstance(self._geometry, Grid1D)
         return self._geometry
 

--- a/src/mikeio/dfs/_dfs3.py
+++ b/src/mikeio/dfs/_dfs3.py
@@ -321,6 +321,7 @@ class Dfs3(_Dfs123):
 
     @property
     def geometry(self) -> Grid3D:
+        """Spatial information."""
         return self._geometry
 
     @property
@@ -340,6 +341,7 @@ class Dfs3(_Dfs123):
 
     @property
     def shape(self) -> tuple[int, int, int, int]:
+        """Tuple with number of values in the t-, z-, y-, x-direction."""
         return (self._n_timesteps, self._nz, self._ny, self._nx)
 
     @property

--- a/src/mikeio/dfsu/_layered.py
+++ b/src/mikeio/dfsu/_layered.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
 
 
 class DfsuLayered:
+    """Base class for layered dfsu files (Dfsu2DV, Dfsu3D)."""
+
     def __init__(self, filename: str | Path) -> None:
         info = _get_dfsu_info(filename)
         self._filename = info.filename
@@ -514,7 +516,8 @@ class Dfsu2DV(DfsuLayered):
         figsize: tuple[float, float] | None = None,
         **kwargs: Any,
     ) -> Axes:
-        # deprecated remove in 3.1
+        """Plot a vertical profile (deprecated, use DataArray.plot() instead)."""
+        # deprecated, remove in v4.0
         import warnings
 
         warnings.warn(

--- a/src/mikeio/dfsu/_spectral.py
+++ b/src/mikeio/dfsu/_spectral.py
@@ -121,6 +121,7 @@ class DfsuSpectral:
 
     @property
     def time(self) -> pd.DatetimeIndex:
+        """Time axis of the file."""
         if self._equidistant:
             return pd.date_range(
                 start=self.start_time,

--- a/src/mikeio/eum/_eum.py
+++ b/src/mikeio/eum/_eum.py
@@ -49,6 +49,8 @@ def _unit_list(eum_type: int) -> list[eumUnit]:
 
 
 class TimeAxisType(IntEnum):
+    """Type of time axis in a dfs file."""
+
     EquidistantRelative = 1
     NonEquidistantRelative = 2
     EquidistantCalendar = 3
@@ -59,6 +61,8 @@ class TimeAxisType(IntEnum):
 
 
 class TimeStepUnit(IntEnum):
+    """Unit of the time step in a dfs file."""
+
     SECOND = 1400
     MINUTE = 1401
     HOUR = 1402
@@ -1348,6 +1352,7 @@ class EUMUnit(IntEnum):
 
     @property
     def short_name(self) -> str:
+        """Abbreviated unit name, e.g. "m" for meter."""
         unit_short_names = {
             "kilometer": "km",
             "centimeter": "cm",
@@ -1511,10 +1516,13 @@ class ItemInfo:
 
 
 class ItemInfoList(list):
+    """List of ItemInfo, e.g. Dataset.items."""
+
     def __init__(self, items: Sequence[ItemInfo]):
         super().__init__(items)
 
     def to_dataframe(self) -> pd.DataFrame:
+        """Convert to a DataFrame with name, type and unit columns."""
         data = [
             {"name": item.name, "type": item.type.name, "unit": item.unit.name}
             for item in self

--- a/src/mikeio/generic.py
+++ b/src/mikeio/generic.py
@@ -337,7 +337,7 @@ def sum(
     infilename_b: str | pathlib.Path,
     outfilename: str | pathlib.Path,
 ) -> None:
-    # deprecated
+    """Add two dfs files (a+b) (deprecated, use add instead)."""
     warnings.warn(FutureWarning("This function is deprecated. Use add instead."))
     _process_dfs_files(infilename_a, infilename_b, outfilename, operator.add)
 

--- a/src/mikeio/pfs/_pfssection.py
+++ b/src/mikeio/pfs/_pfssection.py
@@ -29,8 +29,9 @@ def _merge_dict(a: dict[str, Any], b: Mapping[str, Any]) -> dict[str, Any]:
 
 
 class PfsNonUniqueList(list):
+    """List of the values of PFS keywords that appear more than once."""
+
     # TODO do we really need this, regular lists are not unique
-    pass
 
 
 class PfsSection(SimpleNamespace, MutableMapping[str, Any]):

--- a/src/mikeio/spatial/_FM_geometry.py
+++ b/src/mikeio/spatial/_FM_geometry.py
@@ -1031,6 +1031,22 @@ class GeometryFM2D(_GeometryFM):
     def elements_to_geometry(
         self, elements: int | Sequence[int], keepdims: bool = False
     ) -> GeometryFM2D | GeometryPoint2D:
+        """Export a selection of elements to a new geometry.
+
+        Parameters
+        ----------
+        elements : int or list[int]
+            Element indices to select
+        keepdims : bool
+            Keep the geometry as a mesh even for a single element,
+            by default False (a single element becomes a point geometry)
+
+        Returns
+        -------
+        GeometryFM2D or GeometryPoint2D
+            Geometry for the selected elements
+
+        """
         if isinstance(elements, (int, np.integer)):
             sel_elements: list[int] = [elements]
         else:

--- a/src/mikeio/spatial/_FM_geometry_layered.py
+++ b/src/mikeio/spatial/_FM_geometry_layered.py
@@ -533,6 +533,7 @@ class GeometryFM3D(_GeometryFMLayered):
 
     @property
     def plot(self) -> None:
+        """Not available for GeometryFM3D, use to_2d_geometry().plot instead."""
         raise AttributeError(
             "GeometryFM3D does not support plotting directly. "
             "Use .to_2d_geometry().plot instead."
@@ -540,6 +541,7 @@ class GeometryFM3D(_GeometryFMLayered):
 
     @property
     def boundary_polylines(self) -> BoundaryPolygons:
+        """Lists of polygons defining domain outline (deprecated, use boundary_polygons)."""
         warnings.warn(
             "boundary_polylines is renamed to boundary_polygons", FutureWarning
         )
@@ -547,12 +549,15 @@ class GeometryFM3D(_GeometryFMLayered):
 
     @property
     def boundary_polygons(self) -> BoundaryPolygons:
+        """Lists of polygons defining domain outline."""
         return self.geometry2d.boundary_polygons
 
     def contains(self, points: np.ndarray) -> np.ndarray:
+        """Test if a list of points are contained by the horizontal extent of the mesh."""
         return self.geometry2d.contains(points)
 
     def to_mesh(self, outfilename: str | Path) -> None:
+        """Export the horizontal mesh to a mesh file."""
         return self.geometry2d.to_mesh(outfilename)
 
     def find_index(
@@ -564,6 +569,37 @@ class GeometryFM3D(_GeometryFMLayered):
         area: tuple[float, float, float, float] | None = None,
         layers: int | Layer | Sequence[int] | None = None,
     ) -> np.ndarray:
+        """Find a *set* of 3d element indices for points, an area and/or layers.
+
+        Typically not called directly, but by Dataset/DataArray's
+        sel() method.
+
+        Parameters
+        ----------
+        x: float, optional
+            X coordinate (easting or longitude)
+        y: float, optional
+            Y coordinate (northing or latitude)
+        z: float, optional
+            Z coordinate (depth, positive upwards)
+        coords : np.array(float,float), optional
+            As an alternative to specifying x, y (and z) individually,
+            the argument coords can be used instead,
+            by default None
+        area : (float, float, float, float), optional
+            Bounding box of coordinates (left lower and right upper)
+            to be selected, by default None
+        layers : int or str or list[int], optional
+            layer(s) to be selected: subset of "all", "top", "bottom",
+            "bottom+1", ..., or a layer number (0=bottom, 1, 2, ...),
+            by default None
+
+        Returns
+        -------
+        np.array
+            3d element indices
+
+        """
         if layers is not None:
             idx = self.get_layer_elements(layers)
         else:
@@ -644,6 +680,34 @@ class GeometryFMVerticalProfile(_GeometryFMLayered):
         coords: np.ndarray | None = None,
         layers: int | Sequence[int] | Layer | None = None,
     ) -> np.ndarray:
+        """Find a *set* of element indices for points and/or layers.
+
+        Typically not called directly, but by Dataset/DataArray's
+        sel() method.
+
+        Parameters
+        ----------
+        x: float, optional
+            X coordinate (easting or longitude)
+        y: float, optional
+            Y coordinate (northing or latitude)
+        z: float, optional
+            Z coordinate (depth, positive upwards)
+        coords : np.array(float,float), optional
+            As an alternative to specifying x, y (and z) individually,
+            the argument coords can be used instead,
+            by default None
+        layers : int or str or list[int], optional
+            layer(s) to be selected: subset of "all", "top", "bottom",
+            "bottom+1", ..., or a layer number (0=bottom, 1, 2, ...),
+            by default None
+
+        Returns
+        -------
+        np.array
+            element indices
+
+        """
         if layers is not None:
             idx = self.get_layer_elements(layers)
         else:
@@ -749,6 +813,8 @@ class GeometryFMVerticalColumn(GeometryFM3D):
 
 
 class GeometryFMVerticalProfilePlotter:
+    """Plot a vertical profile geometry, e.g. geometry.plot()."""
+
     def __init__(self, geometry: GeometryFMVerticalProfile) -> None:
         self.g = geometry
 
@@ -768,6 +834,7 @@ class GeometryFMVerticalProfilePlotter:
         return ax
 
     def mesh(self, title: str = "Mesh", edge_color: str = "0.5", **kwargs: Any) -> Axes:
+        """Plot the mesh of the vertical profile."""
         v = np.full_like(self.g.element_coordinates[:, 0], np.nan)
         return _plot_vertical_profile(
             node_coordinates=self.g.node_coordinates,

--- a/src/mikeio/spatial/_FM_geometry_spectral.py
+++ b/src/mikeio/spatial/_FM_geometry_spectral.py
@@ -33,6 +33,7 @@ class GeometryFMPointSpectrum(_Geometry):
 
     @property
     def dims(self) -> tuple[str, ...]:
+        """Names of the spectral dimensions."""
         if self.directions is None:
             return ("frequency",)
         else:
@@ -44,6 +45,7 @@ class GeometryFMPointSpectrum(_Geometry):
 
     @property
     def is_layered(self) -> bool:
+        """Point spectra are never layered."""
         return False
 
     def __repr__(self) -> str:
@@ -110,6 +112,7 @@ class _GeometryFMSpectrum(_GeometryFM):
 
     @property
     def is_layered(self) -> bool:
+        """Spectral geometries are never layered."""
         return False
 
     @property
@@ -147,6 +150,7 @@ class GeometryFMAreaSpectrum(_GeometryFMSpectrum, GeometryFM2D):
 
     @property
     def dims(self) -> tuple[str, ...]:
+        """Names of the dimensions, ("element", ...spectral)."""
         return self._spectral_dims("element")
 
     def get_space_axis(self) -> tuple[int, ...]:
@@ -156,6 +160,7 @@ class GeometryFMAreaSpectrum(_GeometryFMSpectrum, GeometryFM2D):
     def isel(  # type: ignore
         self, idx: Sequence[int], **kwargs: Any
     ) -> GeometryFMPointSpectrum | GeometryFMAreaSpectrum:
+        """Select a subset of elements, see elements_to_geometry."""
         return self.elements_to_geometry(elements=idx)
 
     def elements_to_geometry(  # type: ignore
@@ -208,6 +213,7 @@ class GeometryFMLineSpectrum(_GeometryFMSpectrum):
 
     @property
     def dims(self) -> tuple[str, ...]:
+        """Names of the dimensions, ("node", ...spectral)."""
         return self._spectral_dims("node")
 
     def get_space_axis(self) -> tuple[int, ...]:
@@ -218,6 +224,23 @@ class GeometryFMLineSpectrum(_GeometryFMSpectrum):
     def create_dummy_coordinates(
         n_nodes: int, frequencies: np.ndarray, directions: np.ndarray
     ) -> GeometryFMLineSpectrum:
+        """Create a line spectrum geometry with placeholder node coordinates.
+
+        Parameters
+        ----------
+        n_nodes : int
+            Number of nodes on the line
+        frequencies : np.array
+            Frequency axis
+        directions : np.array
+            Directional axis
+
+        Returns
+        -------
+        GeometryFMLineSpectrum
+            Geometry with nodes placed on a straight line
+
+        """
         # boogus x, y, z 1..n, 1..n, -10
         node_coordinates = np.zeros((n_nodes, 3), dtype=float)
         node_coordinates[:, 0] = np.arange(1, n_nodes + 1)  # x
@@ -242,6 +265,21 @@ class GeometryFMLineSpectrum(_GeometryFMSpectrum):
     def isel(  # type: ignore
         self, idx: Sequence[int], axis: str = "node"
     ) -> GeometryFMPointSpectrum | GeometryFMLineSpectrum:
+        """Select a subset of nodes.
+
+        Parameters
+        ----------
+        idx : list[int]
+            Node indices to select
+        axis : str
+            Not used, nodes is the only spatial axis
+
+        Returns
+        -------
+        GeometryFMPointSpectrum or GeometryFMLineSpectrum
+            Geometry for the selected nodes
+
+        """
         return self._nodes_to_geometry(nodes=idx)
 
     def _get_nodes_and_table_for_elements(

--- a/src/mikeio/spatial/_FM_plot.py
+++ b/src/mikeio/spatial/_FM_plot.py
@@ -30,6 +30,7 @@ class Polygon:
 
     @property
     def area(self) -> float:
+        """Signed area of the polygon."""
         return (
             np.dot(self.xy[:, 1], np.roll(self.xy[:, 0], 1))
             - np.dot(self.xy[:, 0], np.roll(self.xy[:, 1], 1))
@@ -43,6 +44,7 @@ class BoundaryPolygons:
 
     @property
     def lines(self) -> list[Polygon]:
+        """All boundary polygons, exteriors followed by interiors."""
         return self.exteriors + self.interiors
 
     def contains(self, points: np.ndarray) -> np.ndarray:

--- a/src/mikeio/spatial/_geometry.py
+++ b/src/mikeio/spatial/_geometry.py
@@ -40,6 +40,7 @@ class BoundingBox:
     def parse(
         values: "BoundingBox" | Sequence[float],
     ) -> "BoundingBox":
+        """Create a BoundingBox from a BoundingBox or (left, bottom, right, top)."""
         match values:
             case BoundingBox():
                 bbox = values
@@ -133,6 +134,7 @@ class GeometryUndefined(_Geometry):
 
     @property
     def dims(self) -> tuple[str, ...]:
+        """Not available for GeometryUndefined."""
         raise NotImplementedError()
 
 
@@ -163,10 +165,24 @@ class Geometry0D(_Geometry):
 
     @property
     def dims(self) -> tuple[str, ...]:
+        """Names of the dimensions, always empty."""
         return ()
 
 
 class GeometryPoint2D(_Geometry):
+    """A single point in the horizontal plane, e.g. from DataArray.sel(x=..., y=...).
+
+    Parameters
+    ----------
+    x : float
+        X coordinate (easting or longitude)
+    y : float
+        Y coordinate (northing or latitude)
+    projection : str, optional
+        Projection string, by default "LONG/LAT"
+
+    """
+
     def __init__(self, x: float, y: float, projection: str = "LONG/LAT"):
         super().__init__(projection)
         self.x = x
@@ -174,6 +190,7 @@ class GeometryPoint2D(_Geometry):
 
     @property
     def dims(self) -> tuple[str, ...]:
+        """Names of the dimensions, always empty."""
         return ()
 
     def __repr__(self) -> str:
@@ -185,15 +202,32 @@ class GeometryPoint2D(_Geometry):
 
     @property
     def wkt(self) -> str:
+        """Well-known text representation of the point."""
         return f"POINT ({self.x} {self.y})"
 
     def to_shapely(self) -> Any:
+        """Convert to a shapely Point."""
         from shapely.geometry import Point
 
         return Point(self.x, self.y)
 
 
 class GeometryPoint3D(_Geometry):
+    """A single point in space, e.g. from DataArray.sel(x=..., y=..., z=...).
+
+    Parameters
+    ----------
+    x : float
+        X coordinate (easting or longitude)
+    y : float
+        Y coordinate (northing or latitude)
+    z : float
+        Z coordinate (depth, positive upwards)
+    projection : str, optional
+        Projection string, by default "LONG/LAT"
+
+    """
+
     def __init__(self, x: float, y: float, z: float, projection: str = "LONG/LAT"):
         super().__init__(projection)
 
@@ -206,13 +240,16 @@ class GeometryPoint3D(_Geometry):
 
     @property
     def dims(self) -> tuple[str, ...]:
+        """Names of the dimensions, always empty."""
         return ()
 
     @property
     def wkt(self) -> str:
+        """Well-known text representation of the point."""
         return f"POINT Z ({self.x} {self.y} {self.z})"
 
     def to_shapely(self) -> Any:
+        """Convert to a shapely Point."""
         from shapely.geometry import Point
 
         return Point(self.x, self.y, self.z)

--- a/src/mikeio/spatial/_grid_geometry.py
+++ b/src/mikeio/spatial/_grid_geometry.py
@@ -174,6 +174,19 @@ class Grid1D(_Geometry):
         return int(np.argmin(d))
 
     def get_spatial_interpolant(self, x: float) -> Interpolant:
+        """Get weights and indices of the two nearest points for interpolation.
+
+        Parameters
+        ----------
+        x : float
+            x-coordinate of the point to interpolate to
+
+        Returns
+        -------
+        Interpolant
+            Indices and weights, weights are NaN outside the grid
+
+        """
         assert self.nx > 1, "Interpolation not possible for Grid1D with one point"
         d = np.abs(self.x - x)
         ids = np.argsort(d)[0:2]
@@ -1251,6 +1264,7 @@ class Grid3D(_Geometry):
     def find_index(
         self, coords: Any = None, layers: Any = None, area: Any = None
     ) -> Any:
+        """Not yet implemented for Grid3D, use mikeio.read() arguments instead."""
         if layers is not None:
             raise NotImplementedError(
                 f"Layer slicing is not yet implemented. Use the mikeio.read('file.dfs3', layers='{layers}')"

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,75 @@
+"""Every public class, method and property must have a docstring.
+
+ruff's D101/D102 rules do not catch these, because all MIKE IO modules are
+underscore-prefixed and therefore private to pydocstyle - even though the
+classes they hold are public and end up in the API reference.
+"""
+
+import importlib
+import inspect
+import pkgutil
+from typing import Any
+
+import mikeio
+from mikeio import generic
+
+
+def public_classes() -> list[type]:
+    modules = [mikeio]
+    for module_info in pkgutil.walk_packages(mikeio.__path__, "mikeio."):
+        modules.append(importlib.import_module(module_info.name))
+
+    classes = []
+    for module in modules:
+        for name, obj in vars(module).items():
+            if name.startswith("_") or not inspect.isclass(obj):
+                continue
+            if not obj.__module__.startswith("mikeio"):
+                continue
+            if obj not in classes:
+                classes.append(obj)
+    return classes
+
+
+def undocumented_members(cls: type) -> list[str]:
+    missing = []
+    for name, member in vars(cls).items():
+        if name.startswith("_"):
+            continue
+        obj: Any = member.fget if isinstance(member, property) else member
+        if not (callable(obj) or isinstance(member, property)):
+            continue
+        if not (getattr(obj, "__doc__", None) or "").strip():
+            missing.append(name)
+    return missing
+
+
+def test_public_classes_have_docstrings() -> None:
+    undocumented = [
+        f"{cls.__module__}.{cls.__qualname__}"
+        for cls in public_classes()
+        if not (cls.__doc__ or "").strip()
+    ]
+    assert undocumented == []
+
+
+def test_public_methods_and_properties_have_docstrings() -> None:
+    undocumented = [
+        f"{cls.__module__}.{cls.__qualname__}.{name}"
+        for cls in public_classes()
+        for name in undocumented_members(cls)
+    ]
+    assert undocumented == []
+
+
+def test_public_functions_have_docstrings() -> None:
+    undocumented = [
+        f"{module.__name__}.{name}"
+        for module in (mikeio, generic)
+        for name, obj in vars(module).items()
+        if not name.startswith("_")
+        and inspect.isfunction(obj)
+        and obj.__module__.startswith("mikeio")
+        and not (obj.__doc__ or "").strip()
+    ]
+    assert undocumented == []


### PR DESCRIPTION
27 public methods and properties that appear in the [API reference](https://dhi.github.io/mikeio/api/) had no docstring at all — `DataArray.squeeze`, `Dataset.interp_na`, `Dfs3.geometry`, `find_index` on three geometries, `isel` on the spectral geometries — and eleven public classes were undocumented too, `GeometryPoint2D`/`GeometryPoint3D` among them.

ruff never complained, and cannot: [D101/D102](https://docs.astral.sh/ruff/rules/undocumented-public-class/) treat anything inside an underscore-prefixed module as private, and every MIKE IO module is underscore-prefixed. So docstring coverage of the public API has never been checked by anything, which matters more now that [the docs are the primary learning resource](https://dhi.github.io/mikeio/design.html). A test now walks the package and fails on a public class, method, property or function without a docstring.

Two related fixes:

- Replaced the RST markup quartodoc renders verbatim (` ``x`` `, `:class:`, `.. deprecated::`).
- `error_bad_data`/`fill_bad_data_value` are dfsu-only arguments passed through `**kwargs`, and quartodoc warns on every docs build that they are not in `mikeio.read`'s signature. They are now listed with the other file type specific arguments instead of in the parameter list. (This is the same problem as the stale `fix/bad_data_docstring` branch, which keeps them in the parameter list and so keeps the warning.)