### PR TITLE
Show a progress bar when writing dfs files too

### DIFF
--- a/src/mikeio/dfs/_dfs.py
+++ b/src/mikeio/dfs/_dfs.py
@@ -8,6 +8,7 @@ from typing import Any, Sequence
 import numpy as np
 from numpy.typing import NDArray
 import pandas as pd
+from tqdm import trange
 
 from mikecore.DfsFile import (
     DfsDynamicItemInfo,
@@ -23,7 +24,7 @@ from ._custom_blocks import read_custom_blocks
 from ..eum import ItemInfo, ItemInfoList
 from ..exceptions import ItemsError
 from .._time import DateTimeSelector
-from .._options import _item_txt
+from .._options import _item_txt, _show_progress
 from .._path import normalize_path
 
 
@@ -276,7 +277,7 @@ def write_dfs_data(*, dfs: DfsFile, ds: Dataset, n_spatial_dims: int) -> None:
     else:
         t_rel = (ds.time - ds.time[0]).total_seconds()
 
-    for i in range(ds.n_timesteps):
+    for i in trange(ds.n_timesteps, disable=not _show_progress()):
         for item in range(ds.n_items):
             if has_no_time:
                 d = ds[item].values

--- a/src/mikeio/dfsu/_dfsu.py
+++ b/src/mikeio/dfsu/_dfsu.py
@@ -121,7 +121,7 @@ def write_dfsu_data(dfs: DfsuFile, ds: Dataset, is_layered: bool) -> None:
     else:
         t_rel = (data.time - data.time[0]).total_seconds()
 
-    for i in range(n_time_steps):
+    for i in trange(n_time_steps, disable=not _show_progress()):
         if is_layered:
             zn_all = data.z.nodes
             if "time" in data.dims:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -153,3 +153,32 @@ def test_generic_respects_show_progress(
     with mikeio.set_options(show_progress=True):
         generic.scale("tests/testdata/oresundHD_run1.dfsu", outfilename, factor=2.0)
     assert "it/s" in capsys.readouterr().err
+
+
+def test_write_shows_no_progress_bar_by_default(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ds = mikeio.read("tests/testdata/oresundHD_run1.dfsu")
+    capsys.readouterr()
+    ds.to_dfs(tmp_path / "out.dfsu")
+    assert capsys.readouterr().err == ""
+
+
+def test_dfsu_write_shows_progress_bar_when_enabled(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ds = mikeio.read("tests/testdata/oresundHD_run1.dfsu")
+    capsys.readouterr()
+    with mikeio.set_options(show_progress=True):
+        ds.to_dfs(tmp_path / "out.dfsu")
+    assert "it/s" in capsys.readouterr().err
+
+
+def test_dfs2_write_shows_progress_bar_when_enabled(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ds = mikeio.read("tests/testdata/gebco_sound.dfs2")
+    capsys.readouterr()
+    with mikeio.set_options(show_progress=True):
+        ds.to_dfs(tmp_path / "out.dfs2")
+    assert "it/s" in capsys.readouterr().err


### PR DESCRIPTION
`set_options(show_progress=True)` from #1039 covers reading and the generic functions, but not writing: `ds.to_dfs()` on a large dfs1/2/3 or dfsu file prints nothing, even though [the option's own docstring](https://dhi.github.io/mikeio/api/set_options.html) and the [generic user guide](https://dhi.github.io/mikeio/user-guide/generic.html) both say it applies to writing as well. Writing a multi-gigabyte file is exactly as slow as reading one.