### PR TITLE
Release 3.3.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
   affiliation: DHI
 title: "MIKE IO"
 license: BSD-3-Clause
-repository-code: 'https:///github.com/DHI/mikeio'
+repository-code: 'https://github.com/DHI/mikeio'
 url: "https://dhi.github.io/mikeio/"
-version: 3.0.1
-date-released: 2025-12-17
+version: 3.3.0
+date-released: 2026-09-10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "uv_build"
 
 [project]
 name = "mikeio"
-version = "3.3.0.dev0"
+version = "3.3.0"
 dependencies = [
     "mikecore>=0.2.2",
     "numpy>=2.1",


### PR DESCRIPTION
Drops the `.dev0` suffix for the release.

`CITATION.cff` still claimed version 3.0.1 released 2025-12-17, two releases behind — it was not updated for [v3.1.0](https://github.com/DHI/mikeio/releases/tag/v3.1.0) or [v3.2.0](https://github.com/DHI/mikeio/releases/tag/v3.2.0), so anyone citing MIKE IO from the repository has been citing the wrong version. Date set to 2026-09-10; change it if the release lands on another day. Also fixes the three-slash typo in its `repository-code` URL.

Merge last, after any other sweep PRs that should go into 3.3.0.
