### PR TITLE
Stop GeometryFM3D.boundary_polygons warning about its own name

### DIFF
--- a/src/mikeio/spatial/_FM_geometry_layered.py
+++ b/src/mikeio/spatial/_FM_geometry_layered.py
@@ -543,11 +543,11 @@ class GeometryFM3D(_GeometryFMLayered):
         warnings.warn(
             "boundary_polylines is renamed to boundary_polygons", FutureWarning
         )
-        return self.geometry2d.boundary_polylines
+        return self.geometry2d.boundary_polygons
 
     @property
     def boundary_polygons(self) -> BoundaryPolygons:
-        return self.geometry2d.boundary_polylines
+        return self.geometry2d.boundary_polygons
 
     def contains(self, points: np.ndarray) -> np.ndarray:
         return self.geometry2d.contains(points)

--- a/tests/test_dfsu3d.py
+++ b/tests/test_dfsu3d.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -424,6 +425,27 @@ def test_boundary_codes() -> None:
     dfs = mikeio.Dfsu3D(filename)
 
     assert len(dfs.geometry.boundary_codes) == 3
+
+
+def test_boundary_polygons_does_not_warn() -> None:
+    filename = "tests/testdata/oresund_sigma_z.dfsu"
+    geometry = mikeio.Dfsu3D(filename).geometry
+    assert isinstance(geometry, GeometryFM3D)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        polygons = geometry.boundary_polygons
+
+    assert len(polygons.exteriors) > 0
+
+
+def test_boundary_polylines_is_deprecated() -> None:
+    filename = "tests/testdata/oresund_sigma_z.dfsu"
+    geometry = mikeio.Dfsu3D(filename).geometry
+    assert isinstance(geometry, GeometryFM3D)
+
+    with pytest.warns(FutureWarning, match="boundary_polygons"):
+        geometry.boundary_polylines
 
 
 def test_top_elements() -> None:


### PR DESCRIPTION
`boundary_polygons` on a layered geometry called the deprecated `boundary_polylines` on the underlying 2d geometry, so users who had already moved to the current name were told that "boundary_polylines is renamed to boundary_polygons" — a warning they cannot act on.