### PR TITLE
Pin third-party GitHub Actions to a commit SHA

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       with:
         enable-cache: true
 

--- a/.github/workflows/docs_dead_links.yml
+++ b/.github/workflows/docs_dead_links.yml
@@ -13,7 +13,7 @@ jobs:
     name: Broken-Links-Crawler
     steps:
     - name: Checking links
-      uses: ScholliYT/Broken-Links-Crawler-Action@v3
+      uses: ScholliYT/Broken-Links-Crawler-Action@21eab52f98097989d343116dbbd46dc4541b849b # v3
       with:
         website_url: 'https://dhi.github.io/mikeio/'
         exclude_url_prefix: 'https://github.com/DHI/mikeio/edit/main/docs/api/,https://docs.mikepoweredbydhi.com/'

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -19,15 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/ruff-action@v2
+      - uses: astral-sh/ruff-action@f2e32211077f40bfeab40e16285216924ebea4cb # v2
         with:
           version: 0.6.2
           src: src
 
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true

--- a/.github/workflows/notebooks_test.yml
+++ b/.github/workflows/notebooks_test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       with:
         enable-cache: true
     - name: Install dependencies

--- a/.github/workflows/perf_test.yml
+++ b/.github/workflows/perf_test.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: extractions/setup-just@v3
+    - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       with:
         enable-cache: true
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       with:
         enable-cache: true
         python-version: ${{ matrix.python-version }}
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       with:
         enable-cache: true
         python-version: "3.14"
@@ -54,5 +54,5 @@ jobs:
     - name: Build
       run: uv build
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
 

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: extractions/setup-just@v3
+    - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       with:
         python-version: ${{ matrix.python-version }}
         enable-cache: true


### PR DESCRIPTION
A moving tag lets whoever controls an action's repository change what runs in our workflows. That includes `python-publish.yml`, which holds a [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) identity — the account that can ship a release to every MIKE IO user. #1034 tightened the `GITHUB_TOKEN` permissions for the same reason; this closes the other half.

`docs.yml` already pinned setup-just this way, so the style is unchanged: SHA with the tag as a comment. Same versions as before — upgrades (setup-uv v6 → v10, ruff-action v2 → v4, setup-just v3 → v4) are a separate decision.